### PR TITLE
fix(igxGrid): Add min-height to igx-grid__tbody #1014

### DIFF
--- a/src/grid/grid.component.html
+++ b/src/grid/grid.component.html
@@ -34,7 +34,7 @@
     </div>
 </div>
 
-<div class="igx-grid__tbody" role="rowgroup" [style.height.px]='calcHeight' [style.width.px]='calcWidth' #tbody>
+<div class="igx-grid__tbody" role="rowgroup" [style.min-height.px]='200' [style.height.px]='calcHeight' [style.width.px]='calcWidth' #tbody>
     <ng-template igxFor let-rowData [igxForOf]="data | gridFiltering:filteringExpressions:filteringLogic:id:pipeTrigger
                             | gridSort:sortingExpressions:id:pipeTrigger
                             | gridPaging:page:perPage:id:pipeTrigger" let-rowIndex="index" [igxForScrollOrientation]="'vertical'"


### PR DESCRIPTION
Resolves #1014

Adding min-height to igx-grid__tbody, so the filter dialog does not get cut off when the filtered IN data records are few or none at all.