### PR TITLE
Cell Selection on Arrow Up - rework

### DIFF
--- a/src/grid/cell.component.ts
+++ b/src/grid/cell.component.ts
@@ -542,6 +542,16 @@ export class IgxGridCellComponent implements IGridBus, OnInit, OnDestroy {
             if (targetRowOffset === 0 && containerOffset < 0) {
                 // Target is part of the first row in the container that is partially visible
                 verticalScroll.scrollTop += containerOffset;
+                const oldChunkIndex = target.row.grid.verticalScrollContainer.state.startIndex;
+
+                this.row.grid.verticalScrollContainer.onChunkLoad.pipe(take(1)).subscribe({
+                    next: (e: any) => {
+                        if (oldChunkIndex === e.startIndex) {
+                            target.nativeElement.focus();
+                        }
+                        this.row.cdr.detectChanges();
+                    }
+                });
             }
             target.nativeElement.focus();
         } else {


### PR DESCRIPTION
Closes #1063 .  

Key navigation with arrow up was causing the cell selection to sometimes blur and the grid to lose focus. Adjust the arrow up navigation to use code similar to the one for arrow down.

