### PR TITLE
Cell arrow up and down navigation will fully focus target cell

### DIFF
--- a/src/grid/cell.component.ts
+++ b/src/grid/cell.component.ts
@@ -556,13 +556,13 @@ export class IgxGridCellComponent implements IGridBus, OnInit, OnDestroy {
                 && verticalScroll.scrollTop // the scrollbar is not at the first item
                 && target.row.element.nativeElement.offsetTop < this.grid.rowHeight) { // the target is in the first row
 
-                verticalScroll.scrollTop -= this.grid.rowHeight;
+                verticalScroll.scrollTop += containerTopOffset;
                 this._focusNextCell(rowIndex, this.visibleColumnIndex);
             }
             target.nativeElement.focus();
         } else {
-            this.row.grid.verticalScrollContainer.scrollPrev();
-            this._focusNextCell(this.rowIndex, this.visibleColumnIndex);
+            verticalScroll.scrollTop -= this.grid.rowHeight;
+            this._focusNextCell(rowIndex, this.visibleColumnIndex);
         }
     }
 
@@ -597,7 +597,7 @@ export class IgxGridCellComponent implements IGridBus, OnInit, OnDestroy {
             }
         } else {
             verticalScroll.scrollTop += this.grid.rowHeight;
-            this._focusNextCell(this.rowIndex, this.visibleColumnIndex);
+            this._focusNextCell(rowIndex, this.visibleColumnIndex);
         }
     }
 


### PR DESCRIPTION
Closes #1185 .  

When targeting a partially visible cell with keyboard navigation (up and down), the offset is now properly calculated to scroll the cell in the viewport until it is fully visible and aligned just below the header

