### PR TITLE
Update npm deploy tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,12 +25,14 @@ before_deploy:
 - cd dist
 # update package versions
 - npm version "${TRAVIS_TAG}" --no-git-tag-version --save
+- if [[ "${TRAVIS_TAG}" == *"beta"* ]]; then export NPM_TAG="next"; else export NPM_TAG="latest"; fi
 
 # copy readme
 - cp ../README.md README.md
 
 deploy:
   provider: npm
+  tag: ${NPM_TAG}
   skip_cleanup: true
   email: igniteui@infragistics.com
   api_key:


### PR DESCRIPTION
When the release is tagged as "*beta*" (e.g. 5.5.0-beta.1, used as package version) the respective npm package will now also be tagged as `next`.
Note the default is usually `latest`, hence the 
`npm i package@latest`
so this will make beta releases available only through direct version install and:
`npm i igniteui-angular@next`

@Aleksandyr This will also help with changelog generation if you end up keeping the npm plugin for getting latest release version. Meaning, each beta will keep generating full log from the "latest" rather than the beta before it :)