### PR TITLE
Tabs bugfixes

### DIFF
--- a/src/tabs/README.md
+++ b/src/tabs/README.md
@@ -21,8 +21,9 @@ A walkthrough of how to get started can be found [here](https://www.infragistics
 
 ## Tabs Type
 There are two tabs types that specify the sizing mechanism of the items.
- - `fixed` (default)
- - `contentfit`
+ - `contentfit` (default)
+ - `fixed` 
+
 
 You can set the tabs type using the `tabsType` input.
 
@@ -43,17 +44,11 @@ If the total visible items width exceeds the vew port width, scroll buttons are 
 | Name   |      Type      |  Description |
 |:----------|:-------------:|:------|
 | `selectedIndex` |  number | The index of the selected tab. |
-| `selectedTab` | IgxTabItemComponent | The last selected tab. |
+| `selectedTabItem` | IgxTabItemComponent | The last selected tab. |
 | `icon` | string | Set the icon to the item. Currently all icons from the material icon set are supported. |
 | `label` | string | Set the tab item text. |
 | `isDisabled` | boolean | 	Set if the tab is enabled/disabled.	 |
-| `tabsType` | TabsType | 	Set the tab item sizing mode. By default, the sizing type is `fixed` and all tabs have equal size to fit the view port. When `contentfit` is set, the tab item width is sized to its content in the range of min/max width. |
-
-## Methods
-
-| Name   |      Description      |  Return type  |   Parameters   |
-|:----------|:-------------:|:------|:------|
-| `select` |  Selects tab and its content. |  |
+| `tabsType` | TabsType | 	Set the tab item sizing mode. By default, `contentfit` is set, the tab item width is sized to its content in the range of min/max width. When the sizing type is `fixed` - all tabs have equal size to fit the view port. |
 
 ## Events
 

--- a/src/tabs/tabs.component.spec.ts
+++ b/src/tabs/tabs.component.spec.ts
@@ -183,20 +183,22 @@ describe("IgxTabs", () => {
         fixture.detectChanges();
 
         fixture.componentInstance.wrapperDiv.nativeElement.style.width = "500px";
-        window.dispatchEvent(new Event("resize"));
         fixture.detectChanges();
 
         const rightScrollButton = tabs.headerContainer.nativeElement.children[2];
         rightScrollButton.dispatchEvent(new Event("click", { bubbles: true }));
-        fixture.detectChanges();
 
-        requestAnimationFrame(() => {
+        fixture.whenStable().then(() => {
+            fixture.detectChanges();
+
             expect(tabs.offset).toBeGreaterThan(0);
         });
 
         tabs.scrollLeft(null);
 
-        requestAnimationFrame(() => {
+        fixture.whenStable().then(() => {
+            fixture.detectChanges();
+
             expect(tabs.offset).toBe(0);
         });
     });
@@ -207,7 +209,6 @@ describe("IgxTabs", () => {
         fixture.detectChanges();
 
         fixture.componentInstance.wrapperDiv.nativeElement.style.width = "500px";
-        window.dispatchEvent(new Event("resize"));
         fixture.detectChanges();
 
         tabs.tabs.toArray()[2].nativeTabItem.nativeElement.dispatchEvent(new Event("click", { bubbles: true }));

--- a/src/tabs/tabs.component.spec.ts
+++ b/src/tabs/tabs.component.spec.ts
@@ -182,7 +182,7 @@ describe("IgxTabs", () => {
         const tabs = fixture.componentInstance.tabs;
         fixture.detectChanges();
 
-        fixture.componentInstance.wrapperDiv.nativeElement.style.width = "500px";
+        fixture.componentInstance.wrapperDiv.nativeElement.style.width = "400px";
         fixture.detectChanges();
 
         const rightScrollButton = tabs.headerContainer.nativeElement.children[2];
@@ -208,7 +208,7 @@ describe("IgxTabs", () => {
         const tabs = fixture.componentInstance.tabs;
         fixture.detectChanges();
 
-        fixture.componentInstance.wrapperDiv.nativeElement.style.width = "500px";
+        fixture.componentInstance.wrapperDiv.nativeElement.style.width = "400px";
         fixture.detectChanges();
 
         tabs.tabs.toArray()[2].nativeTabItem.nativeElement.dispatchEvent(new Event("click", { bubbles: true }));

--- a/src/tabs/tabs.component.spec.ts
+++ b/src/tabs/tabs.component.spec.ts
@@ -51,11 +51,11 @@ describe("IgxTabs", () => {
         let tabItems;
 
         expect(tabs.selectedIndex).toBe(-1);
-        expect(tabs.selectedTab).toBeUndefined();
+        expect(tabs.selectedTabItem).toBeUndefined();
 
         fixture.componentInstance.tabSelectedHandler = () => {
             expect(tabs.selectedIndex).toBe(0);
-            expect(tabs.selectedTab).toBe(tabItems[0]);
+            expect(tabs.selectedTabItem).toBe(tabItems[0]);
         };
 
         fixture.detectChanges();
@@ -93,7 +93,7 @@ describe("IgxTabs", () => {
         expect(tabs.selectedIndex).toBe(-1);
         fixture.componentInstance.tabSelectedHandler = () => {
             expect(tabs.selectedIndex).toBe(0);
-            expect(tabs.selectedTab).toBe(tab1);
+            expect(tabs.selectedTabItem).toBe(tab1);
         };
 
         fixture.detectChanges();
@@ -107,7 +107,7 @@ describe("IgxTabs", () => {
         fixture.detectChanges();
 
         expect(tabs.selectedIndex).toBe(1);
-        expect(tabs.selectedTab).toBe(tab2);
+        expect(tabs.selectedTabItem).toBe(tab2);
         expect(tabs.selectedIndex).toBe(1);
         expect(tab2.isSelected).toBeTruthy();
         expect(tab1.isSelected).toBeFalsy();
@@ -116,7 +116,7 @@ describe("IgxTabs", () => {
         fixture.detectChanges();
 
         expect(tabs.selectedIndex).toBe(0);
-        expect(tabs.selectedTab).toBe(tab1);
+        expect(tabs.selectedTabItem).toBe(tab1);
         expect(tab1.isSelected).toBeTruthy();
         expect(tab2.isSelected).toBeFalsy();
 
@@ -126,7 +126,7 @@ describe("IgxTabs", () => {
         fixture.detectChanges();
 
         expect(tabs.selectedIndex).toBe(0);
-        expect(tabs.selectedTab).toBe(tab1);
+        expect(tabs.selectedTabItem).toBe(tab1);
         expect(tab1.isSelected).toBeTruthy();
         expect(tab2.isSelected).toBeFalsy();
     });

--- a/src/tabs/tabs.component.ts
+++ b/src/tabs/tabs.component.ts
@@ -97,15 +97,6 @@ export class IgxTabsComponent implements AfterViewInit {
     public visibleItemsWidth: number;
     public offset = 0;
 
-    public applyRightButtonVisibleStyle = false;
-    public applyLeftButtonVisibleStyle = false;
-
-    public applyRightButtonNotDisplayedStyle = true;
-    public applyLeftButtonNotDisplayedStyle = true;
-
-    public applyRightButtonHiddenStyle = false;
-    public applyLeftButtonHiddenStyle = false;
-
     public scrollLeft(event) {
         this._scroll(false);
     }
@@ -140,26 +131,10 @@ export class IgxTabsComponent implements AfterViewInit {
 
             this.offset = (scrollRight) ? element.offsetWidth + element.offsetLeft - viewPortWidth : element.offsetLeft;
             this.itemsContainer.nativeElement.style.transform = `translate(${-this.offset}px)`;
-
-            const total = this.offset + viewPortWidth;
-
-            if (this.offset === 0 && !scrollRight) {
-                this.applyLeftButtonVisibleStyle = false;
-                this.applyLeftButtonHiddenStyle = true;
-            } else {
-                this.applyLeftButtonVisibleStyle = true;
-            }
-
-            if (itemsContainerWidth <= total) {
-                this.applyRightButtonVisibleStyle = false;
-                this.applyRightButtonHiddenStyle = true;
-            } else {
-                this.applyRightButtonVisibleStyle = true;
-            }
         });
     }
 
-    get selectedTab(): IgxTabItemComponent {
+    get selectedTabItem(): IgxTabItemComponent {
         if (this.tabs && this.selectedIndex !== undefined) {
             return this.tabs.toArray()[this.selectedIndex];
         }
@@ -181,40 +156,6 @@ export class IgxTabsComponent implements AfterViewInit {
 
             }
         }, 0);
-
-        const itemsContainerWidth = this.itemsContainer.nativeElement.offsetWidth;
-        const headerContainerWidth = this.headerContainer.nativeElement.offsetWidth;
-        const viewPortWidth = this.viewPort.nativeElement.offsetWidth;
-
-        if (itemsContainerWidth > headerContainerWidth) {
-            this.applyRightButtonVisibleStyle = true;
-            this.applyLeftButtonHiddenStyle = true;
-        }
-
-        // No space for scroll buttons when all tabs are visible initially
-        if (itemsContainerWidth <= headerContainerWidth && this.offset === 0) {
-            this.applyLeftButtonNotDisplayedStyle = true;
-            this.applyRightButtonNotDisplayedStyle = true;
-        }
-    }
-
-    @HostListener("window:resize")
-    public onResize() {
-        const itemsContainerWidth = this.itemsContainer.nativeElement.offsetWidth;
-        const viewPortContainerWidth = this.viewPort.nativeElement.offsetWidth;
-
-        if (itemsContainerWidth <= viewPortContainerWidth + this.offset) {
-            this.applyRightButtonVisibleStyle = false;
-            this.applyRightButtonHiddenStyle = true;
-        } else {
-            this.applyRightButtonVisibleStyle = true;
-        }
-
-        if (this.offset > 0) {
-            this.applyLeftButtonVisibleStyle = true;
-        } else {
-            this.applyLeftButtonHiddenStyle = true;
-        }
     }
 
     @HostListener("onTabItemSelected", ["$event"])
@@ -266,7 +207,7 @@ export class IgxTabsComponent implements AfterViewInit {
 
     private _deselectGroup(group: IgxTabsGroupComponent) {
         // Cannot deselect the selected tab - this will mean that there will be not selected tab left
-        if (group.isDisabled || this.selectedTab.index === group.index) {
+        if (group.isDisabled || this.selectedTabItem.index === group.index) {
             return;
         }
 

--- a/src/tabs/tabs.directives.ts
+++ b/src/tabs/tabs.directives.ts
@@ -8,6 +8,12 @@ import {
 } from "@angular/core";
 import { IgxTabsComponent } from "./tabs.component";
 
+enum ButtonStyle {
+    VISIBLE = "visible",
+    HIDDEN = "hidden",
+    NOT_DISPLAYED = "not_displayed"
+}
+
 @Directive({
     selector: "[igxRightButtonStyle]"
 })
@@ -17,34 +23,37 @@ export class IgxRightButtonStyleDirective {
     public tabs: IgxTabsComponent) {
     }
 
-    @HostBinding("class.igx-tabs__header-button")
-    get visibleCSS(): boolean {
-        if (this.tabs.applyRightButtonVisibleStyle) {
-            this.tabs.applyRightButtonHiddenStyle = false;
-            this.tabs.applyRightButtonNotDisplayedStyle = false;
+    private getRightButtonStyle() {
+        const viewPortWidth = this.tabs.viewPort.nativeElement.offsetWidth;
+        const itemsContainerWidth = this.tabs.itemsContainer.nativeElement.offsetWidth;
+        const headerContainerWidth = this.tabs.headerContainer.nativeElement.offsetWidth;
+        const offset = this.tabs.offset;
+        const total = offset + viewPortWidth;
+
+        if (itemsContainerWidth <= headerContainerWidth && offset === 0) {
+            return ButtonStyle.NOT_DISPLAYED;
         }
 
-        return this.tabs.applyRightButtonVisibleStyle;
+        if (itemsContainerWidth > total) {
+            return ButtonStyle.VISIBLE;
+        } else {
+            return ButtonStyle.HIDDEN;
+        }
+    }
+
+    @HostBinding("class.igx-tabs__header-button")
+    get visibleCSS(): boolean {
+        return (this.getRightButtonStyle() === ButtonStyle.VISIBLE) ? true : false;
     }
 
     @HostBinding("class.igx-tabs__header-button--hidden")
     get hiddenCSS(): boolean {
-        if (this.tabs.applyRightButtonHiddenStyle) {
-            this.tabs.applyRightButtonVisibleStyle = false;
-            this.tabs.applyRightButtonNotDisplayedStyle = false;
-        }
-
-        return this.tabs.applyRightButtonHiddenStyle;
+        return (this.getRightButtonStyle() === ButtonStyle.HIDDEN) ? true : false;
     }
 
     @HostBinding("class.igx-tabs__header-button--none")
     get notDisplayedCSS(): boolean {
-        if (this.tabs.applyRightButtonNotDisplayedStyle) {
-            this.tabs.applyRightButtonVisibleStyle = false;
-            this.tabs.applyRightButtonHiddenStyle = false;
-        }
-
-        return this.tabs.applyRightButtonNotDisplayedStyle;
+        return (this.getRightButtonStyle() === ButtonStyle.NOT_DISPLAYED) ? true : false;
     }
 }
 
@@ -57,34 +66,34 @@ export class IgxLeftButtonStyleDirective {
     public tabs: IgxTabsComponent) {
     }
 
+    private getLeftButtonStyle() {
+        const itemsContainerWidth = this.tabs.itemsContainer.nativeElement.offsetWidth;
+        const headerContainerWidth = this.tabs.headerContainer.nativeElement.offsetWidth;
+        const offset = this.tabs.offset;
+
+        if (offset === 0) {
+            if (itemsContainerWidth <= headerContainerWidth) {
+                return ButtonStyle.NOT_DISPLAYED;
+            }
+            return ButtonStyle.HIDDEN;
+        } else {
+            return ButtonStyle.VISIBLE;
+        }
+    }
+
     @HostBinding("class.igx-tabs__header-button")
     get visibleCSS(): boolean {
-        if (this.tabs.applyLeftButtonVisibleStyle) {
-            this.tabs.applyLeftButtonHiddenStyle = false;
-            this.tabs.applyLeftButtonNotDisplayedStyle = false;
-        }
-
-        return this.tabs.applyLeftButtonVisibleStyle;
+        return (this.getLeftButtonStyle() === ButtonStyle.VISIBLE) ? true : false;
     }
 
     @HostBinding("class.igx-tabs__header-button--hidden")
     get hiddenCSS(): boolean {
-        if (this.tabs.applyLeftButtonHiddenStyle) {
-            this.tabs.applyLeftButtonVisibleStyle = false;
-            this.tabs.applyLeftButtonNotDisplayedStyle = false;
-        }
-
-        return this.tabs.applyLeftButtonHiddenStyle;
+        return (this.getLeftButtonStyle() === ButtonStyle.HIDDEN) ? true : false;
     }
 
     @HostBinding("class.igx-tabs__header-button--none")
     get notDisplayedCSS(): boolean {
-        if (this.tabs.applyLeftButtonNotDisplayedStyle) {
-            this.tabs.applyLeftButtonVisibleStyle = false;
-            this.tabs.applyLeftButtonHiddenStyle = false;
-        }
-
-        return this.tabs.applyLeftButtonNotDisplayedStyle;
+        return (this.getLeftButtonStyle() === ButtonStyle.NOT_DISPLAYED) ? true : false;
     }
 }
 


### PR DESCRIPTION
Bug fixing, refactoring - selectedTab renamed to selectedTabItem - empty space appears on the left before the first tab when window is resized.

