### PR TITLE
Fix for bug #230041

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "grunt-contrib-uglify": "",
     "grunt-contrib-watch": "",
     "jshint-stylish": "",
-    "protractor": "",
+    "protractor": "4.0.14",
     "protractor-istanbul-plugin": "",
     "http-server": "",
     "bower": "",

--- a/src/igniteui-angular.js
+++ b/src/igniteui-angular.js
@@ -433,7 +433,9 @@
 		var unbinder;
 		/* rebind data source on changes */
 		unbinder = scope.$watch(attrs.source, function (newValue) {
-			$(element).igHierarchicalGrid("option", "dataSource", newValue);
+			setTimeout(function(){
+				$(element).igHierarchicalGrid("option", "dataSource", newValue);
+			}, 1);	
 		}, true);
 		markWatcher(scope, "igHierarchicalGrid", attrs);
 		element.one("$destroy", function () {

--- a/src/igniteui-angular.js
+++ b/src/igniteui-angular.js
@@ -431,11 +431,18 @@
 	$.ig.angular.igHierarchicalGrid.bindEvents = $.ig.angular.igHierarchicalGrid.bindEvents ||
 			function (scope, element, attrs) {
 		var unbinder;
-		/* rebind data source on changes */
+		// rebind data source on changes
 		unbinder = scope.$watch(attrs.source, function (newValue) {
-			setTimeout(function(){
-				$(element).igHierarchicalGrid("option", "dataSource", newValue);
-			}, 1);	
+			var ds = scope.$eval(attrs.source), grid = element.data("igHierarchicalGrid");
+
+			if (ds !== grid.options.dataSource) {
+				//Setting a timeout 0 pushes the slow databind event to the end of the stack, letting the digest cycle finish, improving the overall responsivness of the page
+				setTimeout(function () {
+					$(element).igHierarchicalGrid("option", "dataSource", newValue);
+				}, 0);
+				return;
+			}
+			
 		}, true);
 		markWatcher(scope, "igHierarchicalGrid", attrs);
 		element.one("$destroy", function () {


### PR DESCRIPTION
Fixing issue with initialExpandDepth option not affecting the initial expansion state when hierarchical grid is initialized via the AngularJS directives.
The issue is due to angular registering a change in the data source and re-applying it while the child levels are still being toggled (they're toggled on a timeout of 1ms) and cases a second toggle that collapses them again.