### PR TITLE
fix(grid): Evaluate the filtering condition before filtering #1224

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Ignite UI for Angular Change Log
 
 All notable changes for each version of this project will be documented in this file.
+## 5.3.1
+- Filtering a boolean column by `false` condition will return only the real `false` values,excluding `null` and `undefined` values. Filtering by `Null` will return the `null` values and filtering by `Empty` will return the `undefined`.
 ## 5.3.0
 - Added `rowSelectable` property to `igxGrid`
     - Setting `rowSelectable` to `true` enables multiple row selection for the `igx-grid` component. Adds a checkbox column that allows (de)selection of one, multiple or all (via header checkbox) rows.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes for each version of this project will be documented in this file.
 ## 5.3.1
-- Filtering a boolean column by `false` condition will return only the real `false` values,excluding `null` and `undefined` values. Filtering by `Null` will return the `null` values and filtering by `Empty` will return the `undefined`.
+- Filtering a boolean column by `false` condition will return only the real `false` values, excluding `null` and `undefined`. Filtering by `Null` will return the `null` values and filtering by `Empty` will return the `undefined`.
+- The `Filter` button in the filtering UI is replaced with a `Close` button that is always active and closes the UI.
+- Filtering UI input displays a `X` icon that clears the input.
+
 ## 5.3.0
 - Added `rowSelectable` property to `igxGrid`
     - Setting `rowSelectable` to `true` enables multiple row selection for the `igx-grid` component. Adds a checkbox column that allows (de)selection of one, multiple or all (via header checkbox) rows.

