### PR TITLE
Nav drawer rename, readme update

### DIFF
--- a/demos/app/app.component.ts
+++ b/demos/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Output, ViewChild } from "@angular/core";
 import { NavigationStart, Router } from "@angular/router";
 import "rxjs/add/operator/filter";
-import { NavigationDrawer, NavigationDrawerModule } from "../lib/main";
+import { IgxNavigationDrawer, IgxNavigationDrawerModule } from "../lib/main";
 
 @Component({
     selector: "sample-app",
@@ -9,7 +9,7 @@ import { NavigationDrawer, NavigationDrawerModule } from "../lib/main";
     templateUrl: "app.component.html"
 })
 export class AppComponent {
-    @ViewChild("navdrawer") public navdrawer: NavigationDrawer;
+    @ViewChild("navdrawer") public navdrawer: IgxNavigationDrawer;
 
     public drawerState = {
         enableGestures: true,

--- a/demos/app/navdrawer/sample.module.ts
+++ b/demos/app/navdrawer/sample.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { FormsModule } from "@angular/forms";
-import { IgxDirectivesModule, IgxRadioModule, IgxSwitchModule, NavigationDrawerModule } from "../../lib/main";
+import { IgxDirectivesModule, IgxRadioModule, IgxSwitchModule, IgxNavigationDrawerModule } from "../../lib/main";
 import { PageHeaderModule } from "../pageHeading/pageHeading.module";
 import { NavdrawerSampleComponent } from "./sample.component";
 
@@ -12,7 +12,7 @@ import { NavdrawerSampleComponent } from "./sample.component";
     imports: [
         IgxDirectivesModule,
         IgxSwitchModule,
-        NavigationDrawerModule,
+        IgxNavigationDrawerModule,
         CommonModule,
         FormsModule,
         IgxRadioModule,

--- a/src/core/navigation/directives.ts
+++ b/src/core/navigation/directives.ts
@@ -11,7 +11,7 @@ import {IgxNavigationService} from "./nav-service";
  * Where the `ID` matches the ID of compatible `IToggleView` component.
  */
 @Directive({ selector: "[igxNavToggle]" })
-export class NavigationToggle {
+export class IgxNavigationToggle {
     public state: IgxNavigationService;
 
     @Input("igxNavToggle") private target;
@@ -36,7 +36,7 @@ export class NavigationToggle {
  * Where the `ID` matches the ID of compatible `IToggleView` component.
  */
 @Directive({ selector: "[igxNavClose]" })
-export class NavigationClose {
+export class IgxNavigationClose {
     public state: IgxNavigationService;
 
     @Input("igxNavClose") private target;
@@ -52,8 +52,8 @@ export class NavigationClose {
 }
 
 @NgModule({
-    declarations: [NavigationClose, NavigationToggle],
-    exports: [NavigationClose, NavigationToggle],
+    declarations: [IgxNavigationClose, IgxNavigationToggle],
+    exports: [IgxNavigationClose, IgxNavigationToggle],
     providers: [IgxNavigationService]
 })
 export class IgxNavigationDirectives {}

--- a/src/core/navigation/directives.ts
+++ b/src/core/navigation/directives.ts
@@ -1,5 +1,5 @@
 import { Directive, HostListener, Input, NgModule } from "@angular/core";
-import {NavigationService} from "./nav-service";
+import {IgxNavigationService} from "./nav-service";
 
 /**
  * Directive that can toggle targets through provided NavigationService.
@@ -12,11 +12,11 @@ import {NavigationService} from "./nav-service";
  */
 @Directive({ selector: "[igxNavToggle]" })
 export class NavigationToggle {
-    public state: NavigationService;
+    public state: IgxNavigationService;
 
     @Input("igxNavToggle") private target;
 
-    constructor(nav: NavigationService) {
+    constructor(nav: IgxNavigationService) {
         this.state = nav;
     }
 
@@ -37,11 +37,11 @@ export class NavigationToggle {
  */
 @Directive({ selector: "[igxNavClose]" })
 export class NavigationClose {
-    public state: NavigationService;
+    public state: IgxNavigationService;
 
     @Input("igxNavClose") private target;
 
-    constructor(nav: NavigationService) {
+    constructor(nav: IgxNavigationService) {
         this.state = nav;
     }
 
@@ -54,6 +54,6 @@ export class NavigationClose {
 @NgModule({
     declarations: [NavigationClose, NavigationToggle],
     exports: [NavigationClose, NavigationToggle],
-    providers: [NavigationService]
+    providers: [IgxNavigationService]
 })
 export class IgxNavigationDirectives {}

--- a/src/core/navigation/nav-service.ts
+++ b/src/core/navigation/nav-service.ts
@@ -5,7 +5,7 @@ import { IToggleView } from "./toggle";
  * ToggleView interface can register and toggle directives can call their methods.
  * TODO: Track currently active? Events?
  */
-export class NavigationService {
+export class IgxNavigationService {
     private navs: { [id: string]: IToggleView; };
 
     constructor() {

--- a/src/navigation-drawer/README.md
+++ b/src/navigation-drawer/README.md
@@ -1,10 +1,10 @@
-# ig-nav-drawer
+# igx-nav-drawer
 
-The **ig-nav-drawer** is a container element for side navigation, providing quick access between views. It can be used for navigation apps and with top-level views. Drawer will be hidden until invoked by the user.
+The **igx-nav-drawer** is a container element for side navigation, providing quick access between views. It can be used for navigation apps and with top-level views. Drawer will be hidden until invoked by the user.
 
 # Usage
 ```html
-<ig-nav-drawer id="test"
+<igx-nav-drawer id="test"
     (opened)="logEvent($event)"
     [position]="position"
     [pin]="pin"
@@ -21,7 +21,7 @@ The **ig-nav-drawer** is a container element for side navigation, providing quic
             <span class="hamburger" igxNavToggle="test" > &#9776; </span>
             <div *ngFor="let navItem of navItems"><img src="http://www.infragistics.com/assets/images/favicon.ico" width='16' /></div>
         </div>
-</ig-nav-drawer>
+</igx-nav-drawer>
 ```
 
 # API Summary
@@ -34,9 +34,9 @@ The **ig-nav-drawer** is a container element for side navigation, providing quic
 | `enableGestures`| boolean | Enables the use of touch gestures to manipulate the drawer - such as swipe/pan from edge to open, swipe toggle and pan drag. |
 | `isOpen` | boolean | State of the drawer. |
 | `pin` | boolean | Pinned state of the drawer. Currently only support. |
-| `pinThreshold` | number | Minimum device width required for automatic pin to be toggled. Deafult is 1024, can be set to falsy value to ignore. |
-| `width` | string| Width of the drawer in its open state. Defaults to 300px based on the `.ig-nav-drawer` style. Can be used to override or dynamically modify the width.|
-| `miniWidth` | string | Width of the drawer in its mini state. Defaults to 60px based on the `.ig-nav-drawer.mini` style. Can be used to override or dynamically modify the width. |
+| `pinThreshold` | number | Minimum device width required for automatic pin to be toggled. Default is 1024, can be set to falsy value to ignore. |
+| `width` | string| Width of the drawer in its open state. Defaults to 300px based on the `.igx-nav-drawer` style. Can be used to override or dynamically modify the width.|
+| `miniWidth` | string | Width of the drawer in its mini state. Defaults to 60px based on the `.igx-nav-drawer.mini` style. Can be used to override or dynamically modify the width. |
 
 ## Methods
 | Name      |  Description |
@@ -67,7 +67,7 @@ export class MainDrawerSampleComponent {
     open: boolean = false;
     position = "left";
     drawerMiniWidth = "";
-    @ViewChild(NavigationDrawer) viewChild: NavigationDrawer;
+    @ViewChild(IgxNavigationDrawer) viewChild: IgxNavigationDrawer;
     /** Sample-specific configurations: */
     showMiniWidth: boolean = false;
     showEventLog: boolean = true;

--- a/src/navigation-drawer/README.md
+++ b/src/navigation-drawer/README.md
@@ -35,16 +35,15 @@ The **igx-nav-drawer** is a container element for side navigation, providing qui
 | `isOpen` | boolean | State of the drawer. |
 | `pin` | boolean | Pinned state of the drawer. Currently only support. |
 | `pinThreshold` | number | Minimum device width required for automatic pin to be toggled. Default is 1024, can be set to falsy value to ignore. |
-| `width` | string| Width of the drawer in its open state. Defaults to 300px based on the `.igx-nav-drawer` style. Can be used to override or dynamically modify the width.|
-| `miniWidth` | string | Width of the drawer in its mini state. Defaults to 60px based on the `.igx-nav-drawer.mini` style. Can be used to override or dynamically modify the width. |
+| `width` | string| Width of the drawer in its open state. Defaults to 300px based on the `.ig-nav-drawer` style. Can be used to override or dynamically modify the width.|
+| `miniWidth` | string | Width of the drawer in its mini state. Defaults to 60px based on the `.ig-nav-drawer.mini` style. Can be used to override or dynamically modify the width. |
 
 ## Methods
 | Name      |  Description |
 |:----------|:------|
-| `open`    | Open the Navigation Drawer. Has no effect if already opened. *@param* fireEvents Optional flag determining whether events should be fired or not. *@return* Promise that is resolved once the operation completes. |
-| `close`   | Close the Navigation Drawer. Has no effect if already closed. *@param* fireEvents Optional flag determining whether events should be fired or not. *@return* Promise that is resolved once the operation completes. |
-| `expectedWidth()`  | Get the Drawer width for specific state. Will attempt to evaluate requested state and cache. |
-| `expectedMiniWidth()`| Get the Drawer mini width for specific state. Will attempt to evaluate requested state and cache. |
+| `open`    | Open the Navigation Drawer. Has no effect if already opened. Returns `Promise` that is resolved once the operation completes. |
+| `close`   | Close the Navigation Drawer. Has no effect if already closed. Returns `Promise` that is resolved once the operation completes. |
+| `toggle()`  | Toggle the open state of the Navigation Drawer. Returns `Promise` that is resolved once the operation completes. |
 
 ## Events
 | Name      |  Description |

--- a/src/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/src/navigation-drawer/navigation-drawer.component.spec.ts
@@ -19,8 +19,8 @@ describe("Navigation Drawer", () => {
             jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
             TestBed.configureTestingModule({
                 declarations: [
-                    Infragistics.NavigationClose,
-                    Infragistics.NavigationToggle,
+                    Infragistics.IgxNavigationClose,
+                    Infragistics.IgxNavigationToggle,
                     TestComponent,
                     TestComponentDI,
                     TestComponentPin],

--- a/src/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/src/navigation-drawer/navigation-drawer.component.spec.ts
@@ -24,7 +24,7 @@ describe("Navigation Drawer", () => {
                     TestComponent,
                     TestComponentDI,
                     TestComponentPin],
-                imports: [Infragistics.NavigationDrawerModule]
+                imports: [Infragistics.IgxNavigationDrawerModule]
             });
         }));
 
@@ -36,7 +36,7 @@ describe("Navigation Drawer", () => {
             TestBed.compileComponents().then(() => {
                 const fixture = TestBed.createComponent(TestComponent);
                 fixture.detectChanges();
-                expect(fixture.componentInstance.viewChild instanceof Infragistics.NavigationDrawer).toBeTruthy();
+                expect(fixture.componentInstance.viewChild instanceof Infragistics.IgxNavigationDrawer).toBeTruthy();
                 expect(fixture.componentInstance.viewChild.state).toBeNull();
             });
         }));
@@ -47,7 +47,7 @@ describe("Navigation Drawer", () => {
                 fixture.detectChanges();
 
                 expect(fixture.componentInstance.viewChild).toBeDefined();
-                expect(fixture.componentInstance.viewChild instanceof Infragistics.NavigationDrawer).toBeTruthy();
+                expect(fixture.componentInstance.viewChild instanceof Infragistics.IgxNavigationDrawer).toBeTruthy();
                 expect(fixture.componentInstance.viewChild.state instanceof Infragistics.NavigationService)
                     .toBeTruthy();
             });
@@ -97,7 +97,7 @@ describe("Navigation Drawer", () => {
             TestBed.compileComponents().then(() => {
                 const fixture = TestBed.createComponent(TestComponentDI);
                 fixture.detectChanges();
-                const drawer: Infragistics.NavigationDrawer = fixture.componentInstance.viewChild;
+                const drawer: Infragistics.IgxNavigationDrawer = fixture.componentInstance.viewChild;
                 expect(drawer.isOpen).toBeFalsy();
 
                 drawer.open();
@@ -301,7 +301,7 @@ describe("Navigation Drawer", () => {
             TestBed.compileComponents().then(() => {
                 fixture = TestBed.createComponent(TestComponentDI);
                 fixture.detectChanges();
-                const drawer: Infragistics.NavigationDrawer = fixture.componentInstance.viewChild;
+                const drawer: Infragistics.IgxNavigationDrawer = fixture.componentInstance.viewChild;
 
                 fixture.componentInstance.drawerMiniWidth = 60;
                 fixture.detectChanges();
@@ -453,7 +453,7 @@ describe("Navigation Drawer", () => {
     template: "<igx-nav-drawer></igx-nav-drawer>"
 })
 class TestComponent {
-     @ViewChild(Infragistics.NavigationDrawer) public viewChild: Infragistics.NavigationDrawer;
+     @ViewChild(Infragistics.IgxNavigationDrawer) public viewChild: Infragistics.IgxNavigationDrawer;
 }
 
 @Component({
@@ -464,7 +464,7 @@ class TestComponent {
 class TestComponentDI {
      public drawerMiniWidth: string | number;
      public drawerWidth: string | number;
-     @ViewChild(Infragistics.NavigationDrawer) public viewChild: Infragistics.NavigationDrawer;
+     @ViewChild(Infragistics.IgxNavigationDrawer) public viewChild: Infragistics.IgxNavigationDrawer;
 }
 
 class TestComponentPin extends TestComponentDI {

--- a/src/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/src/navigation-drawer/navigation-drawer.component.spec.ts
@@ -48,7 +48,7 @@ describe("Navigation Drawer", () => {
 
                 expect(fixture.componentInstance.viewChild).toBeDefined();
                 expect(fixture.componentInstance.viewChild instanceof Infragistics.IgxNavigationDrawer).toBeTruthy();
-                expect(fixture.componentInstance.viewChild.state instanceof Infragistics.NavigationService)
+                expect(fixture.componentInstance.viewChild.state instanceof Infragistics.IgxNavigationService)
                     .toBeTruthy();
             });
         }));
@@ -78,7 +78,7 @@ describe("Navigation Drawer", () => {
             TestBed.compileComponents().then(() => {
                 const fixture = TestBed.createComponent(TestComponentDI);
                 fixture.detectChanges();
-                const state: Infragistics.NavigationService = fixture.componentInstance.viewChild.state;
+                const state: Infragistics.IgxNavigationService = fixture.componentInstance.viewChild.state;
                 const touchManager = fixture.componentInstance.viewChild.touchManager;
 
                 expect(state.get("testNav")).toBeDefined();
@@ -457,7 +457,7 @@ class TestComponent {
 }
 
 @Component({
-    providers: [Infragistics.NavigationService],
+    providers: [Infragistics.IgxNavigationService],
     selector: "test-cmp",
     template: "<igx-nav-drawer></igx-nav-drawer>"
 })

--- a/src/navigation-drawer/navigation-drawer.component.ts
+++ b/src/navigation-drawer/navigation-drawer.component.ts
@@ -42,7 +42,7 @@ import { HammerGesturesManager } from "../core/touch";
     styleUrls: ["./navigation-drawer.component.scss"],
     templateUrl: "navigation-drawer.component.html"
 })
-export class NavigationDrawer extends BaseComponent implements IToggleView,
+export class IgxNavigationDrawer extends BaseComponent implements IToggleView,
     OnInit,
     AfterContentInit,
     OnDestroy,
@@ -609,8 +609,8 @@ export class NavigationDrawer extends BaseComponent implements IToggleView,
 }
 
 @NgModule({
-    declarations: [NavigationDrawer],
-    exports: [NavigationDrawer]
+    declarations: [IgxNavigationDrawer],
+    exports: [IgxNavigationDrawer]
 })
-export class NavigationDrawerModule {
+export class IgxNavigationDrawerModule {
 }

--- a/src/navigation-drawer/navigation-drawer.component.ts
+++ b/src/navigation-drawer/navigation-drawer.component.ts
@@ -20,7 +20,7 @@ import "rxjs/add/operator/debounce";
 import { Observable } from "rxjs/Observable";
 import { Subscription } from "rxjs/Subscription";
 import { BaseComponent } from "../core/base";
-import { IToggleView, IgxNavigationService } from "../core/navigation";
+import { IgxNavigationService, IToggleView } from "../core/navigation";
 import { HammerGesturesManager } from "../core/touch";
 
 /**

--- a/src/navigation-drawer/navigation-drawer.component.ts
+++ b/src/navigation-drawer/navigation-drawer.component.ts
@@ -20,7 +20,7 @@ import "rxjs/add/operator/debounce";
 import { Observable } from "rxjs/Observable";
 import { Subscription } from "rxjs/Subscription";
 import { BaseComponent } from "../core/base";
-import { IToggleView, NavigationService } from "../core/navigation";
+import { IToggleView, IgxNavigationService } from "../core/navigation";
 import { HammerGesturesManager } from "../core/touch";
 
 /**
@@ -184,7 +184,7 @@ export class IgxNavigationDrawer extends BaseComponent implements IToggleView,
 
     constructor(
         @Inject(ElementRef) private elementRef: ElementRef,
-        @Optional() private _state: NavigationService,
+        @Optional() private _state: IgxNavigationService,
         // private animate: AnimationBuilder, TODO
         protected renderer: Renderer,
         private _touchManager: HammerGesturesManager) {


### PR DESCRIPTION
Closes #512 .  

Additional information related to this pull request:
⚠️ **BREAKING CHANGES: **
- Renamed `NavigationDrawer` to `IgxNavigationDrawer`
- Renamed `NavigationDrawerModule` to `IgxNavigationDrawerModule`
- Renamed `NavigationService` to `IgxNavigationService`
- Renamed `NavigationToggle` to `IgxNavigationToggle`
- Renamed `NavigationClose` to `IgxNavigationClose`
