### PR TITLE
Fixing "No events fired when custom value is entered"

### DIFF
--- a/src/igniteui-angular.js
+++ b/src/igniteui-angular.js
@@ -46,6 +46,12 @@
         function parseValue() {
             //"parse" through the control value, ensure no-flicker with formatted values
             //model controller will attempt to set the edit text (not actual value) to the model. Only allow the actual control value to update.
+            
+            // No events fired when custom value is entered, this change won't affect the old combo
+            var combo = element.data(controlName);
+            if (combo.options.allowCustomValue && combo.refreshValue != undefined) {
+                combo.refreshValue();
+            }
             return comboValue(element.data(controlName));
         }
         element.on($.ig.angular.igCombo.events.join(" "), function (event, args) {

--- a/test/app/index.html
+++ b/test/app/index.html
@@ -89,6 +89,8 @@
 		<ig-combo id="combo2" data-source="northwind" value-key-type="number" value-key="ProductID" text-key-type="string" text-Key="ProductName" ng-model="combo.value2">
             <multi-selection enabled="true"></multi-selection>
 		</ig-combo>
+		<ig-combo id="combo3" data-source="northwind" allow-custom-value="true" value-key="ProductID" text-key="ProductName" ng-model="combo.value1">
+    </ig-combo>
 		<br/>
 		<ul id="combomodel">
 			<li ng-repeat="record in northwind">

--- a/test/e2e/scenarios.js
+++ b/test/e2e/scenarios.js
@@ -562,7 +562,8 @@ describe("my app", function() {
 	describe("Combo", function() {
 		var scope = 'angular.element("#combo1").scope()',
 		combo = '$("#combo1")',
-		combo2 = '$("#combo2")';
+		combo2 = '$("#combo2")',
+		combo3 = '$("#combo3")';
 
 		it("should be initialized", function () {
 			util.resetNorthwindScope();
@@ -608,6 +609,14 @@ describe("my app", function() {
 			// wait for sleep resolve:
 			expect(browser.driver.sleep(250)).toBe(undefined); //util.getResult(combo + '.igCombo("option", "delayInputChangeProcessing");')
         	expect(util.getResult(scope + ".combo.value1")).toBe(2);
+		});
+		
+		it("should update combo value when allowCustomValue is true", function(){
+			util.executeScript(combo3 + ".focus();");
+			expect(util.getResult('typeInInputWrap("customValue1", ' + combo3 + ', "combo.value1");')).toBe(false);
+			expect(browser.driver.sleep(250)).toBe(undefined);
+			util.executeScript(combo3 + ".igCombo('comboWrapper').find('.ui-igcombo-button').click();");
+			expect(util.getResult(combo3 + '.igCombo("value")[0]')).toBe("customValue1");
 		});
 	});
 


### PR DESCRIPTION
No events fired when custom value is entered