### PR TITLE
reset changedVals array

### DIFF
--- a/src/igniteui-angular.js
+++ b/src/igniteui-angular.js
@@ -69,6 +69,7 @@
 									diff.push({ index: key, txlog: changedVals });
 								}
 							}
+							changedVals = [];
 						}
 						if (dirty) {
 							return false;


### PR DESCRIPTION
changedVals was shared between multiple records, so if two different properties were changed on two different records, both would register as having both properties changed.