### PR TITLE
Ensure smooth vertical scrolling

### DIFF
--- a/src/directives/for-of/for_of.directive.spec.ts
+++ b/src/directives/for-of/for_of.directive.spec.ts
@@ -179,6 +179,23 @@ describe("IgxVirtual directive - simple template", () => {
         }
     });
 
+    it("should scroll render one row less when scrolled to bottom", () => {
+        const fix = TestBed.createComponent(VirtualComponent);
+        fix.detectChanges();
+        const container = fix.componentInstance.container;
+        const displayContainer: HTMLElement = fix.nativeElement.querySelector("igx-display-container");
+        const verticalScroller: HTMLElement = fix.nativeElement.querySelector("igx-virtual-helper");
+        const horizontalScroller: HTMLElement = fix.nativeElement.querySelector("igx-horizontal-virtual-helper");
+
+        let rows = displayContainer.querySelectorAll("igx-display-container");
+        expect(rows.length).toBe(9);
+
+        fix.componentInstance.scrollTop(2500000);
+
+        rows = displayContainer.querySelectorAll("igx-display-container");
+        expect(rows.length).toBe(8);
+    });
+
     it("should scroll to wheel event correctly", () => {
         const fix = TestBed.createComponent(VirtualComponent);
         fix.detectChanges();
@@ -248,7 +265,7 @@ describe("IgxVirtual directive - simple template", () => {
         expect(horizontalScroller).not.toBeNull();
 
         let rows = displayContainer.querySelectorAll("igx-display-container");
-        expect(rows.length).toBe(8);
+        expect(rows.length).toBe(9);
         for (let i = 0; i < rows.length; i++) {
             expect(rows[i].children.length).toBe(4);
             expect(rows[i].children[3].textContent)
@@ -260,7 +277,7 @@ describe("IgxVirtual directive - simple template", () => {
         fix.detectChanges();
 
         rows = displayContainer.querySelectorAll("igx-display-container");
-        expect(rows.length).toBe(8);
+        expect(rows.length).toBe(9);
         for (let i = 0; i < rows.length; i++) {
             expect(rows[i].children.length).toBe(5);
             expect(rows[i].children[4].textContent)
@@ -282,7 +299,7 @@ describe("IgxVirtual directive - simple template", () => {
         expect(horizontalScroller).not.toBeNull();
 
         let rows = displayContainer.querySelectorAll("igx-display-container");
-        expect(rows.length).toBe(8);
+        expect(rows.length).toBe(9);
         for (let i = 0; i < rows.length; i++) {
             expect(rows[i].children.length).toBe(4);
             expect(rows[i].children[2].textContent)
@@ -294,7 +311,7 @@ describe("IgxVirtual directive - simple template", () => {
         fix.detectChanges();
 
         rows = displayContainer.querySelectorAll("igx-display-container");
-        expect(rows.length).toBe(14);
+        expect(rows.length).toBe(15);
         for (let i = 0; i < rows.length; i++) {
             expect(rows[i].children.length).toBe(4);
             expect(rows[i].children[2].textContent)
@@ -317,7 +334,7 @@ describe("IgxVirtual directive - simple template", () => {
         expect(horizontalScroller).not.toBeNull();
         expect(fix.componentInstance.isVerticalScrollbarVisible()).toBe(true);
         expect(fix.componentInstance.isHorizontalScrollbarVisible()).toBe(true);
-        expect(rowsRendered.length).toBe(8);
+        expect(rowsRendered.length).toBe(9);
 
         /** Step 1. Lower the amount of rows to 5. The vertical scrollbar then should not be rendered */
         expect(() => {
@@ -358,7 +375,7 @@ describe("IgxVirtual directive - simple template", () => {
         expect(horizontalScroller.scrollLeft).toBe(1000);
         expect(fix.componentInstance.isVerticalScrollbarVisible()).toBe(true);
         expect(fix.componentInstance.isHorizontalScrollbarVisible()).toBe(true);
-        expect(rowsRendered.length).toBe(8);
+        expect(rowsRendered.length).toBe(9);
     });
 
     it("should not render vertical scrollbars when number of rows change to 0 after scrolling down", () => {
@@ -376,7 +393,7 @@ describe("IgxVirtual directive - simple template", () => {
         expect(horizontalScroller).not.toBeNull();
         expect(fix.componentInstance.isVerticalScrollbarVisible()).toBe(true);
         expect(fix.componentInstance.isHorizontalScrollbarVisible()).toBe(true);
-        expect(rowsRendered.length).toBe(8);
+        expect(rowsRendered.length).toBe(9);
 
         fix.componentInstance.generateData(300, 50000);
         fix.detectChanges();
@@ -414,7 +431,7 @@ describe("IgxVirtual directive - simple template", () => {
         expect(verticalScroller.scrollTop).toBe(0);
         expect(fix.componentInstance.isVerticalScrollbarVisible()).toBe(true);
         expect(fix.componentInstance.isHorizontalScrollbarVisible()).toBe(true);
-        expect(rowsRendered.length).toBe(8);
+        expect(rowsRendered.length).toBe(9);
     });
 
     it("should not render vertical scrollbar when number of rows change to 0 after scrolling right", () => {
@@ -433,7 +450,7 @@ describe("IgxVirtual directive - simple template", () => {
         expect(horizontalScroller).not.toBeNull();
         expect(fix.componentInstance.isVerticalScrollbarVisible()).toBe(true);
         expect(fix.componentInstance.isHorizontalScrollbarVisible()).toBe(true);
-        expect(rowsRendered.length).toBe(8);
+        expect(rowsRendered.length).toBe(9);
         expect(colsRendered.length).toBe(4);
 
          /** Step 1. Scroll to the right. */
@@ -478,7 +495,7 @@ describe("IgxVirtual directive - simple template", () => {
         // expect(horizontalScroller.scrollLeft).toBe(0); To be investigated
         expect(fix.componentInstance.isVerticalScrollbarVisible()).toBe(true);
         expect(fix.componentInstance.isHorizontalScrollbarVisible()).toBe(true);
-        expect(rowsRendered.length).toBe(8);
+        expect(rowsRendered.length).toBe(9);
         // expect(colsRendered.length).toBe(4); To be investigated
 
         for (let i = 0; i < rowsRendered.length; i++) {
@@ -504,7 +521,7 @@ describe("IgxVirtual directive - simple template", () => {
         expect(horizontalScroller).not.toBeNull();
         expect(fix.componentInstance.isVerticalScrollbarVisible()).toBe(true);
         expect(fix.componentInstance.isHorizontalScrollbarVisible()).toBe(true);
-        expect(rowsRendered.length).toBe(8);
+        expect(rowsRendered.length).toBe(9);
         expect(colsRendered.length).toBe(4);
 
         /** Step 1. Lower the amount of cols to 3 so there would be no horizontal scrollbar */
@@ -522,7 +539,7 @@ describe("IgxVirtual directive - simple template", () => {
 
         expect(fix.componentInstance.isVerticalScrollbarVisible()).toBe(true);
         expect(fix.componentInstance.isHorizontalScrollbarVisible()).toBe(false);
-        expect(rowsRendered.length).toBe(8);
+        expect(rowsRendered.length).toBe(9);
         expect(colsRendered.length).toBe(3);
 
         /** Step 2. Scroll down. There should be no errors then and everything should be still the same */
@@ -540,7 +557,7 @@ describe("IgxVirtual directive - simple template", () => {
 
         expect(fix.componentInstance.isVerticalScrollbarVisible()).toBe(true);
         expect(fix.componentInstance.isHorizontalScrollbarVisible()).toBe(false);
-        expect(rowsRendered.length).toBe(8);
+        expect(rowsRendered.length).toBe(9);
         expect(colsRendered.length).toBe(3);
 
         /** Step 3. Set the data back to have 300 columns and the horizontal scrollbar should render now. */
@@ -558,7 +575,7 @@ describe("IgxVirtual directive - simple template", () => {
         expect(verticalScroller.scrollTop).toBe(1000);
         expect(fix.componentInstance.isVerticalScrollbarVisible()).toBe(true);
         expect(fix.componentInstance.isHorizontalScrollbarVisible()).toBe(true);
-        expect(rowsRendered.length).toBe(8);
+        expect(rowsRendered.length).toBe(9);
         expect(colsRendered.length).toBe(4);
     });
 

--- a/src/directives/for-of/for_of.directive.ts
+++ b/src/directives/for-of/for_of.directive.ts
@@ -68,6 +68,7 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
     private _lastTouchY = 0;
     private _pointerCapture;
     private _gestureObject;
+    private _isScrolledToBottom = false;
 
     @ViewChild(DisplayContainerComponent)
     private displayContiner: DisplayContainerComponent;
@@ -269,8 +270,19 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
 
         const count = this.isRemote ? this.totalItemCount : this.igxForOf.length;
         const currIndex = Math.floor(ratio * count);
+        var endingIndex = this.state.chunkSize + currIndex;
 
-        const endingIndex = this.state.chunkSize + currIndex;
+        if (endingIndex > this.igxForOf.length) {
+            // shrink the size of the chunk (remove the extra non-visible view) when the scroll is at the bottom.
+            endingIndex = this.igxForOf.length;
+            this._isScrolledToBottom = true;
+            this.applyChunkSizeChange();
+        } else if (this._isScrolledToBottom && this.state.startIndex !== currIndex) {
+            // add one more non-visible view in the chunk to ensure smooth scrolling when we scroll up from the bottom.
+            this._isScrolledToBottom = false;
+            this.applyChunkSizeChange();
+        }
+
         if (this.state.startIndex !== currIndex) {
             this.state.startIndex = currIndex;
             this.onChunkPreload.emit(this.state);
@@ -490,6 +502,9 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
             } else {
                 chunkSize = Math.ceil(parseInt(this.igxForContainerSize, 10) /
                     parseInt(this.igxForItemSize, 10));
+                if (chunkSize !== 0 && !this._isScrolledToBottom) {
+                    chunkSize ++;
+                }
                 if (chunkSize > this.igxForOf.length) {
                     chunkSize = this.igxForOf.length;
                 }
@@ -558,9 +573,14 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
     }
 
     protected addLastElem() {
-        const elemIndex = this.state.startIndex + this.state.chunkSize;
-        if (elemIndex >= this.igxForOf.length) {
+        var elemIndex = this.state.startIndex + this.state.chunkSize;
+        if (elemIndex > this.igxForOf.length) {
             return;
+        }
+
+        // if the end of the igxForOf array is reached add the last element. This is to ensure the smooth scrolling by providing one additional non-visible view.
+        if (elemIndex === this.igxForOf.length) {
+            elemIndex = this.igxForOf.length - 1;
         }
 
         const input = this.igxForOf[elemIndex];

--- a/src/directives/for-of/for_of.directive.ts
+++ b/src/directives/for-of/for_of.directive.ts
@@ -270,7 +270,7 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
 
         const count = this.isRemote ? this.totalItemCount : this.igxForOf.length;
         const currIndex = Math.floor(ratio * count);
-        var endingIndex = this.state.chunkSize + currIndex;
+        let endingIndex = this.state.chunkSize + currIndex;
 
         if (endingIndex > this.igxForOf.length) {
             // shrink the size of the chunk (remove the extra non-visible view) when the scroll is at the bottom.
@@ -573,12 +573,13 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
     }
 
     protected addLastElem() {
-        var elemIndex = this.state.startIndex + this.state.chunkSize;
+        let elemIndex = this.state.startIndex + this.state.chunkSize;
         if (elemIndex > this.igxForOf.length) {
             return;
         }
 
-        // if the end of the igxForOf array is reached add the last element. This is to ensure the smooth scrolling by providing one additional non-visible view.
+        // If the end of the igxForOf array is reached add the last element.
+        // This is to ensure the smooth scrolling by providing one additional non-visible view.
         if (elemIndex === this.igxForOf.length) {
             elemIndex = this.igxForOf.length - 1;
         }

--- a/src/grid/cell.component.ts
+++ b/src/grid/cell.component.ts
@@ -577,26 +577,24 @@ export class IgxGridCellComponent implements IGridBus, OnInit, OnDestroy {
         }
 
         if (target) {
-            const containerHeight = this.grid.calcHeight; // null when there is no vertical virtualization
+            const containerHeight = this.grid.calcHeight ? Math.ceil(this.grid.calcHeight) : null; // null when there is no vertical virtualization
             const containerTopOffset =
                 parseInt(this.row.grid.verticalScrollContainer.dc.instance._viewContainer.element.nativeElement.style.top, 10);
             const targetEndTopOffset = target.row.element.nativeElement.offsetTop + this.grid.rowHeight + containerTopOffset;
-            const oldChunkIndex = this.row.grid.verticalScrollContainer.state.startIndex;
             if (containerHeight && targetEndTopOffset > containerHeight) {
                 verticalScroll.scrollTop += targetEndTopOffset - containerHeight;
 
                 this.row.grid.verticalScrollContainer.onChunkLoad.pipe(take(1)).subscribe({
                     next: (e: any) => {
-                        if (oldChunkIndex === e.startIndex) {
-                            target.nativeElement.focus();
-                        }
+                        const cell = this.gridAPI.get_cell_by_visible_index(this.gridID, rowIndex, this.visibleColumnIndex);
+                        cell.nativeElement.focus();
                         this.row.cdr.detectChanges();
                     }
                 });
             } else {
                 target.nativeElement.focus();
             }
-        } else {
+        } else if (rowIndex < this.grid.data.length) {
             verticalScroll.scrollTop += this.grid.rowHeight;
             this.row.grid.verticalScrollContainer.onChunkLoad.pipe(take(1)).subscribe({
                 next: (e: any) => {

--- a/src/grid/cell.component.ts
+++ b/src/grid/cell.component.ts
@@ -577,7 +577,9 @@ export class IgxGridCellComponent implements IGridBus, OnInit, OnDestroy {
         }
 
         if (target) {
-            const containerHeight = this.grid.calcHeight ? Math.ceil(this.grid.calcHeight) : null; // null when there is no vertical virtualization
+            const containerHeight = this.grid.calcHeight ?
+                                    Math.ceil(this.grid.calcHeight) :
+                                    null; // null when there is no vertical virtualization
             const containerTopOffset =
                 parseInt(this.row.grid.verticalScrollContainer.dc.instance._viewContainer.element.nativeElement.style.top, 10);
             const targetEndTopOffset = target.row.element.nativeElement.offsetTop + this.grid.rowHeight + containerTopOffset;

--- a/src/tabs/tabs.component.spec.ts
+++ b/src/tabs/tabs.component.spec.ts
@@ -1,5 +1,5 @@
 import { AfterContentChecked, AfterViewChecked, Component, ContentChildren, QueryList, ViewChild } from "@angular/core";
-import { async, TestBed } from "@angular/core/testing";
+import { async, TestBed, fakeAsync, tick } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { IgxTabItemComponent } from "./tab-item.component";
 import { IgxTabsGroupComponent } from "./tabs-group.component";
@@ -177,7 +177,7 @@ describe("IgxTabs", () => {
         expect(tabs.selectedIndex).toBe(0);
     });
 
-    it("should scroll tab area when clicking left/right scroll buttons", () => {
+    it("should scroll tab area when clicking left/right scroll buttons", fakeAsync(() => {
         const fixture = TestBed.createComponent(TabsTestComponent);
         const tabs = fixture.componentInstance.tabs;
         fixture.detectChanges();
@@ -189,20 +189,16 @@ describe("IgxTabs", () => {
         window.dispatchEvent(new Event("resize"));
         rightScrollButton.dispatchEvent(new Event("click", { bubbles: true }));
 
-        fixture.whenStable().then(() => {
-            fixture.detectChanges();
-
-            expect(tabs.offset).toBeGreaterThan(0);
-        });
+        tick(100);
+        fixture.detectChanges();
+        expect(tabs.offset).toBeGreaterThan(0);
 
         tabs.scrollLeft(null);
 
-        fixture.whenStable().then(() => {
-            fixture.detectChanges();
-
-            expect(tabs.offset).toBe(0);
-        });
-    });
+        tick(100);
+        fixture.detectChanges();
+        expect(tabs.offset).toBe(0);
+    }));
 
     it("should select tab on click", () => {
         const fixture = TestBed.createComponent(TabsTestComponent);

--- a/src/tabs/tabs.component.spec.ts
+++ b/src/tabs/tabs.component.spec.ts
@@ -1,5 +1,5 @@
 import { AfterContentChecked, AfterViewChecked, Component, ContentChildren, QueryList, ViewChild } from "@angular/core";
-import { async, TestBed, fakeAsync, tick } from "@angular/core/testing";
+import { async, fakeAsync, TestBed, tick } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { IgxTabItemComponent } from "./tab-item.component";
 import { IgxTabsGroupComponent } from "./tabs-group.component";


### PR DESCRIPTION
Closes #1016   

Add one additional (non-visible) row in the virtual vertical scroller chunk. This will ensure the smooth experience when scrolling up and down. The additional row is removed when we scroll to the bottom.
