### PR TITLE
cell selection after chunk load, #986

### DIFF
--- a/src/grid/cell.component.ts
+++ b/src/grid/cell.component.ts
@@ -551,8 +551,6 @@ export class IgxGridCellComponent implements IGridBus, OnInit {
             verticalScroll.scrollTop += this.grid.rowHeight;
             this.row.grid.verticalScrollContainer.onChunkLoad.pipe(take(1)).subscribe({
                 next: (e: any) => {
-                    const prevCell = this.gridAPI.get_cell_by_visible_index(this.gridID, this.rowIndex - 1, this.visibleColumnIndex);
-                    prevCell.nativeElement.focus();
                     const cell = this.gridAPI.get_cell_by_visible_index(this.gridID, this.rowIndex, this.visibleColumnIndex);
                     cell.nativeElement.focus();
                 }

--- a/src/grid/grid-selection.spec.ts
+++ b/src/grid/grid-selection.spec.ts
@@ -183,6 +183,40 @@ describe("IgxGrid - Row Selection", () => {
         });
     }));
 
+    fit("Should properly move focus when loading new row chunk", async(() => {
+        const fix = TestBed.createComponent(GridWithSelectionComponent);
+        fix.detectChanges();
+        const grid = fix.componentInstance.gridSelection3;
+        const gridElement: HTMLElement = fix.nativeElement.querySelector(".igx-grid");
+        const targetCellPrimaryKey = grid.rowList.last.rowID;
+        const targetCell = grid.getCellByColumn(targetCellPrimaryKey, "Column1");
+        const initialValue = targetCell.value;
+        const targetCellElement: HTMLElement = targetCell.nativeElement;
+        spyOn(targetCell, "onFocus").and.callThrough();
+        expect(targetCell.focused).toEqual(false);
+        targetCellElement.focus();
+        spyOn(targetCell.gridAPI, "get_cell_by_visible_index").and.callThrough();
+        fix.whenStable().then(() => {
+            fix.detectChanges();
+            expect(targetCell.focused).toEqual(true);
+            const targetCellDebugElement = fix.debugElement.query(By.css(".igx-grid__td--selected"));
+            simulateKeyDown(targetCellElement, "ArrowDown").then(() => {
+                setTimeout(() => {
+                    fix.whenStable().then(() => {
+                        fix.detectChanges();
+                        const newLastRow = grid.rowList.last.rowID;
+                        expect(grid.getCellByColumn(newLastRow, "Column1").value === initialValue).toBeFalsy();
+                        expect(grid.getCellByColumn(newLastRow, "Column1").focused).toEqual(true);
+                        expect(grid.getCellByColumn(newLastRow, "Column1").selected).toEqual(true);
+                        expect(grid.getCellByColumn(newLastRow, "Column1").nativeElement.class).toContain("igx-grid__td--selected");
+                        expect(grid.getCellByColumn(targetCellPrimaryKey, "Column1").focused).toEqual(false);
+                        expect(grid.selectedCells.length).toEqual(1);
+                    });
+                }, 100);
+            });
+        });
+    }));
+
     it("Should persist through paging", async(() => {
         const fix = TestBed.createComponent(GridWithPagingAndSelectionComponent);
         fix.detectChanges();


### PR DESCRIPTION
Closes #986 .  

When a new data chunk is loaded, the cell selection is not properly moved. Add subscription to onChunkLoad to ensure proper cell selection is in place.
