### PR TITLE
feat(themes): add mixins for generating css classes from color palette

### DIFF
--- a/demos/style/igniteui-theme.scss
+++ b/demos/style/igniteui-theme.scss
@@ -30,7 +30,8 @@ $exclude: (
     // igx-bottom-nav,
     // igx-toast
 );
-// Generating a palette
+
+// Generating a theme
 @include igx-core();
 @include igx-theme($default-palette, $exclude);
 
@@ -52,37 +53,9 @@ $my-tabs-theme: igx-tabs-theme(
 }
 
 $my-nav-theme: igx-navbar-theme(
-    $disable-shadow: 'true'
+    $disable-shadow: true
 );
 
 .tabs-demo {
     @include igx-navbar($my-nav-theme);
 }
-
-// @mixin gen-color-class($name, $variant, $prefix, $suffix) {
-//     $prefix: if($prefix, '#{$prefix}-', '');
-//     $suffix: if($suffix, '-#{$suffix}', '');
-
-//     .#{$prefix}#{$name}-#{$variant}#{$suffix} {
-//         @content;
-//     }
-// }
-
-// @mixin gen-color-classes($prop, $prefix, $suffix) {
-//     @each $palette-name, $sub-palette in $default-palette {
-//         @each $variant, $color in $sub-palette {
-//             @if type-of($color) != 'map' {
-//                 @include gen-color-class($palette-name, $variant, $prefix, $suffix) {
-//                     #{$prop}: $color;
-//                 }
-//             }
-//         }
-//     }
-// }
-
-// @mixin igx-color-classes($prop, $suffix: null, $prefix: 'igx') {
-//     @include gen-color-classes($prop, $prefix, $suffix);
-// }
-
-// @include igx-color-classes($prop: 'background-color', $prefix: 'my', $suffix: 'bg');
-// @include igx-color-classes($prop: 'color');

--- a/src/core/styles/base/utilities/_mixins.scss
+++ b/src/core/styles/base/utilities/_mixins.scss
@@ -99,3 +99,65 @@
     text-overflow: ellipsis;
     overflow: hidden;
 }
+
+/// Generates a CSS class name for a color from a
+/// given name, variant, prefix and suffix
+/// @access private
+/// @param {string} $name - The main class name.
+/// @param {string} $variant - An additional string to be attached to the main class name.
+/// @param {string} $prefix - A prefix to be attached to the name and variant string.
+/// @param {string} $prefix - A suffix to be attached to the name and variant string.
+@mixin gen-color-class($name, $variant, $prefix, $suffix) {
+    $prefix: if($prefix, '#{$prefix}-', '');
+    $suffix: if($suffix, '-#{$suffix}', '');
+
+    .#{$prefix}#{$name}-#{$variant}#{$suffix} {
+        @content;
+    }
+}
+
+/// Generates CSS class names for all colors from
+/// the color palette for a given property, with
+/// optional prefix and suffix attached to the class name.
+/// @access private
+/// @param {string} $prop - The CSS property to assign the palette color to.
+/// @param {string} $prefix - A prefix to be attached to the class name.
+/// @param {string} $suffix - A suffix to be attached to the class name.
+/// @example scss Generate background classes with colors from the palette.
+///   // Will generate class names like
+///   // .my-primary-500-bg { ... };
+///   @include gen-color-classes(
+///     $prop: 'background-color',
+///     $prefix: 'my', $suffix: 'bg'
+///   );
+/// @requires gen-color-class
+@mixin gen-color-classes($prop, $prefix, $suffix) {
+    @each $palette-name, $sub-palette in $default-palette {
+        @each $variant, $color in $sub-palette {
+            @if type-of($color) != 'map' {
+                @include gen-color-class($palette-name, $variant, $prefix, $suffix) {
+                    #{$prop}: $color;
+                }
+            }
+        }
+    }
+}
+
+/// Generates CSS class names for all colors from
+/// the color palette for a given property, with
+/// optional prefix and suffix attached to the class name.
+/// @access private
+/// @param {string} $prop - The CSS property to assign the palette color to.
+/// @param {string} $prefix [null] - A prefix to be attached to the class name.
+/// @param {string} $suffix [igx] - A suffix to be attached to the class name.
+/// @example scss Generate background classes with colors from the palette.
+///   // Will generate class names like
+///   // .igx-primary-500-bg { ... };
+///   @include igx-color-classes(
+///     $prop: 'background-color',
+///     $suffix: 'bg'
+///   );
+/// @requires gen-color-classes
+@mixin igx-color-classes($prop, $suffix: null, $prefix: 'igx') {
+    @include gen-color-classes($prop, $prefix, $suffix);
+}


### PR DESCRIPTION
It would be useful to provide a way to generate CSS classes from from
the palette colors. The classes can assign the palette color to a CSS property upon generation.

