### PR TITLE
IgxAvatar - Replace the canvas usage with svg when rendering initials

### DIFF
--- a/src/avatar/avatar.component.html
+++ b/src/avatar/avatar.component.html
@@ -1,10 +1,10 @@
 <div class="igx-avatar igx-avatar--{{size}}" aria-label="avatar" role="img">
     <img #image *ngIf="src" src="{{src}}" class="igx-avatar--image igx-avatar--{{size}}" [class.igx-avatar--rounded]="isRounded"
-		[style.backgroundColor]="bgColor" [attr.aria-roledescription]="roleDescription" />
-	<svg #initialsImage *ngIf="initials && !src" xmlns="http://www.w3.org/2000/svg" [class.igx-avatar--rounded]="isRounded"
-		[style.backgroundColor]="bgColor" [attr.aria-roledescription]="roleDescription">
-		<text text-anchor="middle"/>
-	</svg>
+         [style.backgroundColor]="bgColor" [attr.aria-roledescription]="roleDescription" />
+        <svg #initialsImage *ngIf="initials && !src" xmlns="http://www.w3.org/2000/svg" [class.igx-avatar--rounded]="isRounded" [style.backgroundColor]="bgColor"
+            [attr.aria-roledescription]="roleDescription">
+            <text text-anchor="middle" />
+        </svg>
     <span *ngIf="!src && !initials" class="igx-avatar--{{size}} igx-avatar--icon" [class.igx-avatar--rounded]="isRounded" [style.backgroundColor]="bgColor"
         [style.color]="color" [attr.aria-roledescription]="roleDescription">
         <igx-icon fontSet="material" [name]="icon"></igx-icon>

--- a/src/avatar/avatar.component.html
+++ b/src/avatar/avatar.component.html
@@ -1,13 +1,21 @@
-<div class="igx-avatar igx-avatar--{{size}}" aria-label="avatar" role="img">
-    <img #image *ngIf="src" src="{{src}}" class="igx-avatar--image igx-avatar--{{size}}" [class.igx-avatar--rounded]="isRounded"
-         [style.backgroundColor]="bgColor" [attr.aria-roledescription]="roleDescription" />
-        <svg #initialsImage *ngIf="initials && !src" xmlns="http://www.w3.org/2000/svg" [class.igx-avatar--rounded]="isRounded" [style.backgroundColor]="bgColor"
-            [attr.aria-roledescription]="roleDescription">
-            <text text-anchor="middle" />
-        </svg>
-    <span *ngIf="!src && !initials" class="igx-avatar--{{size}} igx-avatar--icon" [class.igx-avatar--rounded]="isRounded" [style.backgroundColor]="bgColor"
+<ng-template #imageTemplate>
+    <img #image src="{{src}}" class="igx-avatar--image igx-avatar--{{size}}" [class.igx-avatar--rounded]="isRounded" [style.backgroundColor]="bgColor"
+        [attr.aria-roledescription]="roleDescription" />
+</ng-template>
+
+<ng-template #initialsTemplate>
+    <svg #initialsImage xmlns="http://www.w3.org/2000/svg" [class.igx-avatar--rounded]="isRounded" [style.backgroundColor]="bgColor"
+        [attr.aria-roledescription]="roleDescription">
+        <text text-anchor="middle" />
+    </svg>
+</ng-template>
+
+<ng-template #iconTemplate>
+    <span class="igx-avatar--{{size}} igx-avatar--icon" [class.igx-avatar--rounded]="isRounded" [style.backgroundColor]="bgColor"
         [style.color]="color" [attr.aria-roledescription]="roleDescription">
         <igx-icon fontSet="material" [name]="icon"></igx-icon>
     </span>
-    <ng-content></ng-content>
-</div>
+</ng-template>
+
+<ng-container *ngTemplateOutlet="template"></ng-container>
+<ng-content></ng-content>

--- a/src/avatar/avatar.component.html
+++ b/src/avatar/avatar.component.html
@@ -1,6 +1,10 @@
 <div class="igx-avatar igx-avatar--{{size}}" aria-label="avatar" role="img">
