### PR TITLE
docs(flat-button): Adding missing color parameter

### DIFF
--- a/src/core/styles/components/button/_button-theme.scss
+++ b/src/core/styles/components/button/_button-theme.scss
@@ -13,6 +13,7 @@
 /// @param {Color} $flat-hover-text-color [null] - The hover text color of a flat button.
 /// @param {Color} $flat-background [null] - The background color of a flat button.
 /// @param {Color} $flat-hover-background [null] - The hover background color of a flat button.
+/// @param {Color} $flat-focus-text-color [null] - The focus text color of a button.
 /// @param {Color} $flat-focus-background [null] - The focus background color of a flat button.
 ///
 /// @param {Color} $raised-text-color [null] - The idle text color of a raised button.


### PR DESCRIPTION
Closes # .  

Additional information related to this pull request:

