### PR TITLE
Ddavidkov/fix export statements

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -54,9 +54,3 @@ export * from "./directives/mask/mask.directive";
 export * from "./time-picker/time-picker.component";
 export * from "./directives/ripple/ripple.directive";
 export * from "./directives/toggle/toggle.directive";
-
-// Export services
-export * from "./services/excel/excel-exporter";
-export * from "./services/excel/excel-exporter-options";
-export * from "./services/csv/csv-exporter";
-export * from "./services/csv/csv-exporter-options";

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,6 @@
+// Export services
+export * from "./csv/csv-exporter";
+export * from "./csv/csv-exporter-options";
+export * from "./excel/excel-exporter";
+export * from "./excel/excel-exporter-options";
+export * from "./exporter-common/base-export-service";

--- a/tsconfig-aot.json
+++ b/tsconfig-aot.json
@@ -22,7 +22,8 @@
       ]
     },
     "files": [
-      "./tmp/src-inlined/main.ts"
+      "./tmp/src-inlined/main.ts",
+      "./tmp/src-inlined/services/index.ts"
     ],
     "angularCompilerOptions": {
       "genDir": "dist",

--- a/webpack-umd.config.ts
+++ b/webpack-umd.config.ts
@@ -20,7 +20,7 @@ export default {
     },
     externals: [
         function(context, request, callback) {
-            if (request.startsWith('jszip')) {
+            if (/^jszip/i.test(request)) {
                 return callback(null, {
                   commonjs: request,
                   commonjs2: request,

--- a/webpack-umd.config.ts
+++ b/webpack-umd.config.ts
@@ -6,8 +6,8 @@ import * as rxjsExternals from "webpack-rxjs-externals";
 
 export default {
     entry: {
-        "index.umd": "./src/main.ts",
-        "index.umd.min": "./src/main.ts"
+        "index.umd": ["./src/main.ts", "./src/services/index.ts"],
+        "index.umd.min": ["./src/main.ts", "./src/services/index.ts"]
     },
     output: {
         path: path.join(__dirname, "dist"),
@@ -19,6 +19,16 @@ export default {
         extensions: [".ts", ".js", ".json"]
     },
     externals: [
+        function(context, request, callback) {
+            if (request.startsWith('jszip')) {
+                return callback(null, {
+                  commonjs: request,
+                  commonjs2: request,
+                  amd: request
+                });
+              }
+              callback();
+        },
         angularExternals(),
         rxjsExternals()
     ],


### PR DESCRIPTION
Closes #912 .  

Moved the excel and csv exporters' export statements to a separate file. Now you can import all the exposed classes/interfaces from "igniteui-angular/services/index". Note that you will still need to install jszip for the excel exporter as it is a peer dependency.