--- a/src/grid/column.component.ts
+++ b/src/grid/column.component.ts
@@ -105,8 +105,7 @@ export class IgxColumnComponent implements AfterContentInit {
     public formatter: (value: any) => any;
 
     @Input()
-    public filteringCondition: (target: any, searchVal: any, ignoreCase?: boolean) =>
-        boolean = STRING_FILTERS.contains;
+    public filteringCondition: (target: any, searchVal: any, ignoreCase?: boolean) => any;
 
     @Input()
     public filteringIgnoreCase = true;

--- a/src/grid/grid-filtering-ui.spec.ts
+++ b/src/grid/grid-filtering-ui.spec.ts
@@ -10,7 +10,7 @@ import { IgxInputDirective } from "../directives/input/input.directive";
 import { IgxGridComponent } from "./grid.component";
 import { IgxGridModule } from "./index";
 
-fdescribe("IgxGrid - Filtering actions", () => {
+describe("IgxGrid - Filtering actions", () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             declarations: [
@@ -142,7 +142,7 @@ fdescribe("IgxGrid - Filtering actions", () => {
     }));
 
     // UI tests string column with value in input
-    fit("UI tests on string column", async(() => {
+    it("UI tests on string column", async(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 

--- a/src/grid/grid-filtering-ui.spec.ts
+++ b/src/grid/grid-filtering-ui.spec.ts
@@ -10,7 +10,7 @@ import { IgxInputDirective } from "../directives/input/input.directive";
 import { IgxGridComponent } from "./grid.component";
 import { IgxGridModule } from "./index";
 
-describe("IgxGrid - Filtering actions", () => {
+fdescribe("IgxGrid - Filtering actions", () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             declarations: [
@@ -142,7 +142,7 @@ describe("IgxGrid - Filtering actions", () => {
     }));
 
     // UI tests string column with value in input
-    it("UI tests on string column", async(() => {
+    fit("UI tests on string column", async(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
@@ -249,7 +249,7 @@ describe("IgxGrid - Filtering actions", () => {
             expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
-            const emptyTemplate = fix.debugElement.query(By.css("p.igx-grid__empty"));
+            const emptyTemplate = fix.debugElement.query(By.css("p.igx-grid--empty"));
             expect(emptyTemplate.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // does not equal

--- a/src/grid/grid-filtering-ui.spec.ts
+++ b/src/grid/grid-filtering-ui.spec.ts
@@ -302,6 +302,8 @@ describe("IgxGrid - Filtering actions", () => {
             expect(grid.getCellByColumn(0, "Downloads").value).toEqual(0);
             expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            const clear = filterUIContainer.query(By.css("igx-suffix"));
+            expect(clear.nativeElement.offsetHeight).toBeGreaterThan(0);
             // clear input value
             input.nativeElement.value = "";
             input.nativeElement.dispatchEvent(new Event("input"));
@@ -374,6 +376,7 @@ describe("IgxGrid - Filtering actions", () => {
             input = filterUIContainer.query(By.directive(IgxInputDirective));
             expect(grid.rowList.length).toEqual(7);
             expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // iterate over not unary conditions and fill the input
@@ -386,6 +389,8 @@ describe("IgxGrid - Filtering actions", () => {
             expect(grid.getCellByColumn(0, "Downloads").value).toEqual(100);
             expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            const clear = filterUIContainer.query(By.css("igx-suffix"));
+            expect(clear.nativeElement.offsetHeight).toBeGreaterThan(0);
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // does not equal
@@ -420,6 +425,7 @@ describe("IgxGrid - Filtering actions", () => {
             expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+            expect(select.nativeElement.value).toMatch("equals");
 
             // less than
             options[3].selected = true;
@@ -433,6 +439,19 @@ describe("IgxGrid - Filtering actions", () => {
             expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // use clear button
+            const clear = filterUIContainer.query(By.css("igx-suffix"));
+            clear.nativeElement.click();
+            fix.detectChanges();
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(8);
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+            expect(select.nativeElement.value).toMatch("lessThan");
 
             // greater than or equal to
             options[4].selected = true;

--- a/src/grid/grid-filtering-ui.spec.ts
+++ b/src/grid/grid-filtering-ui.spec.ts
@@ -23,7 +23,8 @@ describe("IgxGrid - Filtering actions", () => {
         .compileComponents();
     }));
 
-    it("UI - do not filter when selecting not unary conditions and input is empty", async(() => {
+    // UI tests string column
+    it("UI tests on string column", async(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
@@ -42,9 +43,10 @@ describe("IgxGrid - Filtering actions", () => {
         fix.detectChanges();
 
         fix.whenStable().then(() => {
-            fix.detectChanges();
-
+            // iterate over not unary conditions when input is empty
             // starts with
+            verifyFilterUIPosition(filterUIContainer, grid);
+
             options[1].selected = true;
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
@@ -89,6 +91,7 @@ describe("IgxGrid - Filtering actions", () => {
             expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
+            // iterate over unary conditions
             // null
             options[6].selected = true;
             select.nativeElement.dispatchEvent(new Event("change"));
@@ -125,7 +128,8 @@ describe("IgxGrid - Filtering actions", () => {
             expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toEqual(0);
 
-            // contains - filter should keep its state and not be reset
+            // changing from unary to not unary condition when input is empty - filtering should keep its state
+            // contains
             options[0].selected = true;
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
@@ -134,615 +138,392 @@ describe("IgxGrid - Filtering actions", () => {
             expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // iterate over not unary conditions and fill the input
+            // contains
+            sendInput(input, "Ignite", fix);
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(2);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // starts with
+            options[1].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            sendInput(input, "Net", fix);
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+            verifyFilterUIPosition(filterUIContainer, grid);
+            expect(grid.rowList.length).toEqual(1);
+            expect(grid.getCellByColumn(0, "ID").value).toEqual(2);
+            expect(grid.getCellByColumn(0, "ProductName").value).toMatch("NetAdvantage");
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // ends with
+            options[2].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            sendInput(input, "script", fix);
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(2);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // does not contain
+            options[3].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(6);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // use reset button
+            resetButt.nativeElement.click();
+            fix.detectChanges();
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(8);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // equals
+            options[4].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            sendInput(input, "NetAdvantage", fix);
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(1);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // equals
+            options[4].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            sendInput(input, " ", fix);
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(0);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // does not equal
+            options[5].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            sendInput(input, "NetAdvantage", fix);
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(7);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
         });
     }));
 
-    // UI tests string column
-    it("UI - should correctly filter string column by 'Contains' filtering conditions", (done) => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.query(By.css("igx-grid-filter"));
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-
-        sendInput(input, "NetAdvantage", fix).then(() => {
-            fix.detectChanges();
-            verifyFilterUIPosition(filterUIContainer, grid);
-            expect(grid.rowList.length).toEqual(1);
-            expect(grid.getCellByColumn(0, "ID").value).toEqual(2);
-            expect(grid.getCellByColumn(0, "ProductName").value).toMatch("NetAdvantage");
-            done();
-        });
-    });
-
-    it("UI - should correctly filter string column by 'DoesNotContain' filtering conditions", (done) => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.query(By.css("igx-grid-filter"));
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-        const select = filterUIContainer.query(By.css("div > select"));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "doesNotContain";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        sendInput(input, "Ignite", fix).then(() => {
-            fix.detectChanges();
-            verifyFilterUIPosition(filterUIContainer, grid);
-            expect(grid.rowList.length).toEqual(6);
-            expect(grid.getCellByColumn(0, "ProductName").value).toMatch("NetAdvantage");
-            expect(grid.getCellByColumn(1, "ProductName").value).toEqual(null);
-            expect(grid.getCellByColumn(2, "ProductName").value).toMatch("");
-            expect(grid.getCellByColumn(3, "ProductName").value).toMatch("Some other item with Script");
-            done();
-        });
-    });
-
-    it("UI - should correctly filter string column by 'StartsWith' filtering conditions", (done) => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.query(By.css("igx-grid-filter"));
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-        const select = filterUIContainer.query(By.css("div > select"));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "startsWith";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        sendInput(input, "Net", fix).then(() => {
-            fix.detectChanges();
-            verifyFilterUIPosition(filterUIContainer, grid);
-            expect(grid.rowList.length).toEqual(1);
-            expect(grid.getCellByColumn(0, "ID").value).toEqual(2);
-            expect(grid.getCellByColumn(0, "ProductName").value).toMatch("NetAdvantage");
-            done();
-        });
-    });
-
-    it("UI - should correctly filter string column by 'EndsWith' filtering conditions", (done) => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.query(By.css("igx-grid-filter"));
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-        const select = filterUIContainer.query(By.css("div > select"));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "endsWith";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        sendInput(input, "for", fix).then(() => {
-            fix.detectChanges();
-            verifyFilterUIPosition(filterUIContainer, grid);
-            expect(grid.rowList.length).toEqual(0);
-            done();
-        });
-    });
-
-    it("UI - should correctly filter string column by 'Equals' filtering conditions", (done) => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.query(By.css("igx-grid-filter"));
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-        const select = filterUIContainer.query(By.css("div > select"));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "equals";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        sendInput(input, "Some other item with Script", fix).then(() => {
-            fix.detectChanges();
-            verifyFilterUIPosition(filterUIContainer, grid);
-            expect(grid.rowList.length).toEqual(1);
-            expect(grid.getCellByColumn(0, "ID").value).toEqual(6);
-            expect(grid.getCellByColumn(0, "ProductName").value).toMatch("Some other item with Script");
-            done();
-        });
-    });
-
-    it("UI - should correctly filter string column by 'doesNotEqual' filtering conditions", (done) => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.query(By.css("igx-grid-filter"));
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-        const select = filterUIContainer.query(By.css("div > select"));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "doesNotEqual";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        sendInput(input, "NetAdvantage", fix).then(() => {
-            fix.detectChanges();
-            verifyFilterUIPosition(filterUIContainer, grid);
-            expect(grid.rowList.length).toEqual(7);
-            expect(grid.getCellByColumn(0, "ProductName").value).toMatch("Ignite UI for JavaScript");
-            expect(grid.getCellByColumn(1, "ProductName").value).toMatch("Ignite UI for Angular");
-            expect(grid.getCellByColumn(4, "ProductName").value).toMatch("Some other item with Script");
-            done();
-        });
-    });
-
-    it("UI - should correctly filter string column by 'Empty' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.query(By.css("igx-grid-filter"));
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "empty";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        fix.detectChanges();
-        expect(grid.rowList.length).toEqual(4);
-        expect(grid.getCellByColumn(0, "ProductName").value).toMatch("");
-        expect(grid.getCellByColumn(1, "ProductName").value).toMatch("");
-        expect(grid.getCellByColumn(2, "ProductName").value).toMatch("");
-        expect(grid.getCellByColumn(3, "ProductName").value).toMatch("");
-
-    });
-
-    it("UI - should correctly filter string column by 'NotEmpty' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.query(By.css("igx-grid-filter"));
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "notEmpty";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        fix.detectChanges();
-        expect(grid.rowList.length).toEqual(4);
-        expect(grid.getCellByColumn(0, "ProductName").value).toMatch("Ignite UI for JavaScript");
-        expect(grid.getCellByColumn(1, "ProductName").value).toMatch("NetAdvantage");
-        expect(grid.getCellByColumn(2, "ProductName").value).toMatch("Ignite UI for Angular");
-        expect(grid.getCellByColumn(3, "ProductName").value).toMatch("Some other item with Script");
-    });
-
-    it("UI - should correctly filter string column by 'null' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.query(By.css("igx-grid-filter"));
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "null";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        fix.detectChanges();
-        expect(grid.rowList.length).toEqual(3);
-        expect(grid.getCellByColumn(0, "ProductName").value).toEqual(null);
-        expect(grid.getCellByColumn(1, "ProductName").value).toEqual(null);
-        expect(grid.getCellByColumn(2, "ProductName").value).toEqual(null);
-
-    });
-
-    it("UI - should correctly filter string column by 'NotNull' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.query(By.css("igx-grid-filter"));
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "notNull";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        fix.detectChanges();
-        expect(grid.rowList.length).toEqual(5);
-        expect(grid.getCellByColumn(3, "ProductName").value).toMatch("");
-    });
-
-    // UI tests boolean column
-    it("UI - should correctly filter boolean by 'true' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[2];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-
-        select.nativeElement.value = "true";
-        select.nativeElement.dispatchEvent(new Event("change"));
-        fix.detectChanges();
-
-        expect(grid.rowList.length).toEqual(3);
-        expect(grid.getCellByColumn(0, "Released").value).toBe(true);
-        expect(grid.getCellByColumn(1, "Released").value).toBe(true);
-        expect(grid.getCellByColumn(2, "Released").value).toBe(true);
-    });
-
-    it("UI - should correctly filter boolean by 'false' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[2];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "false";
-        select.nativeElement.dispatchEvent(new Event("change"));
-        fix.detectChanges();
-
-        expect(grid.rowList.length).toEqual(2);
-        expect(grid.getCellByColumn(0, "Released").value).toBeFalsy();
-        expect(grid.getCellByColumn(1, "Released").value).toBeFalsy();
-    });
-
-    it("UI - should correctly filter boolean by 'null' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[2];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "null";
-        select.nativeElement.dispatchEvent(new Event("change"));
-        fix.detectChanges();
-
-        expect(grid.rowList.length).toEqual(2);
-        expect(grid.getCellByColumn(0, "Released").value).toEqual(null);
-        expect(grid.getCellByColumn(1, "Released").value).toEqual(null);
-    });
-
-    it("UI - should correctly filter boolean by 'notNull' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[2];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "notNull";
-        select.nativeElement.dispatchEvent(new Event("change"));
-        fix.detectChanges();
-
-        expect(grid.rowList.length).toEqual(6);
-        expect(grid.getCellByColumn(0, "Released").value).toBe(false);
-        expect(grid.getCellByColumn(1, "Released").value).toBe(true);
-        expect(grid.getCellByColumn(2, "Released").value).toBe(true);
-        expect(grid.getCellByColumn(3, "Released").value).toMatch("");
-        expect(grid.getCellByColumn(4, "Released").value).toBe(true);
-        expect(grid.getCellByColumn(5, "Released").value).toBe(undefined);
-    });
-
-    it("UI - should correctly filter boolean by 'empty' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[2];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "empty";
-        select.nativeElement.dispatchEvent(new Event("change"));
-        fix.detectChanges();
-
-        expect(grid.rowList.length).toEqual(3);
-        expect(grid.getCellByColumn(0, "Released").value).toEqual(null);
-        expect(grid.getCellByColumn(1, "Released").value).toEqual(null);
-        expect(grid.getCellByColumn(2, "Released").value).toEqual(undefined);
-    });
-
-    it("UI - should correctly filter boolean by 'notEmpty' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[2];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "notEmpty";
-        select.nativeElement.dispatchEvent(new Event("change"));
-        fix.detectChanges();
-
-        expect(grid.rowList.length).toEqual(5);
-        expect(grid.getCellByColumn(0, "Released").value).toBe(false);
-        expect(grid.getCellByColumn(1, "Released").value).toBe(true);
-        expect(grid.getCellByColumn(2, "Released").value).toBe(true);
-        expect(grid.getCellByColumn(3, "Released").value).toMatch("");
-        expect(grid.getCellByColumn(4, "Released").value).toBe(true);
-    });
-
     // UI tests number column
-    it("UI - should correctly filter number column by 'Equal' filtering conditions", (done) => {
+    it("UI tests on number column", async(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[1];
         const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
+        let input = filterUIContainer.query(By.directive(IgxInputDirective));
         const select = filterUIContainer.query(By.css("div > select"));
         const options = select.nativeElement.options;
+        const resetButt = filterUIContainer.queryAll(By.css("button"))[0];
+        const filtButt = filterUIContainer.queryAll(By.css("button"))[1];
+
+        expect(grid.rowList.length).toEqual(8);
 
         filterIcon.nativeElement.click();
         fix.detectChanges();
 
-        options[0].selected = true;
-        select.nativeElement.dispatchEvent(new Event("change"));
-        fix.detectChanges();
+        fix.whenStable().then(() => {
 
-        sendInput(input, 100, fix).then(() => {
-            fix.detectChanges();
             verifyFilterUIPosition(filterUIContainer, grid);
+
+            // iterate over not unary conditions and fill the input
+            // equals
+            sendInput(input, 0, fix);
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(1);
+            expect(grid.getCellByColumn(0, "Downloads").value).toEqual(0);
+
+            // clear input value
+            input.nativeElement.value = "";
+            input.nativeElement.dispatchEvent(new Event("input"));
+            fix.detectChanges();
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+
+            // iterate over not unary conditions when input is empty
+            // does not equal
+            options[1].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(8);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // greater than
+            options[2].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(8);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // iterate over unary conditions
+            // null
+            options[6].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(1);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toEqual(0);
+
+            // not null
+            options[7].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(7);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toEqual(0);
+
+            // empty
+            options[8].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(1);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toEqual(0);
+
+            // not empty
+            options[9].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(7);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toEqual(0);
+
+            // changing from unary to not unary condition when input is empty - filtering should keep its state
+            // equals - filter should keep its state and not be reset
+            options[0].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            input = filterUIContainer.query(By.directive(IgxInputDirective));
+            expect(grid.rowList.length).toEqual(7);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // iterate over not unary conditions and fill the input
+            // equals
+            sendInput(input, 100, fix);
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
             expect(grid.rowList.length).toEqual(1);
             expect(grid.getCellByColumn(0, "Downloads").value).toEqual(100);
-            done();
-        });
-    });
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
-    it("UI - should correctly filter number column by 'DoesNotEqual' filtering conditions", (done) => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[1];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "doesNotEqual";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        sendInput(input, 100, fix).then(() => {
+            // does not equal
+            options[1].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
-            verifyFilterUIPosition(filterUIContainer, grid);
             expect(grid.rowList.length).toEqual(7);
-            expect(grid.getCellByColumn(6, "Downloads").value).toEqual(1000);
-            done();
-        });
-    });
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
-    it("UI - should correctly filter number column by 'GreaterThan' filtering conditions", (done) => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[1];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "greaterThan";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        sendInput(input, 300, fix).then(() => {
+            // greater than
+            options[2].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
-            verifyFilterUIPosition(filterUIContainer, grid);
+            sendInput(input, 300, fix);
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
             expect(grid.rowList.length).toEqual(2);
-            expect(grid.getCellByColumn(0, "Downloads").value).toEqual(702);
-            expect(grid.getCellByColumn(1, "Downloads").value).toEqual(1000);
-            done();
-        });
-    });
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
-    it("UI - should correctly filter number column by 'LessThan' filtering conditions", (done) => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[1];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "lessThan";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        sendInput(input, 100, fix).then(() => {
+            // use reset button
+            resetButt.nativeElement.click();
             fix.detectChanges();
-            verifyFilterUIPosition(filterUIContainer, grid);
-            expect(grid.rowList.length).toEqual(3);
-            expect(grid.getCellByColumn(0, "Downloads").value).toEqual(20);
-            expect(grid.getCellByColumn(1, "Downloads").value).toEqual(null);
-            expect(grid.getCellByColumn(2, "Downloads").value).toEqual(0);
-            done();
-        });
-    });
-
-    it("UI - should correctly filter number column by 'greaterThanOrEqualTo' filtering conditions", (done) => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[1];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "greaterThanOrEqualTo";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        sendInput(input, 254, fix).then(() => {
+            return fix.whenStable();
+        }).then(() => {
             fix.detectChanges();
-            verifyFilterUIPosition(filterUIContainer, grid);
-            expect(grid.rowList.length).toEqual(3);
-            expect(grid.getCellByColumn(0, "Downloads").value).toEqual(254);
-            expect(grid.getCellByColumn(1, "Downloads").value).toEqual(702);
-            expect(grid.getCellByColumn(2, "Downloads").value).toEqual(1000);
-            done();
-        });
-    });
+            expect(grid.rowList.length).toEqual(8);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
-    it("UI - should correctly filter number column by 'lessThanOrEqualTo' filtering conditions", (done) => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[1];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
-
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "lessThanOrEqualTo";
-        select.nativeElement.dispatchEvent(new Event("change"));
-
-        sendInput(input, 20, fix).then(() => {
+            // less than
+            options[3].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
-            verifyFilterUIPosition(filterUIContainer, grid);
+            sendInput(input, 100, fix);
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
             expect(grid.rowList.length).toEqual(3);
-            expect(grid.getCellByColumn(0, "Downloads").value).toEqual(20);
-            expect(grid.getCellByColumn(1, "Downloads").value).toEqual(null);
-            expect(grid.getCellByColumn(2, "Downloads").value).toEqual(0);
-            done();
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // greater than or equal to
+            options[4].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            sendInput(input, 254, fix);
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(3);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+
+            // less than or equal to
+            options[5].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(6);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
         });
-    });
+    }));
 
-    it("UI - should correctly filter number column number column by 'null' filtering conditions", () => {
+    // UI tests boolean column
+    it("UI tests on boolean column", async(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[1];
+        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[2];
         const filterIcon = filterUIContainer.query(By.css("igx-icon"));
         const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
+        const options = select.nativeElement.options;
+        const resetButt = filterUIContainer.queryAll(By.css("button"))[0];
+        const filtButt = filterUIContainer.queryAll(By.css("button"))[1];
 
-        filterIcon.triggerEventHandler("mousedown", null);
-        fix.detectChanges();
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "null";
-        select.nativeElement.dispatchEvent(new Event("change"));
-        fix.detectChanges();
-
-        expect(grid.rowList.length).toEqual(1);
-        expect(grid.getCellByColumn(0, "ID").value).toEqual(4);
-        expect(grid.getCellByColumn(0, "Downloads").value).toEqual(null);
-    });
-
-    it("UI - should correctly filter number column by 'notNull' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
-
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[1];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
+        expect(grid.rowList.length).toEqual(8);
 
         filterIcon.nativeElement.click();
         fix.detectChanges();
-        select.nativeElement.value = "notNull";
-        select.nativeElement.dispatchEvent(new Event("change"));
-        fix.detectChanges();
 
-        expect(grid.rowList.length).toEqual(7);
-    });
+        fix.whenStable().then(() => {
+            verifyFilterUIPosition(filterUIContainer, grid);
 
-    it("UI - should correctly filter number column by 'empty' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
+            // false condition
+            options[1].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(2);
+            expect(grid.getCellByColumn(0, "Released").value).toBeFalsy();
+            expect(grid.getCellByColumn(1, "Released").value).toBeFalsy();
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
 
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[1];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
 
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "empty";
-        select.nativeElement.dispatchEvent(new Event("change"));
-        fix.detectChanges();
+            // true condition
+            options[0].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(3);
+            expect(grid.getCellByColumn(0, "Released").value).toBe(true);
+            expect(grid.getCellByColumn(1, "Released").value).toBe(true);
+            expect(grid.getCellByColumn(2, "Released").value).toBe(true);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
 
-        expect(grid.rowList.length).toEqual(1);
-        expect(grid.getCellByColumn(0, "ID").value).toEqual(4);
-        expect(grid.getCellByColumn(0, "Downloads").value).toEqual(null);
-    });
+            // null condition
+            options[2].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(2);
+            expect(grid.getCellByColumn(0, "Released").value).toEqual(null);
+            expect(grid.getCellByColumn(1, "Released").value).toEqual(null);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
 
-    it("UI - should correctly filter number column by 'notEmpty' filtering conditions", () => {
-        const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        fix.detectChanges();
+            // not null condition
+            options[3].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(6);
+            expect(grid.getCellByColumn(0, "Released").value).toBe(false);
+            expect(grid.getCellByColumn(1, "Released").value).toBe(true);
+            expect(grid.getCellByColumn(2, "Released").value).toBe(true);
+            expect(grid.getCellByColumn(3, "Released").value).toMatch("");
+            expect(grid.getCellByColumn(4, "Released").value).toBe(true);
+            expect(grid.getCellByColumn(5, "Released").value).toBe(undefined);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
 
-        const grid = fix.componentInstance.grid;
-        const filterUIContainer = fix.debugElement.queryAll(By.css("igx-grid-filter"))[1];
-        const filterIcon = filterUIContainer.query(By.css("igx-icon"));
-        const select = filterUIContainer.query(By.css("div > select"));
-        const input = filterUIContainer.query(By.directive(IgxInputDirective));
+            // empty condition
+            options[4].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(3);
+            expect(grid.getCellByColumn(0, "Released").value).toEqual(null);
+            expect(grid.getCellByColumn(1, "Released").value).toEqual(null);
+            expect(grid.getCellByColumn(2, "Released").value).toEqual(undefined);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
 
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        select.nativeElement.value = "notEmpty";
-        select.nativeElement.dispatchEvent(new Event("change"));
-        fix.detectChanges();
-
-        expect(grid.rowList.length).toEqual(7);
-    });
+            // not empty condition
+            options[5].selected = true;
+            select.nativeElement.dispatchEvent(new Event("change"));
+            fix.detectChanges();
+            expect(grid.rowList.length).toEqual(5);
+            expect(grid.getCellByColumn(0, "Released").value).toBe(false);
+            expect(grid.getCellByColumn(1, "Released").value).toBe(true);
+            expect(grid.getCellByColumn(2, "Released").value).toBe(true);
+            expect(grid.getCellByColumn(3, "Released").value).toMatch("");
+            expect(grid.getCellByColumn(4, "Released").value).toBe(true);
+            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+        });
+    }));
 
     // UI tests date column
     it("UI - should correctly filter date column by 'today' filtering conditions", () => {

--- a/src/grid/grid-filtering-ui.spec.ts
+++ b/src/grid/grid-filtering-ui.spec.ts
@@ -34,8 +34,8 @@ describe("IgxGrid - Filtering actions", () => {
         let input = filterUIContainer.query(By.directive(IgxInputDirective));
         const select = filterUIContainer.query(By.css("div > select"));
         const options = select.nativeElement.options;
-        const resetButt = filterUIContainer.queryAll(By.css("button"))[0];
-        const filtButt = filterUIContainer.queryAll(By.css("button"))[1];
+        const reset = filterUIContainer.queryAll(By.css("button"))[0];
+        const close = filterUIContainer.queryAll(By.css("button"))[1];
 
         expect(grid.rowList.length).toEqual(8);
 
@@ -51,8 +51,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(8);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // ends with
@@ -60,8 +60,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(8);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // does not contain
@@ -69,8 +69,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(8);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // equals
@@ -78,8 +78,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(8);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // does not equal
@@ -87,8 +87,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(8);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // iterate over unary conditions
@@ -97,8 +97,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(3);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toEqual(0);
 
             // not null
@@ -106,8 +106,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(5);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toEqual(0);
 
             // empty
@@ -115,8 +115,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(4);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toEqual(0);
 
             // not empty
@@ -124,8 +124,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(4);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toEqual(0);
 
             // changing from unary to not unary condition when input is empty - filtering should keep its state
@@ -135,8 +135,8 @@ describe("IgxGrid - Filtering actions", () => {
             fix.detectChanges();
             input = filterUIContainer.query(By.directive(IgxInputDirective));
             expect(grid.rowList.length).toEqual(4);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
         });
     }));
@@ -152,8 +152,8 @@ describe("IgxGrid - Filtering actions", () => {
         const input = filterUIContainer.query(By.directive(IgxInputDirective));
         const select = filterUIContainer.query(By.css("div > select"));
         const options = select.nativeElement.options;
-        const resetButt = filterUIContainer.queryAll(By.css("button"))[0];
-        const filtButt = filterUIContainer.queryAll(By.css("button"))[1];
+        const reset = filterUIContainer.queryAll(By.css("button"))[0];
+        const close = filterUIContainer.queryAll(By.css("button"))[1];
 
         expect(grid.rowList.length).toEqual(8);
 
@@ -168,8 +168,8 @@ describe("IgxGrid - Filtering actions", () => {
         }).then(() => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(2);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // starts with
@@ -184,8 +184,8 @@ describe("IgxGrid - Filtering actions", () => {
             expect(grid.rowList.length).toEqual(1);
             expect(grid.getCellByColumn(0, "ID").value).toEqual(2);
             expect(grid.getCellByColumn(0, "ProductName").value).toMatch("NetAdvantage");
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // ends with
@@ -197,8 +197,8 @@ describe("IgxGrid - Filtering actions", () => {
         }).then(() => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(2);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // does not contain
@@ -209,19 +209,19 @@ describe("IgxGrid - Filtering actions", () => {
         }).then(() => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(6);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // use reset button
-            resetButt.nativeElement.click();
+            reset.nativeElement.click();
             fix.detectChanges();
             return fix.whenStable();
         }).then(() => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(8);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // equals
@@ -233,8 +233,8 @@ describe("IgxGrid - Filtering actions", () => {
         }).then(() => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(1);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // equals
@@ -246,9 +246,11 @@ describe("IgxGrid - Filtering actions", () => {
         }).then(() => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(0);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
+            const emptyTemplate = fix.debugElement.query(By.css("p.igx-grid__empty"));
+            expect(emptyTemplate.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // does not equal
             options[5].selected = true;
@@ -259,8 +261,8 @@ describe("IgxGrid - Filtering actions", () => {
         }).then(() => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(7);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
         });
     }));
@@ -276,10 +278,12 @@ describe("IgxGrid - Filtering actions", () => {
         let input = filterUIContainer.query(By.directive(IgxInputDirective));
         const select = filterUIContainer.query(By.css("div > select"));
         const options = select.nativeElement.options;
-        const resetButt = filterUIContainer.queryAll(By.css("button"))[0];
-        const filtButt = filterUIContainer.queryAll(By.css("button"))[1];
+        const reset = filterUIContainer.queryAll(By.css("button"))[0];
+        const close = filterUIContainer.queryAll(By.css("button"))[1];
 
         expect(grid.rowList.length).toEqual(8);
+        expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+        expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
 
         filterIcon.nativeElement.click();
         fix.detectChanges();
@@ -296,7 +300,8 @@ describe("IgxGrid - Filtering actions", () => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(1);
             expect(grid.getCellByColumn(0, "Downloads").value).toEqual(0);
-
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             // clear input value
             input.nativeElement.value = "";
             input.nativeElement.dispatchEvent(new Event("input"));
@@ -311,8 +316,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(8);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // greater than
@@ -320,8 +325,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(8);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // iterate over unary conditions
@@ -330,8 +335,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(1);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toEqual(0);
 
             // not null
@@ -339,8 +344,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(7);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toEqual(0);
 
             // empty
@@ -348,8 +353,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(1);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toEqual(0);
 
             // not empty
@@ -357,8 +362,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(7);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toEqual(0);
 
             // changing from unary to not unary condition when input is empty - filtering should keep its state
@@ -368,8 +373,7 @@ describe("IgxGrid - Filtering actions", () => {
             fix.detectChanges();
             input = filterUIContainer.query(By.directive(IgxInputDirective));
             expect(grid.rowList.length).toEqual(7);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // iterate over not unary conditions and fill the input
@@ -380,8 +384,8 @@ describe("IgxGrid - Filtering actions", () => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(1);
             expect(grid.getCellByColumn(0, "Downloads").value).toEqual(100);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // does not equal
@@ -389,8 +393,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(7);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // greater than
@@ -402,19 +406,19 @@ describe("IgxGrid - Filtering actions", () => {
         }).then(() => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(2);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // use reset button
-            resetButt.nativeElement.click();
+            reset.nativeElement.click();
             fix.detectChanges();
             return fix.whenStable();
         }).then(() => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(8);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // less than
@@ -426,8 +430,8 @@ describe("IgxGrid - Filtering actions", () => {
         }).then(() => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(3);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // greater than or equal to
@@ -439,8 +443,8 @@ describe("IgxGrid - Filtering actions", () => {
         }).then(() => {
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(3);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // less than or equal to
@@ -448,8 +452,8 @@ describe("IgxGrid - Filtering actions", () => {
             select.nativeElement.dispatchEvent(new Event("change"));
             fix.detectChanges();
             expect(grid.rowList.length).toEqual(6);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
         });
     }));
@@ -464,8 +468,8 @@ describe("IgxGrid - Filtering actions", () => {
         const filterIcon = filterUIContainer.query(By.css("igx-icon"));
         const select = filterUIContainer.query(By.css("div > select"));
         const options = select.nativeElement.options;
-        const resetButt = filterUIContainer.queryAll(By.css("button"))[0];
-        const filtButt = filterUIContainer.queryAll(By.css("button"))[1];
+        const reset = filterUIContainer.queryAll(By.css("button"))[0];
+        const close = filterUIContainer.queryAll(By.css("button"))[1];
 
         expect(grid.rowList.length).toEqual(8);
 
@@ -482,8 +486,8 @@ describe("IgxGrid - Filtering actions", () => {
             expect(grid.rowList.length).toEqual(2);
             expect(grid.getCellByColumn(0, "Released").value).toBeFalsy();
             expect(grid.getCellByColumn(1, "Released").value).toBeFalsy();
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
 
             // true condition
             options[0].selected = true;
@@ -493,8 +497,8 @@ describe("IgxGrid - Filtering actions", () => {
             expect(grid.getCellByColumn(0, "Released").value).toBe(true);
             expect(grid.getCellByColumn(1, "Released").value).toBe(true);
             expect(grid.getCellByColumn(2, "Released").value).toBe(true);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
 
             // null condition
             options[2].selected = true;
@@ -503,8 +507,8 @@ describe("IgxGrid - Filtering actions", () => {
             expect(grid.rowList.length).toEqual(2);
             expect(grid.getCellByColumn(0, "Released").value).toEqual(null);
             expect(grid.getCellByColumn(1, "Released").value).toEqual(null);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
 
             // not null condition
             options[3].selected = true;
@@ -517,8 +521,8 @@ describe("IgxGrid - Filtering actions", () => {
             expect(grid.getCellByColumn(3, "Released").value).toMatch("");
             expect(grid.getCellByColumn(4, "Released").value).toBe(true);
             expect(grid.getCellByColumn(5, "Released").value).toBe(undefined);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
 
             // empty condition
             options[4].selected = true;
@@ -528,8 +532,8 @@ describe("IgxGrid - Filtering actions", () => {
             expect(grid.getCellByColumn(0, "Released").value).toEqual(null);
             expect(grid.getCellByColumn(1, "Released").value).toEqual(null);
             expect(grid.getCellByColumn(2, "Released").value).toEqual(undefined);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
 
             // not empty condition
             options[5].selected = true;
@@ -541,8 +545,8 @@ describe("IgxGrid - Filtering actions", () => {
             expect(grid.getCellByColumn(2, "Released").value).toBe(true);
             expect(grid.getCellByColumn(3, "Released").value).toMatch("");
             expect(grid.getCellByColumn(4, "Released").value).toBe(true);
-            expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
         });
     }));
 

--- a/src/grid/grid-filtering-ui.spec.ts
+++ b/src/grid/grid-filtering-ui.spec.ts
@@ -485,7 +485,6 @@ describe("IgxGrid - Filtering actions", () => {
             expect(filtButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
             expect(resetButt.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
 
-
             // true condition
             options[0].selected = true;
             select.nativeElement.dispatchEvent(new Event("change"));

--- a/src/grid/grid-filtering-ui.spec.ts
+++ b/src/grid/grid-filtering-ui.spec.ts
@@ -376,7 +376,7 @@ describe("IgxGrid - Filtering actions", () => {
             input = filterUIContainer.query(By.directive(IgxInputDirective));
             expect(grid.rowList.length).toEqual(7);
             expect(close.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
-            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeFalsy();
+            expect(reset.nativeElement.classList.contains("igx-button--disabled")).toBeTruthy();
             expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
             // iterate over not unary conditions and fill the input

--- a/src/grid/grid-filtering.component.html
+++ b/src/grid/grid-filtering.component.html
@@ -1,7 +1,10 @@
 <ng-template #defaultFilterUI>
     <div *ngIf="!unaryCondition" class="igx-filtering__op">
         <igx-input-group>
-            <input type="text" igxInput placeholder="Value" autocomplete="off" [value]="value" (input)="onInputChanged($event.target.value)" />
+            <input type="text" igxInput placeholder="Value" autocomplete="off" [value]="value" (input)="onInputChanged($event.target.value)" #input />
+            <igx-suffix *ngIf="input.value.length > 0" (click)="clearInput()">
+                <igx-icon>clear</igx-icon>
+            </igx-suffix>
         </igx-input-group>
     </div>
     <br>
@@ -27,7 +30,7 @@
     </div>
     <ng-container *ngTemplateOutlet="template; context: { $implicit: this }"></ng-container>
     <div class="igx-filtering__options-bgroup">
-        <button igxButton igxRipple (click)="clearFiltering()" [disabled]="disabled">Reset</button>
+        <button igxButton igxRipple (click)="clearFiltering(true)" [disabled]="disabled">Reset</button>
         <button igxButton igxRipple (click)="directive.close(true)">Close</button>
     </div>
 </span>

--- a/src/grid/grid-filtering.component.html
+++ b/src/grid/grid-filtering.component.html
@@ -24,7 +24,7 @@
 
 <span igxToggle (onOpen)="refresh()" (onClose)="refresh()" #directive="toggle" [attr.class]="dialogPosition">
     <div>
-        <select (change)="selectionChanged($event.target.value)">
+        <select (change)="selectionChanged($event.target.value)" #select>
             <option [selected]="isActive(each)" *ngFor="let each of conditions" [value]="each">{{ each | filterCondition | titlecase }}</option>
         </select>
     </div>

--- a/src/grid/grid-filtering.component.html
+++ b/src/grid/grid-filtering.component.html
@@ -1,9 +1,6 @@
 <ng-template #defaultFilterUI>
     <div *ngIf="!unaryCondition" class="igx-filtering__op">
         <igx-input-group>
-            <igx-prefix>
-                <igx-icon>filter_list</igx-icon>
-            </igx-prefix>
             <input type="text" igxInput placeholder="Value" autocomplete="off" [value]="value" (input)="onInputChanged($event.target.value)" />
         </igx-input-group>
     </div>
@@ -17,7 +14,7 @@
 <div class="igx-filtering">
     <div [attr.class]="filterCSS">
         <span class="toggle-icon" [igxToggleAction]="directive">
-            <igx-icon (mousedown)="onMouseDown()">more_vert</igx-icon>
+            <igx-icon (mousedown)="onMouseDown()">filter_list</igx-icon>
         </span>
     </div>
 </div>
@@ -30,7 +27,7 @@
     </div>
     <ng-container *ngTemplateOutlet="template; context: { $implicit: this }"></ng-container>
     <div class="igx-filtering__options-bgroup">
-        <button igxButton igxRipple (click)="clearFiltering()">Reset</button>
-        <button igxButton igxRipple (click)="filter()" [disabled]="disabled">Filter</button>
+        <button igxButton igxRipple (click)="clearFiltering()" [disabled]="disabled">Reset</button>
+        <button igxButton igxRipple (click)="directive.close(true)">Close</button>
     </div>
 </span>

--- a/src/grid/grid-filtering.component.ts
+++ b/src/grid/grid-filtering.component.ts
@@ -134,7 +134,7 @@ export class IgxGridFilterComponent implements IGridBus, OnInit, OnDestroy {
     @ViewChild("select", { read: ElementRef})
     protected select: ElementRef;
 
-    constructor(public gridAPI: IgxGridAPIService, public cdr: ChangeDetectorRef, private elementRef: ElementRef) {
+    constructor(private zone: NgZone, public gridAPI: IgxGridAPIService, public cdr: ChangeDetectorRef, private elementRef: ElementRef) {
         this.filterChanged.pipe(
             debounceTime(250)
         ).subscribe((value) => this.value = value);

--- a/src/grid/grid-filtering.component.ts
+++ b/src/grid/grid-filtering.component.ts
@@ -167,6 +167,9 @@ export class IgxGridFilterComponent implements IGridBus, OnInit, OnDestroy, DoCh
 
     public refresh() {
         this.dialogShowing = !this.dialogShowing;
+        if (this.dialogShowing) {
+            this.column.filteringCondition = this.getCondition(this.select.nativeElement.value);
+        }
         this.cdr.detectChanges();
     }
 

--- a/src/grid/grid-filtering.component.ts
+++ b/src/grid/grid-filtering.component.ts
@@ -38,7 +38,7 @@ export class IgxGridFilterComponent implements IGridBus, OnInit, OnDestroy {
     public column;
 
     get value() {
-        return this._value || "";
+        return this._value;
     }
 
     set value(val) {
@@ -130,6 +130,9 @@ export class IgxGridFilterComponent implements IGridBus, OnInit, OnDestroy {
     @ViewChild(IgxToggleDirective, { read: IgxToggleDirective})
     protected toggleDirective: IgxToggleDirective;
 
+    @ViewChild("select", { read: ElementRef})
+    protected select: ElementRef;
+
     constructor(public gridAPI: IgxGridAPIService, public cdr: ChangeDetectorRef, private elementRef: ElementRef) {
         this.filterChanged.pipe(
             debounceTime(250)
@@ -177,6 +180,7 @@ export class IgxGridFilterComponent implements IGridBus, OnInit, OnDestroy {
     @autoWire(true)
     public filter(): void {
         const grid = this.gridAPI.get(this.gridID);
+        this.column.filteringCondition = this.getCondition(this.select.nativeElement.value);
         this.gridAPI.filter(
             this.column.gridID, this.column.field,
             this._value, this.column.filteringCondition, this.column.filteringIgnoreCase);
@@ -197,7 +201,6 @@ export class IgxGridFilterComponent implements IGridBus, OnInit, OnDestroy {
 
     public selectionChanged(value): void {
         this._filterCondition = value;
-        this.column.filteringCondition = this.getCondition(value);
         if (this.unaryCondition) {
             this.unaryConditionChanged.next(value);
         } else {
@@ -210,7 +213,7 @@ export class IgxGridFilterComponent implements IGridBus, OnInit, OnDestroy {
     }
 
     public get disabled() {
-        if (this.value && !this.unaryCondition) {
+        if ((!!this.value || this.value === 0) && !this.unaryCondition) {
             return false;
         } else if (this.unaryCondition) {
             return false;

--- a/src/grid/grid-filtering.component.ts
+++ b/src/grid/grid-filtering.component.ts
@@ -46,7 +46,7 @@ export class IgxGridFilterComponent implements IGridBus, OnInit, OnDestroy, DoCh
     set value(val) {
         // filtering needs to be cleared if value is null, undefined or empty string
         if (!val && val !== 0) {
-            this.clearFiltering();
+            this.clearFiltering(false);
             return;
         }
         this._value = this.transformValue(val);
@@ -202,8 +202,9 @@ export class IgxGridFilterComponent implements IGridBus, OnInit, OnDestroy, DoCh
     }
 
     @autoWire(true)
-    public clearFiltering(): void {
+    public clearFiltering(resetCondition: boolean): void {
         this._value = null;
+        this._filterCondition = resetCondition ? undefined : this._filterCondition;
         this.gridAPI.clear_filter(this.gridID, this.column.field);
         this.gridAPI.get(this.gridID).clearSummaryCache();
         // XXX - Temp fix for (#1183, #1177) (Should be deleted)
@@ -223,6 +224,10 @@ export class IgxGridFilterComponent implements IGridBus, OnInit, OnDestroy, DoCh
 
     public onInputChanged(val): void {
         this.filterChanged.next(val);
+    }
+
+    public clearInput(): void {
+        this.clearFiltering(false);
     }
 
     public get disabled() {

--- a/src/grid/grid-filtering.spec.ts
+++ b/src/grid/grid-filtering.spec.ts
@@ -194,7 +194,7 @@ describe("IgxGrid - Filtering actions", () => {
         // Empty filter
         grid.filter("Released", null, BOOLEAN_FILTERS.empty);
         fix.detectChanges();
-        expect(grid.rowList.length).toEqual(2);
+        expect(grid.rowList.length).toEqual(3);
 
         // False filter
         grid.clearFilter("Released");
@@ -202,7 +202,7 @@ describe("IgxGrid - Filtering actions", () => {
         expect(grid.rowList.length).toEqual(8);
         grid.filter("Released", null, BOOLEAN_FILTERS.false);
         fix.detectChanges();
-        expect(grid.rowList.length).toEqual(3);
+        expect(grid.rowList.length).toEqual(2);
 
         // True filter
         grid.clearFilter("Released");
@@ -216,7 +216,7 @@ describe("IgxGrid - Filtering actions", () => {
         fix.detectChanges();
         grid.filter("Released", null, BOOLEAN_FILTERS.notEmpty);
         fix.detectChanges();
-        expect(grid.rowList.length).toEqual(6);
+        expect(grid.rowList.length).toEqual(5);
 
         // NotNull filter
         grid.clearFilter("Released");
@@ -462,7 +462,7 @@ export class IgxGridFilteringComponent {
             ID: 8,
             ProductName: null,
             ReleaseDate: this.today,
-            Released: false
+            Released: undefined
         }
     ];
 

--- a/src/grid/grid.component.html
+++ b/src/grid/grid.component.html
@@ -74,5 +74,5 @@
 </div>
 
 <ng-template #emptyGrid>
-    <p class="igx-grid__empty">No records found.</p>
+    <p class="igx-grid--empty">No records found.</p>
 </ng-template>

--- a/src/grid/grid.component.html
+++ b/src/grid/grid.component.html
@@ -36,12 +36,16 @@
 
 <div class="igx-grid__tbody" role="rowgroup" [style.height.px]='calcHeight' [style.width.px]='calcWidth' #tbody>
     <ng-template igxFor let-rowData [igxForOf]="data | gridFiltering:filteringExpressions:filteringLogic:id:pipeTrigger
-                            | gridSort:sortingExpressions:id:pipeTrigger
-                            | gridPaging:page:perPage:id:pipeTrigger" let-rowIndex="index" [igxForScrollOrientation]="'vertical'"
+        | gridSort:sortingExpressions:id:pipeTrigger
+        | gridPaging:page:perPage:id:pipeTrigger" let-rowIndex="index" [igxForScrollOrientation]="'vertical'"
         [igxForContainerSize]='calcHeight' [igxForItemSize]="rowHeight" #verticalScrollContainer (onChunkPreload)="dataLoading($event)">
         <igx-grid-row [gridID]="id" [index]="rowIndex" [rowData]="rowData">
         </igx-grid-row>
     </ng-template>
+    <ng-container *ngIf="!!filteredData && filteredData.length === 0">
+        <ng-container *ngTemplateOutlet="template">
+        </ng-container>
+    </ng-container>
 </div>
 
 
@@ -68,3 +72,7 @@
     <ng-container *ngTemplateOutlet="paginationTemplate ? paginationTemplate : defaultPager; context: { $implicit: this }">
     </ng-container>
 </div>
+
+<ng-template #emptyGrid>
+    <p class="igx-grid__empty">No records found.</p>
+</ng-template>

--- a/src/grid/grid.component.ts
+++ b/src/grid/grid.component.ts
@@ -307,6 +307,9 @@ export class IgxGridComponent implements OnInit, OnDestroy, AfterContentInit, Af
     @ViewChildren(IgxGridRowComponent, { read: IgxGridRowComponent })
     public rowList: QueryList<IgxGridRowComponent>;
 
+    @ViewChild("emptyGrid", { read: TemplateRef })
+    public emptyGridTemplate: TemplateRef<any>;
+
     @ViewChild("scrollContainer", { read: IgxForOfDirective })
     public parentVirtDir: IgxForOfDirective<any>;
 
@@ -1089,6 +1092,10 @@ export class IgxGridComponent implements OnInit, OnDestroy, AfterContentInit, Af
         return this._filteringExpressions.length > 0 ?
             this.headerCheckbox && this.headerCheckbox.checked ? "Deselect all filtered" : "Select all filtered" :
             this.headerCheckbox && this.headerCheckbox.checked ? "Deselect all" : "Select all";
+    }
+
+    public get template(): TemplateRef<any> {
+        return this.emptyGridTemplate;
     }
 
     public checkHeaderChecboxStatus(headerStatus?: boolean) {


### PR DESCRIPTION
Closes #1224, Closes #1228, Closes #1187, Closes #1263 

- [x] Evaluate the filtering condition before filtering #1224
- [x] Added test to verify #1224
- [x] do not disable the FIlter button if value in inout is 0 #1228
- [x] new expectation in test to verify Reset and Filter buttons state
- [x] UI tests on string, boolean and numeric columns refactored
- [x] #1187:
- [x] Replace the “more“ icon with the “filter” icon
- [x] remove the filter icon from the input
- [x] - Reset Button becomes active only when there is a value already in the input or some of the non value required options is chosen + tests
- [x] - "Filter" is changed to "Close". "Close" button is always active and closes the dropdown + tests
- [x] - When the filter has no records, display "No Records Found"

NEW:
- [x] - Closes #1263
- [x] - clear icon in input
- [x] - tests for clear icon
- [x] - reset button resets the filtering condition
- [x] - test if reset button resets the filtering condition
