### PR TITLE
Replacing the JS Blocks reference occurrences

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,8 +12,8 @@ In order to perform all the necessary checks before pulling your changes in, you
     npm install
     npm test
 
-[Naming Convention](https://github.com/IgniteUI/igniteui-js-blocks/wiki/General-Naming-Guidelines-for-Ignite-UI-JS-Blocks)  
-[CSS Naming Convention](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/css-naming-convention.md)  
+[Naming Convention](https://github.com/IgniteUI/igniteui-angular/wiki/General-Naming-Guidelines-for-Ignite-UI-JS-Blocks)  
+[CSS Naming Convention](https://github.com/IgniteUI/igniteui-angular/blob/master/css-naming-convention.md)  
 
 # Workflow
 When working on an issue for the Ignite UI JS Blocks repository, you need to be aware of and to follow a correct status workflow. We have created a number of status labels in order to communicate well what the current status of a single issue/pull request is. The statuses are as follows:
@@ -44,10 +44,10 @@ In order to test a pull request that is awaiting test, perform the following act
 
   Replace the `<PULL_ID>` with the respective pull number in the following:
   ```bash
-  git fetch IgniteUI-JS-Blocks +refs/pull/<PULL_ID>/merge
+  git fetch igniteui-angular +refs/pull/<PULL_ID>/merge
   git checkout -qf FETCH_HEAD
   ```
-  > Note that the above assumes the remote for this repo is "IgniteUI-JS-Blocks" but "https://github.com/IgniteUI/igniteui-js-blocks.git" can be used as well. This uses a detached and temporary ref to quickly get PR merged state the same as the CI builds so there's no branch to dispose of after switching away. If you do want to make some changes, consider creating a branch from the pull request one or check out the [Checking out pull requests locally](https://help.github.com/articles/checking-out-pull-requests-locally/) article.
+  > Note that the above assumes the remote for this repo is "igniteui-angular" but "https://github.com/IgniteUI/igniteui-angular.git" can be used as well. This uses a detached and temporary ref to quickly get PR merged state the same as the CI builds so there's no branch to dispose of after switching away. If you do want to make some changes, consider creating a branch from the pull request one or check out the [Checking out pull requests locally](https://help.github.com/articles/checking-out-pull-requests-locally/) article.
 4. Verify that the expected behavior is observed with the changes in the pull request.
 5. Return the pull request in a not fixed state if you're still reproducing the issue.
 6. Don't forget to make the necessary status updates, as described in the workflow section.

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
 - npm run lint
 - npm run build
 - npm run test
-- if [ "${TRAVIS_REPO_SLUG}" == "IgniteUI/igniteui-js-blocks" ]; then cat ./coverage/lcov.info | coveralls; fi
+- if [ "${TRAVIS_REPO_SLUG}" == "IgniteUI/igniteui-angular" ]; then cat ./coverage/lcov.info | coveralls; fi
 
 before_deploy:
 # move to dist
@@ -37,4 +37,4 @@ deploy:
     secure: UvQG2jKbNOUsKoN2XEj1zMhehq14ZUtXnSFGFH7XcryVo5GNVfzeqzTouRmbEAxn9XvfwyZP+QLwQAFBggIdfXhld/CDrxJ6mTTl+b3kp055XVIJuRwgYfs2w+VusUxZlJpkq5t1sdPa19q/Xd6ITiUgVllymZu3udFe/3LP29UPvg4V5iAIOxUCBkIWvAcvygt9NvBe1B51PbfhBemiK4LvV88t8AGipF3dd5YTjs0M4f6+P97ehdjJUkr8WG2VcIui7ER9fGrkc/KmybglxygWV65WPJC6vsqxIpB0QSLGSSbvbDoagnbuxOmizrvFabZFO7hfwcEUR/1VneiRjjLNUeMiIF/1WVGAcPVVJKm8ABIzRtk8Vuj8QR79SAhXNdF2wvd/lVnb0CkcWjJhpRwq1dKIh7CX+/tmGzhubKUYaDCqKeNIAPVZIiehcELsTizW/99RoJq03IIbbNJnAD1qUO7PCW9dCWIGgF7p5UNPb7Mo7x/vVcEgh/NHLorVx+p7dqAWi2OGiSdq+ZU6ZtCgNKNYJHaJXaYdwALGktKfJkiuNYJ+3/o7tM8ruXhimmZ5h5olzlyk4kPK9OCfWPR7HLzWpjy5BFiQS+ZPgIL0z1/6I/qqs59bXGHAE9UABTyvc4mM32mSnJ7xsnKxuxefHayOdRvVB/CeJmA14rk=
   on:
     tags: true
-    repo: IgniteUI/igniteui-js-blocks
+    repo: IgniteUI/igniteui-angular

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Ignite UI for Angular - from Infragistics
 
-[![Build Status](https://travis-ci.org/IgniteUI/igniteui-js-blocks.svg?branch=master)](https://travis-ci.org/IgniteUI/igniteui-js-blocks)
-[![Coverage Status](https://coveralls.io/repos/github/IgniteUI/igniteui-js-blocks/badge.svg?branch=master)](https://coveralls.io/github/IgniteUI/igniteui-js-blocks?branch=master)
-[![npm version](https://badge.fury.io/js/igniteui-js-blocks.svg)](https://badge.fury.io/js/igniteui-js-blocks)
+[![Build Status](https://travis-ci.org/IgniteUI/igniteui-angular.svg?branch=master)](https://travis-ci.org/IgniteUI/igniteui-angular)
+[![Coverage Status](https://coveralls.io/repos/github/IgniteUI/igniteui-angular/badge.svg?branch=master)](https://coveralls.io/github/IgniteUI/igniteui-angular?branch=master)
+[![npm version](https://badge.fury.io/js/igniteui-angular.svg)](https://badge.fury.io/js/igniteui-angular)
 
 [Ignite UI for Angular](https://www.infragistics.com/products/ignite-ui-angular) is a complete set of Material-based UI Widgets, Components & Sketch UI kits and supporting directives for [Angular](https://angular.io/) by Infragistics.  Ignite UI for Angular is designed to enable developers to build the most modern, high-performance HTML5 & JavaScript apps for modern desktop browsers, mobile experiences and progressive web apps (PWA’s) targeting Google's Angular framework.  
 
-You can find source files under the [`src`](https://github.com/IgniteUI/igniteui-js-blocks/tree/master/src) folder, including samples and tests.
+You can find source files under the [`src`](https://github.com/IgniteUI/igniteui-angular/tree/master/src) folder, including samples and tests.
 
 #### [**View running samples here**](https://www.infragistics.com/products/ignite-ui-angular/angular/components/grid.html)
 
@@ -18,31 +18,31 @@ Current list of controls include:
 
 | *Components*          | Status              | Docs                                                                                            |     | *Directives*  | Status        | Docs                                                                                                  |
 | :-:                   | :-:                 | :-:                                                                                             | :-: | :-:           | :-:           | :-:                                                                                                   |
-| **avatar**            |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/avatar/README.md)       |     | **button**    |     Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/button/README.md)             |
-| **badge**             |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/badge/README.md)        |     | **filter**    |     Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/directives/README-FILTER.md)  |
-| **carousel**          |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/carousel/README.md)     |     | **ripple**    |     Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/directives/README-RIPPLE.md)  |
-| **list**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/list/README.md)         |     | **input**     |     Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/input/README.md)              |
-| **navbar**            |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/navbar/README.md)       |     | **label**     |     Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/label/README.md)              |
-| **tabbar**            |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/tabbar/README.md)       |     | **layout**    |     Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/layout/README.md)             |
-| **dialog**            |     Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/dialog/README.md)       |     |               |               |                                                                                                       |
-| **snackbar**          |     Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/snackbar/README.md)     |     |               |               |                                                                                                       |
-| **toast**             |     Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/toast/README.md)     |     |               |               |                                                                                                       |
-| **navigation drawer** |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/navigation-drawer/README.md)    |     |               |               |                                                                                                       |
-| **radio**             |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/radio/README.md)        |     |               |               |                                                                                                       |
-| **checkbox**          |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/checkbox/README.md)     |     |               |               |                                                                                                       |
-| **switch**            |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/switch/README.md)       |     |               |               |                                                                                                       |
-| **scroll**            |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/scroll/README.md)       |     |               |               |                                                                                                       |
-| **linear progress**    |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/progressbar/README.md)  |     |               |               |                                                                                                       |
-| **circular progress** |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/progressbar/README.md)  |     |               |               |                                                                                                       |
-| **icon**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/tree/master/src/icon/README.md)         |     |               |               |                                                                                                       |
-| **card**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/card/README.md)         |     |               |               |                                                                                                       |
-| **grid**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/grid/README.md)         |     |               |               |                                                                                                       |
-| **slider**            |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/slider/README.md)       |     |               |               |                                                                                                       |
-| **calendar**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/tree/master/src/calendar/README.md)         |     |               |               |                                                                                                       |
-| **buttonGroup**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/buttonGroup/README.md)      |               |               |                                                                                                       |
-| **dataContainer**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/data-operations/README-DATACONTAINER.md)      |               |               |                                                                                                       |
-| **dataUtil**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/data-operations/README-DATAUTIL.md)      |               |               |                                                                                                       |
-| **datePicker**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/src/date-picker/README.md)      |               |               |                                                                                                       |
+| **avatar**            |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/avatar/README.md)       |     | **button**    |     Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/button/README.md)             |
+| **badge**             |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/badge/README.md)        |     | **filter**    |     Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/directives/README-FILTER.md)  |
+| **carousel**          |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/carousel/README.md)     |     | **ripple**    |     Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/directives/README-RIPPLE.md)  |
+| **list**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/list/README.md)         |     | **input**     |     Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/input/README.md)              |
+| **navbar**            |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/navbar/README.md)       |     | **label**     |     Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/label/README.md)              |
+| **tabbar**            |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/tabbar/README.md)       |     | **layout**    |     Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/layout/README.md)             |
+| **dialog**            |     Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/dialog/README.md)       |     |               |               |                                                                                                       |
+| **snackbar**          |     Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/snackbar/README.md)     |     |               |               |                                                                                                       |
+| **toast**             |     Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/toast/README.md)     |     |               |               |                                                                                                       |
+| **navigation drawer** |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/navigation-drawer/README.md)    |     |               |               |                                                                                                       |
+| **radio**             |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/radio/README.md)        |     |               |               |                                                                                                       |
+| **checkbox**          |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/checkbox/README.md)     |     |               |               |                                                                                                       |
+| **switch**            |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/switch/README.md)       |     |               |               |                                                                                                       |
+| **scroll**            |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/scroll/README.md)       |     |               |               |                                                                                                       |
+| **linear progress**    |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/progressbar/README.md)  |     |               |               |                                                                                                       |
+| **circular progress** |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/progressbar/README.md)  |     |               |               |                                                                                                       |
+| **icon**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/tree/master/src/icon/README.md)         |     |               |               |                                                                                                       |
+| **card**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/card/README.md)         |     |               |               |                                                                                                       |
+| **grid**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/grid/README.md)         |     |               |               |                                                                                                       |
+| **slider**            |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/slider/README.md)       |     |               |               |                                                                                                       |
+| **calendar**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/tree/master/src/calendar/README.md)         |     |               |               |                                                                                                       |
+| **buttonGroup**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/buttonGroup/README.md)      |               |               |                                                                                                       |
+| **dataContainer**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/data-operations/README-DATACONTAINER.md)      |               |               |                                                                                                       |
+| **dataUtil**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/data-operations/README-DATAUTIL.md)      |               |               |                                                                                                       |
+| **datePicker**              |           Available | [Readme](https://github.com/IgniteUI/igniteui-angular/blob/master/src/date-picker/README.md)      |               |               |                                                                                                       |
 
 ## Setup
 From the root folder run:
@@ -110,7 +110,7 @@ It will watch both the `src` and `demos` directories and will rebuild both the l
 
 You can include Ignite UI for Angular in your project as a dependency using the NPM package.
 
-`npm install igniteui-js-blocks --save-dev`
+`npm install igniteui-angular --save-dev`
 
 ## Contributing
 [Coding Guidelines](../../wiki//Coding-guidelines-for-Ignite-UI-JS-Blocks)
@@ -119,11 +119,11 @@ You can include Ignite UI for Angular in your project as a dependency using the 
 
 
 ## Quickstart App
-[Ignite UI for Angular Quickstart app](https://github.com/IgniteUI/igniteui-js-blocks-quickstart)
+[Ignite UI for Angular Quickstart app](https://github.com/IgniteUI/igniteui-angular-quickstart)
 This repository is a fork of the Angular QuickStart Source and has been updated to demonstrate how to include and use components from Ignite UI for Angular. It basically follows the shortest path to bootstrap writing the application with Ignite UI for Angular:
 
 - Fork the [the angular quickstart](https://github.com/angular/quickstart)
-- Install Ignite UI for Angular from npm using `npm install igniteui-js-blocks --save-dev`
+- Install Ignite UI for Angular from npm using `npm install igniteui-angular --save-dev`
 - Update the views with sample Ignite UI for Angular controls.
 
 ## Demo Apps & Documentation
@@ -134,7 +134,7 @@ To get started with the Data Grid, use the steps in the [grid walk-through](http
 All help, related API documents and walk-throughs can be found for each control [here](https://www.infragistics.com/angular-samples/components/grid.html). 
 
 ## Roadmap
-[Roadmap document](https://github.com/IgniteUI/igniteui-js-blocks/blob/master/ROADMAP.md)
+[Roadmap document](https://github.com/IgniteUI/igniteui-angular/blob/master/ROADMAP.md)
 
 ## Support
 Developer support is provided as part of the commercial, paid-for license via [Infragistics Forums](https://www.infragistics.com/community/forums/), or via Chat & Phone with a Priority Support license.  To acquire a license for paid support or Prioroty Support, please visit this [page](https://www.infragistics.com/how-to-buy/product-pricing#developers).

--- a/README.md
+++ b/README.md
@@ -10,8 +10,7 @@ You can find source files under the [`src`](https://github.com/IgniteUI/igniteui
 
 #### [**View running samples here**](https://www.infragistics.com/products/ignite-ui-angular/angular/components/grid.html)
 
-
-
+**IMPORTANT** The repository has been renamed from `igniteui-js-blocks` to `igniteui-angular`. Read more on our new [naming convention](https://www.infragistics.com/community/blogs/b/infragistics/posts/ignite-ui-github-repo-name-changes). 
 
 Current list of controls include:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@
 1.1. Adding component views like App Host, Tabs, List
 1.2. Updating the default project look
 1.3. Move the project navigation inside an App Host
-2. Grid Multi-column Headers [issue](https://github.com/IgniteUI/igniteui-js-blocks/issues/488)
+2. Grid Multi-column Headers [issue](https://github.com/IgniteUI/igniteui-angular/issues/488)
 3. Collapsible Column Groups with state templating (collapsed state column can be templated)
 4. Column pinning
 5. Grouping
@@ -17,15 +17,15 @@
 
 ## Next three months (due January 15th, 2018)
 
-1. Row objects - 1st sprint (by November 20th, 2017) [issue](https://github.com/IgniteUI/igniteui-js-blocks/issues/479)  
+1. Row objects - 1st sprint (by November 20th, 2017) [issue](https://github.com/IgniteUI/igniteui-angular/issues/479)  
 	In order to implement virtualization in the Grid, we would need a row object to be abstracted. 
-2. Cell objects - 2nd sprint (by December 11th, 2017) [issue](https://github.com/IgniteUI/igniteui-js-blocks/issues/480)  
-3. Virtualization - research 1st sprint [issue](https://github.com/IgniteUI/igniteui-js-blocks/issues/482)  
+2. Cell objects - 2nd sprint (by December 11th, 2017) [issue](https://github.com/IgniteUI/igniteui-angular/issues/480)  
+3. Virtualization - research 1st sprint [issue](https://github.com/IgniteUI/igniteui-angular/issues/482)  
 	We need a virtual container as an extension/feature of the `DataContainer`. Virtualization would behave similar to how the controls operate with the `Paging` pipe. There would be a mechanism for components to request the `DataContainer` to skip `n` records and return `k` records. Then the control takes care of rendering those `k` records in a container, which we call `virtual DOM container`. The side of the `virtual DOM container` will be fixed, and there should be no difference for the component whether the records are available in memory, or should be requested from a remote service. This is, in fact, a generalization of the `Paging` feature, where with paging the skip is performed on a multiple of `k` and `k` is fixed and controlled by the developer.
 4. Grid Row virtualization - after row objects and virtualization are implemented
 5. Grid Column virtualization - after row objects and column component refactoring are done  
 	This feature enables Grid columns to be virtualized. The feature splits records into parts, and only a certain part of the record is rendered.
-6. Data Operations UI (by December 31st, 2017) [issue](https://github.com/IgniteUI/igniteui-js-blocks/issues/486)  
+6. Data Operations UI (by December 31st, 2017) [issue](https://github.com/IgniteUI/igniteui-angular/issues/486)  
 	We need a data oprations UI component, which communicates with our filtering, sorting, and other data opration pipes. The data operations component should be templatable and pluggable into any component that is bound to our `DataContainer`, but should also provide an exceptional default template.
 7. Alternating row style  
 8. **[DONE]** Ignite UI CLI integration [issue](https://github.com/IgniteUI/ignite-ui-cli/issues/53)  

--- a/demos/package-lock.json
+++ b/demos/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "igniteui-js-blocks-demos",
+    "name": "igniteui-angular-demos",
     "version": "0.1.0",
     "lockfileVersion": 1,
     "requires": true,

--- a/demos/package.json
+++ b/demos/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "igniteui-js-blocks-demos",
+    "name": "igniteui-angular-demos",
     "version": "0.1.0",
     "scripts": {
         "build:aot": "npm run build:aot:compile && npm run build:aot:bundle",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "igniteui-js-blocks",
+    "name": "igniteui-angular",
     "version": "0.1.0",
     "lockfileVersion": 1,
     "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-    "name": "igniteui-js-blocks",
+    "name": "igniteui-angular",
     "version": "0.1.0",
     "description": "Infragistics mobile-first Angular native components and supporting directives built with TypeScript",
     "author": "Infragistics",
     "license": "Apache-2.0",
     "repository": {
         "type": "git",
-        "url": "https://github.com/IgniteUI/igniteui-js-blocks"
+        "url": "https://github.com/IgniteUI/igniteui-angular"
     },
     "bugs": {
-        "url": "https://github.com/IgniteUI/igniteui-js-blocks/issues"
+        "url": "https://github.com/IgniteUI/igniteui-angular/issues"
     },
     "keywords": [
-        "igniteui-js-blocks",
+        "igniteui-angular",
         "angular",
         "angular4",
         "UI components",

--- a/src/animations/README.md
+++ b/src/animations/README.md
@@ -2,17 +2,17 @@
 
 Ignite UI JS Blocks includes over 100+ pre-built animations. They are split in 7 groups:
 
-  - [Fade](https://github.com/IgniteUI/igniteui-js-blocks/tree/master/src/animations/fade/README.md)
-  - [Flip](https://github.com/IgniteUI/igniteui-js-blocks/tree/master/src/animations/flip/README.md)
-  - [Miscellaneous](https://github.com/IgniteUI/igniteui-js-blocks/tree/master/src/animations/misc/README.md)
+  - [Fade](https://github.com/IgniteUI/igniteui-angular/tree/master/src/animations/fade/README.md)
+  - [Flip](https://github.com/IgniteUI/igniteui-angular/tree/master/src/animations/flip/README.md)
+  - [Miscellaneous](https://github.com/IgniteUI/igniteui-angular/tree/master/src/animations/misc/README.md)
     - Blink
     - Heartbeat
     - Pulsate
     - Shake
-  - [Rotate](https://github.com/IgniteUI/igniteui-js-blocks/tree/master/src/animations/rotate/README.md)
-  - [Scale](https://github.com/IgniteUI/igniteui-js-blocks/tree/master/src/animations/scale/README.md)
-  - [Slide](https://github.com/IgniteUI/igniteui-js-blocks/tree/master/src/animations/slide/README.md)
-  - [Swing](https://github.com/IgniteUI/igniteui-js-blocks/tree/master/src/animations/swing/README.md)
+  - [Rotate](https://github.com/IgniteUI/igniteui-angular/tree/master/src/animations/rotate/README.md)
+  - [Scale](https://github.com/IgniteUI/igniteui-angular/tree/master/src/animations/scale/README.md)
+  - [Slide](https://github.com/IgniteUI/igniteui-angular/tree/master/src/animations/slide/README.md)
+  - [Swing](https://github.com/IgniteUI/igniteui-angular/tree/master/src/animations/swing/README.md)
 
 Each group accepts a different set of parameters, allowing you to modify the behavior  of any of the included animations. Each animation is an [`AnimationReferenceMetadata`](https://angular.io/api/animations/AnimationReferenceMetadata) object as produced by the [`animation`](https://angular.io/api/animations/animation) function provided by Angular.
 
@@ -64,7 +64,7 @@ There are three main timing function groups - **EaseIn**, **EaseOut**, and **Eas
 
 To use a specific timing function, import it first:
 ``` typescript 
-import { EaseOut } from "igniteui-js-blocks/animations/easings";
+import { EaseOut } from "igniteui-angular/animations/easings";
 ```
 and then use it as value for the easing param in any animation:
 

--- a/src/animations/fade/README.md
+++ b/src/animations/fade/README.md
@@ -21,7 +21,7 @@ const params: IAnimationParams = {
 If parameters are attached, they act as default values.  When an animation is invoked via [`useAnimation`](https://angular.io/api/animations/useAnimation) then parameter values are allowed to be passed in directly. If any of the passed in parameter values are missing then the default values will be used.
 
 ``` typescript
-import { fadeIn } from "igniteui-js-blocks/animations/main";
+import { fadeIn } from "igniteui-angular/animations/main";
 import { EaseOut } from "ignieui-js-blocks/animations/easings";
 
 useAnimation(fadeIn, {

--- a/src/animations/fade/README.md
+++ b/src/animations/fade/README.md
@@ -22,7 +22,7 @@ If parameters are attached, they act as default values.  When an animation is in
 
 ``` typescript
 import { fadeIn } from "igniteui-angular/animations/main";
-import { EaseOut } from "ignieui-js-blocks/animations/easings";
+import { EaseOut } from "ignieui-angular/animations/easings";
 
 useAnimation(fadeIn, {
     params: {

--- a/src/animations/flip/README.md
+++ b/src/animations/flip/README.md
@@ -32,7 +32,7 @@ const params: IAnimationParams = {
 If parameters are attached, they act as default values.  When an animation is invoked via [`useAnimation`](https://angular.io/api/animations/useAnimation) then parameter values are allowed to be passed in directly. If any of the passed in parameter values are missing then the default values will be used.
 
 ``` typescript
-import { flipTop } from "igniteui-js-blocks/animations/main";
+import { flipTop } from "igniteui-angular/animations/main";
 
 useAnimation(fadeIn);
 ```

--- a/src/animations/misc/README.md
+++ b/src/animations/misc/README.md
@@ -72,7 +72,7 @@ const shakeParams: IAnimationParams = {
 If parameters are attached, they act as default values.  When an animation is invoked via [`useAnimation`](https://angular.io/api/animations/useAnimation) then parameter values are allowed to be passed in directly. If any of the passed in parameter values are missing then the default values will be used.
 
 ``` typescript
-import { blink } from "igniteui-js-blocks/animations/main";
+import { blink } from "igniteui-angular/animations/main";
 
 useAnimation(blink);
 ```

--- a/src/animations/rotate/README.md
+++ b/src/animations/rotate/README.md
@@ -52,7 +52,7 @@ const params: IAnimationParams = {
 If parameters are attached, they act as default values.  When an animation is invoked via [`useAnimation`](https://angular.io/api/animations/useAnimation) then parameter values are allowed to be passed in directly. If any of the passed in parameter values are missing then the default values will be used.
 
 ``` typescript
-import { rotateInCenter } from "igniteui-js-blocks/animations/main";
+import { rotateInCenter } from "igniteui-angular/animations/main";
 
 useAnimation(rotateInCenter);
 ```

--- a/src/animations/scale/README.md
+++ b/src/animations/scale/README.md
@@ -54,7 +54,7 @@ const params: IAnimationParams = {
 If parameters are attached, they act as default values.  When an animation is invoked via [`useAnimation`](https://angular.io/api/animations/useAnimation) then parameter values are allowed to be passed in directly. If any of the passed in parameter values are missing then the default values will be used.
 
 ``` typescript
-import { flipTop } from "igniteui-js-blocks/animations/main";
+import { flipTop } from "igniteui-angular/animations/main";
 
 useAnimation(fadeIn);
 ```

--- a/src/animations/slide/README.md
+++ b/src/animations/slide/README.md
@@ -54,7 +54,7 @@ const params: IAnimationParams = {
 If parameters are attached, they act as default values.  When an animation is invoked via [`useAnimation`](https://angular.io/api/animations/useAnimation) then parameter values are allowed to be passed in directly. If any of the passed in parameter values are missing then the default values will be used.
 
 ``` typescript
-import { scaleInTop } from "igniteui-js-blocks/animations/main";
+import { scaleInTop } from "igniteui-angular/animations/main";
 
 useAnimation(scaleInTop);
 ```

--- a/src/animations/swing/README.md
+++ b/src/animations/swing/README.md
@@ -40,7 +40,7 @@ const params: IAnimationParams = {
 If parameters are attached, they act as default values.  When an animation is invoked via [`useAnimation`](https://angular.io/api/animations/useAnimation) then parameter values are allowed to be passed in directly. If any of the passed in parameter values are missing then the default values will be used.
 
 ``` typescript
-import { swingInTopFwd } from "igniteui-js-blocks/animations/main";
+import { swingInTopFwd } from "igniteui-angular/animations/main";
 
 useAnimation(swingInTopFwd);
 ```

--- a/src/calendar/README.md
+++ b/src/calendar/README.md
@@ -6,7 +6,7 @@ You can see it in action [here](http://139.59.168.161/demos/calendar)
 
 ## Usage
 ```typescript
-import { IgxCalendarComponent } from "igniteui-js-blocks";
+import { IgxCalendarComponent } from "igniteui-angular";
 ```
 
 Basic initialization

--- a/src/core/touch.ts
+++ b/src/core/touch.ts
@@ -14,7 +14,7 @@ export class HammerGesturesManager {
      */
     protected hammerOptions: HammerOptions = {
         // D.P. #447 Force TouchInput due to PointerEventInput bug (https://github.com/hammerjs/hammer.js/issues/1065)
-        // see https://github.com/IgniteUI/igniteui-js-blocks/issues/447#issuecomment-324601803
+        // see https://github.com/IgniteUI/igniteui-angular/issues/447#issuecomment-324601803
         inputClass: Hammer.TouchInput,
         recognizers: [
             [ Hammer.Pan, { threshold: 0 } ],

--- a/src/date-picker/README.md
+++ b/src/date-picker/README.md
@@ -5,7 +5,7 @@ which is presented into input field.
 
 # Usage
 ```typescript
-import { IgxDatePickerComponent } from "igniteui-js-blocks";
+import { IgxDatePickerComponent } from "igniteui-angular";
 ```
 
 Basic initialization


### PR DESCRIPTION
Renaming everything from `igniteui-angular2` to `igniteui-angular-wrappers` as outlined in the blog post.

https://www.infragistics.com/community/blogs/b/infragistics/posts/ignite-ui-github-repo-name-changes 
