### PR TITLE
#929 Changing ng-template into *ngIf

### DIFF
--- a/src/carousel/carousel.component.html
+++ b/src/carousel/carousel.component.html
@@ -12,7 +12,8 @@
     <div class="igx-carousel__inner" role="list">
         <ng-content></ng-content>
     </div>
-    <div ng-template="ngIf navigation">
+    <!-- S.S. April 9th, 2018 #929 Changed ng-template="ngIf navigation" into an *ngIf -->
+    <div *ngIf="navigation">
         <a role="button" tabindex="0" class="igx-carousel__arrow--prev" (click)="prev()" [hidden]="!slides.length">
             <igx-icon fontSet="material" name="arrow_back"></igx-icon>
         </a>

--- a/src/carousel/carousel.component.html
+++ b/src/carousel/carousel.component.html
@@ -12,7 +12,6 @@
     <div class="igx-carousel__inner" role="list">
         <ng-content></ng-content>
     </div>
-    <!-- S.S. April 9th, 2018 #929 Changed ng-template="ngIf navigation" into an *ngIf -->
     <div *ngIf="navigation">
         <a role="button" tabindex="0" class="igx-carousel__arrow--prev" (click)="prev()" [hidden]="!slides.length">
             <igx-icon fontSet="material" name="arrow_back"></igx-icon>

--- a/src/carousel/carousel.component.spec.ts
+++ b/src/carousel/carousel.component.spec.ts
@@ -235,6 +235,32 @@ describe("Carousel", () => {
         fixture.detectChanges();
         expect(carousel.next).toHaveBeenCalled();
     });
+
+    it("Carousel navigation changes visibility of arrows", () => {
+        const fixture = TestBed.createComponent(CarouselTestComponent);
+        fixture.detectChanges();
+
+        let carousel;
+	let carouselNative;
+
+	carouselNative = fixture.debugElement;
+        carousel = fixture.componentInstance.carousel;
+
+	//carousel.navigation = true;
+        fixture.detectChanges();
+	expect(carouselNative.query(By.css(".igx-carousel__arrow--prev")) !== null).toBe(true);
+	expect(carouselNative.query(By.css(".igx-carousel__arrow--next")) !== null).toBe(true);
+
+	carousel.navigation = false;
+        fixture.detectChanges();
+	expect(carouselNative.query(By.css(".igx-carousel__arrow--prev")) == null).toBe(true);
+	expect(carouselNative.query(By.css(".igx-carousel__arrow--next")) == null).toBe(true);
+
+	carousel.navigation = true;
+        fixture.detectChanges();
+	expect(carouselNative.query(By.css(".igx-carousel__arrow--prev")) !== null).toBe(true);
+	expect(carouselNative.query(By.css(".igx-carousel__arrow--next")) !== null).toBe(true);
+    });
 });
 
 @Component({


### PR DESCRIPTION
Closes #929 

Changing ng-template="ngIf ..." into an *ngIf such that setting _navigation_ to **false** actually has an effect on the carousel.

