### PR TITLE
Increasing coverage of Csv exporter

### DIFF
--- a/src/services/csv/char-separated-value-data.ts
+++ b/src/services/csv/char-separated-value-data.ts
@@ -13,24 +13,6 @@ export class CharSeparatedValueData {
         this.setDelimiter(valueDelimiter);
     }
 
-    public get valueDelimiter() {
-        return this._delimiter;
-    }
-
-    public set valueDelimiter(value) {
-        if (value !== undefined && value !== null) {
-            this.setDelimiter(value);
-        }
-    }
-
-    public get data() {
-        return this._data;
-    }
-
-    public set data(value: any[]) {
-        this._data = value;
-    }
-
     public prepareData() {
         if (!this._data || this._data.length === 0) {
             return "";


### PR DESCRIPTION
#987 

Removing redundant **valueDelimiter** and **data** getters and setters from CharSeparatedValueData, since the IgxCsvExporterOptions exposes getter and setter for the **valueDelimeter** and the **data** is used internally by the IgxCsvExporterService.