### PR TITLE
Fix for issue #838 - When setting the igxForContainerSize post init and binding a new array scrolling with the mouse wheel scrolls the page as well.

### DIFF
--- a/src/directives/for-of/for_of.directive.ts
+++ b/src/directives/for-of/for_of.directive.ts
@@ -505,8 +505,7 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
         if (this.igxForScrollOrientation === "vertical") {
             const count = this.totalItemCount || this.igxForOf.length;
             this.vh.instance.elementRef.nativeElement.style.height = parseInt(this.igxForContainerSize, 10) + "px";
-            this.vh.instance.elementRef.nativeElement.children[0].style.height =
-                (count * parseInt(this.igxForItemSize, 10)) + "px";
+            this.vh.instance.height = count * parseInt(this.igxForItemSize, 10);
         }
     }
 


### PR DESCRIPTION
Closes #838  . 

