### PR TITLE
Mask directive improvements

### DIFF
--- a/src/directives/mask/mask-helper.ts
+++ b/src/directives/mask/mask-helper.ts
@@ -44,7 +44,7 @@ export class MaskHelper {
             }
         } else {
             const char = inputValue[cursor];
-            const isCharValid = this.validateCharOnPostion(char, cursor, mask);
+            let isCharValid = this.validateCharOnPostion(char, cursor, mask);
             if (nonLiteralIndeces.indexOf(cursor) !== -1) {
                 inputValue = this.replaceCharAt(inputValue, cursor, "");
                 if (isCharValid) {
@@ -60,7 +60,7 @@ export class MaskHelper {
                     if (literalKeys.indexOf(this._cursor) !== -1) {
                         this._cursor = ++cursor;
                     } else {
-                        const isCharValid = this.validateCharOnPostion(char, cursor, mask);
+                        isCharValid = this.validateCharOnPostion(char, cursor, mask);
                         if (isCharValid) {
                             inputValue = this.replaceCharAt(inputValue, cursor, char);
                             this._cursor = ++cursor;
@@ -196,6 +196,11 @@ export class MaskHelper {
                 }
             }
         } else {
+            if (inputValue === "" && cursor === -1) {
+                this._cursor = 0;
+                return this.parseValueByMaskOnInit(value, maskOptions);
+            } // workaround for IE 'x' button
+
             if (this._cursor < 0) {
                 this._cursor++;
                 cursor++;

--- a/src/directives/mask/mask-helper.ts
+++ b/src/directives/mask/mask-helper.ts
@@ -55,15 +55,19 @@ export class MaskHelper {
                 }
             } else {
                 inputValue = this.replaceCharAt(inputValue, cursor, "");
-                this._cursor++;
-                cursor++;
+                this._cursor = ++cursor;
                 for (let i = cursor; i < mask.length; i++) {
                     if (literalKeys.indexOf(this._cursor) !== -1) {
-                        this._cursor++;
+                        this._cursor = ++cursor;
                     } else {
-                        inputValue = this.replaceCharAt(inputValue, this._cursor, char);
-                        this._cursor++;
-                        break;
+                        const isCharValid = this.validateCharOnPostion(char, cursor, mask);
+                        if (isCharValid) {
+                            inputValue = this.replaceCharAt(inputValue, cursor, char);
+                            this._cursor = ++cursor;
+                            break;
+                        } else {
+                            break;
+                        }
                     }
                 }
             }

--- a/src/directives/mask/mask-helper.ts
+++ b/src/directives/mask/mask-helper.ts
@@ -23,6 +23,11 @@ export class MaskHelper {
         const nonLiteralIndeces: number[] = this.getNonLiteralIndeces(mask, literalKeys);
 
         if (inputValue.length < mask.length) { // BACKSPACE, DELETE
+            if (inputValue === "" && cursor === -1) {
+                this._cursor = 0;
+                return this.parseValueByMaskOnInit(value, maskOptions);
+            } // workaround for IE 'x' button
+
             if (nonLiteralIndeces.indexOf(cursor + 1) !== -1) {
                 inputValue = this.insertCharAt(inputValue, cursor + 1, maskOptions.promptChar);
                 this._cursor = cursor + 1;
@@ -50,11 +55,14 @@ export class MaskHelper {
                 }
             } else {
                 inputValue = this.replaceCharAt(inputValue, cursor, "");
-                this._cursor = cursor;
+                this._cursor++;
+                cursor++;
                 for (let i = cursor; i < mask.length; i++) {
                     if (literalKeys.indexOf(this._cursor) !== -1) {
                         this._cursor++;
                     } else {
+                        inputValue = this.replaceCharAt(inputValue, this._cursor, char);
+                        this._cursor++;
                         break;
                     }
                 }

--- a/src/directives/mask/mask.directive.spec.ts
+++ b/src/directives/mask/mask.directive.spec.ts
@@ -279,6 +279,46 @@ describe("AppComponent", () => {
         expect(input.nativeElement.value).toEqual("(___) ____-___");
 
     }));
+
+    it("Enter value over literal", fakeAsync(() => {
+        const fixture = TestBed.createComponent(MaskComponent);
+        fixture.detectChanges();
+
+        const input = fixture.debugElement.query(By.css("input"));
+
+        input.nativeElement.focus();
+        tick();
+
+        input.nativeElement.select();
+        tick();
+
+        const keyEvent = new KeyboardEvent("keydown", {key : "8"});
+        input.nativeElement.dispatchEvent(keyEvent);
+        tick();
+
+        fixture.detectChanges();
+
+        input.nativeElement.value = "";
+        input.nativeElement.dispatchEvent(new Event("input"));
+        tick();
+
+        input.nativeElement.dispatchEvent(new Event("focus"));
+        tick();
+
+        fixture.detectChanges();
+
+        expect(input.nativeElement.value).toEqual("(___) ____-___");
+
+        input.nativeElement.value = "6666";
+        input.nativeElement.dispatchEvent(new Event("input"));
+        tick();
+
+        input.triggerEventHandler("focus", {});
+        tick();
+
+        fixture.detectChanges();
+        expect(input.nativeElement.value).toEqual("(666) 6___-___");
+    }));
 });
 
 @Component({ template: `<input type="text" igxInput [(ngModel)]="value" [igxMask]="mask"/>` })


### PR DESCRIPTION
- improve user experience while typing on a literal: instead of skipping the literal and just placing the cursor behind it, the value is now entered on the next available valid position.

- add workaround for the IE 'x' button breaking the mask;

Closes #789.  

