### PR TITLE
Adding an option for ig-grid directive to choose between a collection watch or a deep object watch.

### DIFF
--- a/src/igniteui-angular.js
+++ b/src/igniteui-angular.js
@@ -96,10 +96,13 @@
 
     // Two way data binding for the grid control
     $.ig.angular.igGrid.bindEvents = $.ig.angular.igGrid.bindEvents || function (scope, element, attrs) {
-    	var unbinder;
+    	var unbinder,
+            collectionWatchMode = attrs && attrs.collectionWatch && attrs.collectionWatch === "true";
         element.on($.ig.angular.igGrid.events.join(' '), function () {
         	unbinder();
-            unbinder = scope.$watch(attrs.source, watchGridDataSource, true);
+              // When in collection watch mode, a change is detected only when the collection changes - a element is inserted or removed or the whole collection reference changes. 
+            //     Changes in a specific element inside collection are not detected. This provides huge performance boost when such change detection is not required
+            unbinder = collectionWatchMode ? scope.$watchCollection(attrs.source, watchGridDataSource) : scope.$watch(attrs.source, watchGridDataSource, true);
             scope.$apply();
            	markWatcher(scope, "igGrid", attrs);
         }).one('$destroy', function() {
@@ -187,7 +190,7 @@
             }
         }
         // watch for changes from the data source to the view
-        unbinder = scope.$watch(attrs.source, watchGridDataSource, true);
+         unbinder = collectionWatchMode ? scope.$watchCollection(attrs.source, watchGridDataSource) : scope.$watch(attrs.source, watchGridDataSource, true);
 		markWatcher(scope, "igGrid", attrs);
     };
 


### PR DESCRIPTION
An option to be able to choose whether to use a deep object watch or a collection watch can be very useful in cases when you need to work with large data sets and you don't expect(or care about) external changes to individual elements of the collection. Using $watchCollection provides a huge performance boost over $watch(..., ..., true) because angular no longer needs to maintain a full copy of the whole collection to do its dirty checking magic.