### PR TITLE
fix(grid-filtering): Push the filtering menu below the grid header

### DIFF
--- a/src/core/styles/components/grid-filtering/_grid-filtering-theme.scss
+++ b/src/core/styles/components/grid-filtering/_grid-filtering-theme.scss
@@ -111,7 +111,7 @@
     $filtering-menu-min-width: 240px;
     $filtering-menu-shadow: igx-elevation($elevations, 8);
     $filtering-menu-radius: 4px;
-    $filtering-menu-distance-to-toggle: 4px;
+    $filtering-menu-distance-to-toggle: 24px;
 
     %igx-filtering-display {
         position: static;


### PR DESCRIPTION
Because of the way the filtering menu is currently implemented as part
of the header, its visibility is affected by the z-index of the header
itself. So if a column header has a higher z-index than the next
sibling, that sibling will have its filtering UI covered by the previous
header. To avoid that I am pushing the filtering menu below the header
so it doesn't get covered by the headers.

Closes #1078