-    <img #image *ngIf="src || initials" src="{{src}}" class="igx-avatar--image igx-avatar--{{size}}" [class.igx-avatar--rounded]="isRounded"
-        [style.backgroundColor]="bgColor" [attr.aria-roledescription]="roleDescription" />
+    <img #image *ngIf="src" src="{{src}}" class="igx-avatar--image igx-avatar--{{size}}" [class.igx-avatar--rounded]="isRounded"
+		[style.backgroundColor]="bgColor" [attr.aria-roledescription]="roleDescription" />
+	<svg #initialsImage *ngIf="initials && !src" xmlns="http://www.w3.org/2000/svg" [class.igx-avatar--rounded]="isRounded"
+		[style.backgroundColor]="bgColor" [attr.aria-roledescription]="roleDescription">
+		<text text-anchor="middle"/>
+	</svg>
     <span *ngIf="!src && !initials" class="igx-avatar--{{size}} igx-avatar--icon" [class.igx-avatar--rounded]="isRounded" [style.backgroundColor]="bgColor"
         [style.color]="color" [attr.aria-roledescription]="roleDescription">
         <igx-icon fontSet="material" [name]="icon"></igx-icon>

--- a/src/avatar/avatar.component.html
+++ b/src/avatar/avatar.component.html
@@ -4,9 +4,9 @@
 </ng-template>
 
 <ng-template #initialsTemplate>
-    <svg #initialsImage xmlns="http://www.w3.org/2000/svg" [class.igx-avatar--rounded]="isRounded" [style.backgroundColor]="bgColor"
+    <svg #initialsImage xmlns="http://www.w3.org/2000/svg" [attr.class]="initialsClasses" [style.backgroundColor]="bgColor"
         [attr.aria-roledescription]="roleDescription">
-        <text text-anchor="middle" />
+        <text text-anchor="middle"/> 
     </svg>
 </ng-template>
 

--- a/src/avatar/avatar.component.spec.ts
+++ b/src/avatar/avatar.component.spec.ts
@@ -28,9 +28,8 @@ describe("Avatar", () => {
         fixture.detectChanges();
         const avatar = fixture.componentInstance.avatar;
 
-        expect(avatar.image).toBeTruthy();
-        expect(avatar.image.nativeElement.classList.contains("igx-avatar--image")).toBeTruthy();
-        expect(avatar.image.nativeElement.classList.contains("igx-avatar--medium")).toBeTruthy();
+        expect(avatar.initialsImage).toBeTruthy();
+        expect(avatar.initialsImage.nativeElement.classList.contains("igx-avatar--medium")).toBeTruthy();
         expect(avatar.isRounded).toBeFalsy();
     });
 
