### PR TITLE
Adding a timeout 0 to grid databind event

### DIFF
--- a/src/igniteui-angular.js
+++ b/src/igniteui-angular.js
@@ -112,8 +112,11 @@
 				ds = scope.$eval(attrs.source), diff = [];
             // check for a change of the data source. In this case rebind the grid
             if (ds !== grid.options.dataSource) {
-                grid.options.dataSource = ds;
-                grid.dataBind();
+                 //Setting a timeout 0 pushes the slow databind event to the end of the stack, letting the digest cycle finish, improving the overall responsivness of the page
+                setTimeout(function () {
+                    grid.options.dataSource = ds;
+                    grid.dataBind();
+                }, 0);
                 return;
             }
             equalsDiff(newValue, oldValue, diff);


### PR DESCRIPTION
Adding a timeout 0 to the grid databind event when the datasource is changed allows the browser to catch up on stack execution before proceeding with the slow databind process, providing a nice little boost of responsiveness.