### PR TITLE
Make pinned column resizing works with % width set on grid

### DIFF
--- a/src/grid/grid.component.ts
+++ b/src/grid/grid.component.ts
@@ -506,7 +506,7 @@ export class IgxGridComponent implements OnInit, OnDestroy, AfterContentInit, Af
     }
 
     get calcPinnedContainerMaxWidth(): number {
-        return (parseInt(this.width.toString(), 10) * 80) / 100;
+        return (this.calcWidth * 80) / 100;
     }
 
     get pinnedWidth() {


### PR DESCRIPTION

Calculate correctly pinned columns max allowable width when restricting the resizing of pinned columns.