@@ -39,9 +38,8 @@ describe("Avatar", () => {
         fixture.detectChanges();
         const avatar = fixture.componentInstance.avatar;
 
-        expect(avatar.image).toBeTruthy();
-        expect(avatar.image.nativeElement.classList.contains("igx-avatar--image")).toBeTruthy();
-        expect(avatar.image.nativeElement.classList.contains("igx-avatar--small")).toBeTruthy();
+        expect(avatar.initialsImage).toBeTruthy();
+        expect(avatar.initialsImage.nativeElement.classList.contains("igx-avatar--small")).toBeTruthy();
         expect(avatar.isRounded).toBeTruthy();
     });
     it("Initializes icon avatar", () => {
@@ -59,8 +57,6 @@ describe("Avatar", () => {
 
         // For ARIA
         expect(spanEl[0].getAttribute("aria-roledescription") === "icon type avatar").toBeTruthy();
-        expect(avatar.elementRef.nativeElement.getElementsByTagName("div")[0].getAttribute("aria-label") === "avatar")
-            .toBeTruthy();
     });
 
     it("Initializes image avatar with src element", () => {
@@ -77,8 +73,6 @@ describe("Avatar", () => {
         // For ARIA
         expect(avatar.image.nativeElement.getAttribute("aria-roledescription") === "image type avatar").toBeTruthy();
         expect(avatar.roleDescription === "image type avatar").toBeTruthy();
-        expect(avatar.elementRef.nativeElement.getElementsByTagName("div")[0].getAttribute("aria-label") === "avatar")
-            .toBeTruthy();
     });
 
     it("Should set ARIA attributes.", () => {
@@ -86,10 +80,8 @@ describe("Avatar", () => {
         fixture.detectChanges();
         const avatar = fixture.componentInstance.avatar;
 
-        expect(avatar.image.nativeElement.getAttribute("aria-roledescription") === "initials type avatar").toBeTruthy();
+        expect(avatar.initialsImage.nativeElement.getAttribute("aria-roledescription") === "initials type avatar").toBeTruthy();
         expect(avatar.roleDescription === "initials type avatar").toBeTruthy();
-        expect(avatar.elementRef.nativeElement.getElementsByTagName("div")[0].getAttribute("aria-label") === "avatar")
-            .toBeTruthy();
     });
 });
 

--- a/src/avatar/avatar.component.ts
+++ b/src/avatar/avatar.component.ts
@@ -4,9 +4,11 @@ import {
     AfterViewInit,
     Component,
     ElementRef,
+    HostBinding,
     Input,
     NgModule,
     Renderer2,
+    TemplateRef,
     ViewChild,
     ViewEncapsulation
 } from "@angular/core";
@@ -35,7 +37,18 @@ export class IgxAvatarComponent implements AfterViewInit, AfterContentChecked {
     public sizeEnum = Size;
     public roleDescription: string;
 
+    @ViewChild("imageTemplate", { read: TemplateRef }) protected imageTemplate: TemplateRef<any>;
+    @ViewChild("initialsTemplate", { read: TemplateRef }) protected initialsTemplate: TemplateRef<any>;
+    @ViewChild("iconTemplate", { read: TemplateRef }) protected iconTemplate: TemplateRef<any>;
+
     protected fontName = "Titillium Web";
+
+    @HostBinding("attr.aria-label") private ariaLabel = "avatar";
+    @HostBinding("attr.role") private role = "img";
+    @HostBinding("attr.class")
+    get classes() {
+        return "igx-avatar igx-avatar--" + this.size;
+    }
 
     private _size: string;
     private _bgColor: string;
@@ -71,6 +84,18 @@ export class IgxAvatarComponent implements AfterViewInit, AfterContentChecked {
 
     get isRounded(): boolean {
         return this.roundShape.toUpperCase() === "TRUE" ? true : false;
+    }
+
+    get template() {
+        if (this.src) {
+            return this.imageTemplate;
+        }
+
+        if (this.initials) {
+            return this.initialsTemplate;
+        }
+
+        return this.iconTemplate;
     }
 
     @Input()

--- a/src/avatar/avatar.component.ts
+++ b/src/avatar/avatar.component.ts
@@ -25,7 +25,8 @@ export enum Size {
     templateUrl: "avatar.component.html"
 })
 export class IgxAvatarComponent implements AfterViewInit, AfterContentChecked {
-    @ViewChild("image") public image: ElementRef;
+	@ViewChild("image") public image: ElementRef;
+	@ViewChild("initialsImage") public initialsImage: ElementRef;
     @Input() public initials: string;
     @Input() public src: string;
     @Input("roundShape") public roundShape = "false";
@@ -86,11 +87,12 @@ export class IgxAvatarComponent implements AfterViewInit, AfterContentChecked {
     }
 
     public ngAfterViewInit() {
-        if (this.initials && this.image) {
-            const src = this.generateInitials(
-                parseInt(this.image.nativeElement.width, 10)
-            );
-            this.image.nativeElement.src = src;
+        if (this.initials && this.initialsImage) {
+			// it seems the svg element is not yet fully initialized so give it some time
+			setTimeout(()=>{ 
+				var size = parseInt(this.initialsImage.nativeElement.width.baseVal.value, 10);
+				this.generateInitials(size);
+			}, 50);
         }
     }
 
@@ -109,26 +111,23 @@ export class IgxAvatarComponent implements AfterViewInit, AfterContentChecked {
     }
 
     private generateInitials(size) {
-        const canvas = document.createElement("canvas");
         const fontSize = size / 2;
-        let ctx;
 
-        canvas.width = size;
-        canvas.height = size;
+		var svg = this.initialsImage.nativeElement;
+		svg.setAttribute('width', size);
+		svg.setAttribute('height', size);
 
-        ctx = canvas.getContext("2d");
-        ctx.fillStyle = this.bgColor;
-        ctx.fillRect(0, 0, canvas.width, canvas.height);
-        ctx.textAlign = "center";
-        ctx.fillStyle = this.color;
-        ctx.font = fontSize + `px ${this.fontName}`;
-        ctx.fillText(
-            this.initials.toUpperCase(),
-            size / 2,
-            size - size / 2 + fontSize / 3
-        );
-
-        return canvas.toDataURL("image/png");
+		var svgText = svg.children[0];
+		if (svgText) {
+			svgText.textContent = this.initials.toUpperCase();
+			svgText.setAttribute('font-size', fontSize);
+			svgText.setAttribute('font-family', this.fontName);
+			
+			let x = fontSize;
+			svgText.setAttribute('x', x);
+			var y = size - size / 2 + fontSize / 3;
+			svgText.setAttribute('y', y);
+		}
     }
 
     private _addEventListeners(renderer: Renderer2) { }

--- a/src/avatar/avatar.component.ts
+++ b/src/avatar/avatar.component.ts
@@ -25,8 +25,8 @@ export enum Size {
     templateUrl: "avatar.component.html"
 })
 export class IgxAvatarComponent implements AfterViewInit, AfterContentChecked {
-	@ViewChild("image") public image: ElementRef;
-	@ViewChild("initialsImage") public initialsImage: ElementRef;
+    @ViewChild("image") public image: ElementRef;
+    @ViewChild("initialsImage") public initialsImage: ElementRef;
     @Input() public initials: string;
     @Input() public src: string;
     @Input("roundShape") public roundShape = "false";
@@ -88,11 +88,11 @@ export class IgxAvatarComponent implements AfterViewInit, AfterContentChecked {
 
     public ngAfterViewInit() {
         if (this.initials && this.initialsImage) {
-			// it seems the svg element is not yet fully initialized so give it some time
-			setTimeout(()=>{ 
-				var size = parseInt(this.initialsImage.nativeElement.width.baseVal.value, 10);
-				this.generateInitials(size);
-			}, 50);
+            // it seems the svg element is not yet fully initialized so give it some time
+            setTimeout(() => {
+                const size = parseInt(this.initialsImage.nativeElement.width.baseVal.value, 10);
+                this.generateInitials(size);
+            }, 50);
         }
     }
 
@@ -113,21 +113,21 @@ export class IgxAvatarComponent implements AfterViewInit, AfterContentChecked {
     private generateInitials(size) {
         const fontSize = size / 2;
 
-		var svg = this.initialsImage.nativeElement;
-		svg.setAttribute('width', size);
-		svg.setAttribute('height', size);
+        const svg = this.initialsImage.nativeElement;
+        svg.setAttribute("width", size);
+        svg.setAttribute("height", size);
 
-		var svgText = svg.children[0];
-		if (svgText) {
-			svgText.textContent = this.initials.toUpperCase();
-			svgText.setAttribute('font-size', fontSize);
-			svgText.setAttribute('font-family', this.fontName);
-			
-			let x = fontSize;
-			svgText.setAttribute('x', x);
-			var y = size - size / 2 + fontSize / 3;
-			svgText.setAttribute('y', y);
-		}
+        const svgText = svg.children[0];
+        if (svgText) {
+            svgText.textContent = this.initials.toUpperCase();
+            svgText.setAttribute("font-size", fontSize);
+            svgText.setAttribute("font-family", this.fontName);
+
+            const x = fontSize;
+            svgText.setAttribute("x", x);
+            const y = size - size / 2 + fontSize / 3;
+            svgText.setAttribute("y", y);
+        }
     }
 
     private _addEventListeners(renderer: Renderer2) { }

--- a/src/themes/material/extends/_avatar.scss
+++ b/src/themes/material/extends/_avatar.scss
@@ -4,6 +4,7 @@
     align-items: center;
     position: relative;
     pointer-events: none;
+    font-family: 'Titillium Web';
 }
 
 %igx-avatar--rounded {


### PR DESCRIPTION
Closes #136  

Only the logic which renders initials is changed. No changes made on the image rendering size as it looks fine now.
