### PR TITLE
Fix igxForOf not rendering data due to parentElement of a comment in IE11 being undefined.

### DIFF
--- a/src/directives/for-of/for_of.directive.ts
+++ b/src/directives/for-of/for_of.directive.ts
@@ -443,7 +443,7 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
     }
 
     protected getElement(viewref, nodeName) {
-        const elem = viewref.element.nativeElement.parentElement.getElementsByTagName(nodeName);
+        const elem = viewref.element.nativeElement.parentNode.getElementsByTagName(nodeName);
         return elem.length > 0 ? elem[0] : null;
     }
 


### PR DESCRIPTION
Related to #642
