### PR TITLE
fixes to grid selection

### DIFF
--- a/demos/app/grid-selection/sample.component.html
+++ b/demos/app/grid-selection/sample.component.html
@@ -12,5 +12,6 @@
 <ng-container *ngIf="selection">
     <button igxButton="flat" class="igx-button--flat" (click)="toggle()" igxButtonColor="#FBB13C" igxButtonBackground="#340068" igxRipple="#FBB13C" >Toggle rows with ID 1,2,5 </button>
     <button igxButton="flat" class="igx-button--flat" (click)="toggleAll()" igxButtonColor="#FBB13C" igxButtonBackground="#340068" igxRipple="#FBB13C" >Toggle All rows</button>
+    <button igxButton="flat" class="igx-button--flat" (click)="callSelectAll()" igxButtonColor="#FBB13C" igxButtonBackground="#340068" igxRipple="#FBB13C" >Select All Rows</button>
 </ng-container>
 </div>

--- a/demos/app/grid-selection/sample.component.ts
+++ b/demos/app/grid-selection/sample.component.ts
@@ -80,4 +80,8 @@ export class GridSelectionComponent implements OnInit, AfterViewInit {
             this.grid1.deselectAllRows();
         }
     }
+
+    public callSelectAll() {
+        this.grid1.selectAllRows();
+    }
 }

--- a/src/grid/grid-selection.spec.ts
+++ b/src/grid/grid-selection.spec.ts
@@ -581,14 +581,14 @@ describe("IgxGrid - Row Selection", () => {
         spyOn(grid, "triggerRowSelectionChange").and.callThrough();
         spyOn(grid.onRowSelectionChange, "emit").and.callThrough();
         rowsCollection = grid.selectedRows();
-        expect(rowsCollection).toBeUndefined();
+        expect(rowsCollection).toEqual([]);
         expect(firstRow.isSelected).toBeFalsy();
         expect(secondRow.isSelected).toBeFalsy();
         expect(thirdRow.isSelected).toBeFalsy();
         grid.deselectRows(["0_0", "0_1", "0_2"]);
         fix.whenStable().then(() => {
             fix.detectChanges();
-            expect(rowsCollection).toBeUndefined();
+            expect(rowsCollection).toEqual([]);
         });
         grid.selectRows(["0_0", "0_1", "0_2"], false);
         fix.whenStable().then(() => {
@@ -619,7 +619,7 @@ describe("IgxGrid - Row Selection", () => {
         let rowsCollection = [];
         const firstRow = grid.getRowByKey("0_0");
         rowsCollection = grid.selectedRows();
-        expect(rowsCollection).toBeUndefined();
+        expect(rowsCollection).toEqual([]);
         expect(firstRow.isSelected).toBeFalsy();
         spyOn(grid, "triggerRowSelectionChange").and.callThrough();
         spyOn(grid.onRowSelectionChange, "emit").and.callThrough();
@@ -657,7 +657,7 @@ describe("IgxGrid - Row Selection", () => {
         let rowsCollection = [];
 
         rowsCollection = grid.selectedRows();
-        expect(rowsCollection).toBeUndefined();
+        expect(rowsCollection).toEqual([]);
 
         grid.filter("ProductName", "Ignite", STRING_FILTERS.contains, true);
         fix.detectChanges();
@@ -665,7 +665,7 @@ describe("IgxGrid - Row Selection", () => {
         expect(headerCheckbox.indeterminate).toBeFalsy();
         expect(grid.onRowSelectionChange.emit).toHaveBeenCalledTimes(0);
         rowsCollection = grid.selectedRows();
-        expect(rowsCollection).toBeUndefined();
+        expect(rowsCollection).toEqual([]);
         expect(headerCheckbox.getAttribute("aria-checked")).toMatch("false");
         expect(headerCheckbox.getAttribute("aria-label")).toMatch("Select all filtered");
         grid.clearFilter("ProductName");
@@ -763,7 +763,7 @@ describe("IgxGrid - Row Selection", () => {
         expect(secondRow.isSelected).toBeFalsy();
         let rowsCollection = [];
         rowsCollection = grid.selectedRows();
-        expect(rowsCollection).toBeUndefined();
+        expect(rowsCollection).toEqual([]);
 
         grid.selectRows(["0_0", "0_1"], false);
         fix.detectChanges();

--- a/src/grid/grid-selection.spec.ts
+++ b/src/grid/grid-selection.spec.ts
@@ -916,6 +916,78 @@ describe("IgxGrid - Row Selection", () => {
             expect(thirdRow.isSelected).toBeFalsy();
         });
     }));
+
+    it("Should be able to programatically select all rows with a correct reference, #1297", async(() => {
+        const fix = TestBed.createComponent(GridWithPrimaryKeyComponent);
+        fix.detectChanges();
+        const grid = fix.componentInstance.gridSelection1;
+        const gridElement: HTMLElement = fix.nativeElement.querySelector(".igx-grid");
+        grid.selectAllRows();
+        fix.whenStable().then(() => {
+            fix.detectChanges();
+            expect(grid.selectedRows()).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+            grid.selectAllRows();
+        });
+    }));
+
+    it("Should be able to programatically select all rows and keep the header checkbox intact,  #1298", async(() => {
+        const fixture = TestBed.createComponent(GridWithPagingAndSelectionComponent);
+        fixture.detectChanges();
+        const grid = fixture.componentInstance.gridSelection2;
+        const gridElement: HTMLElement = fixture.nativeElement.querySelector(".igx-grid");
+        const headerRow: HTMLElement = fixture.nativeElement.querySelector(".igx-grid__thead");
+        const headerCheckboxElement: HTMLElement = headerRow.querySelector(".igx-checkbox");
+        const firstRow = grid.getRowByIndex(0);
+        const firstRowCheckbox: HTMLElement = firstRow.nativeElement.querySelector(".igx-checkbox__input");
+        const thirdRow = grid.getRowByIndex(2);
+        const thirdRowCheckbox: HTMLElement = thirdRow.nativeElement.querySelector(".igx-checkbox__input");
+        expect(firstRow.isSelected).toBeFalsy();
+        expect(thirdRow.isSelected).toBeFalsy();
+        grid.selectAllRows();
+        fixture.whenStable().then(() => {
+            fixture.detectChanges();
+            expect(firstRow.isSelected).toBeTruthy();
+            expect(thirdRow.isSelected).toBeTruthy();
+            expect(headerCheckboxElement.classList.contains("igx-checkbox--checked")).toBeTruthy();
+            grid.selectAllRows();
+            return fixture.whenStable();
+        }).then(() => {
+            fixture.detectChanges();
+            expect(firstRow.isSelected).toBeTruthy();
+            expect(thirdRow.isSelected).toBeTruthy();
+            expect(headerCheckboxElement.classList.contains("igx-checkbox--checked")).toBeTruthy();
+        });
+    }));
+
+    it("Should be able to programatically get a collection of all selected rows", async(() => {
+        const fix = TestBed.createComponent(GridWithPagingAndSelectionComponent);
+        fix.detectChanges();
+        const grid = fix.componentInstance.gridSelection2;
+        const gridElement: HTMLElement = fix.nativeElement.querySelector(".igx-grid");
+        const headerRow: HTMLElement = fix.nativeElement.querySelector(".igx-grid__thead");
+        const headerCheckboxElement: HTMLElement = headerRow.querySelector(".igx-checkbox");
+        const firstRow = grid.getRowByIndex(0);
+        const firstRowCheckbox: HTMLElement = firstRow.nativeElement.querySelector(".igx-checkbox__input");
+        const thirdRow = grid.getRowByIndex(2);
+        const thirdRowCheckbox: HTMLElement = thirdRow.nativeElement.querySelector(".igx-checkbox__input");
+        expect(firstRow.isSelected).toBeFalsy();
+        expect(thirdRow.isSelected).toBeFalsy();
+        expect(grid.selectedRows()).toEqual([]);
+        thirdRowCheckbox.click();
+        fix.whenStable().then(() => {
+            fix.detectChanges();
+            expect(firstRow.isSelected).toBeFalsy();
+            expect(thirdRow.isSelected).toBeTruthy();
+            expect(grid.selectedRows()).toEqual(["0_2"]);
+            thirdRowCheckbox.click();
+            return fix.whenStable();
+        }).then(() => {
+            fix.detectChanges();
+            expect(firstRow.isSelected).toBeFalsy();
+            expect(thirdRow.isSelected).toBeFalsy();
+            expect(grid.selectedRows()).toEqual([]);
+        });
+    }));
 });
 
 @Component({

--- a/src/grid/grid.component.ts
+++ b/src/grid/grid.component.ts
@@ -1109,10 +1109,12 @@ export class IgxGridComponent implements OnInit, OnDestroy, AfterContentInit, Af
             this.allRowsSelected = this.selectionAPI.are_all_selected(this.id, this.data);
             if (this.headerCheckbox) {
                 this.headerCheckbox.indeterminate = !this.allRowsSelected && !this.selectionAPI.are_none_selected(this.id);
+                if (!this.headerCheckbox.indeterminate) {
+                    this.headerCheckbox.checked = this.selectionAPI.are_all_selected(this.id, this.data);
+                }
             }
             this.cdr.markForCheck();
-        }
-        if (this.headerCheckbox) {
+        } else if (this.headerCheckbox) {
             this.headerCheckbox.checked = headerStatus !== undefined ? headerStatus : false;
         }
     }

--- a/src/grid/grid.component.ts
+++ b/src/grid/grid.component.ts
@@ -1190,7 +1190,7 @@ export class IgxGridComponent implements OnInit, OnDestroy, AfterContentInit, Af
     }
 
     public selectAllRows() {
-        this.triggerRowSelectionChange(this.selectionAPI.get_all_ids(this.data, this.id));
+        this.triggerRowSelectionChange(this.selectionAPI.get_all_ids(this.data, this.primaryKey));
     }
 
     public deselectAllRows() {

--- a/src/grid/grid.component.ts
+++ b/src/grid/grid.component.ts
@@ -1175,8 +1175,8 @@ export class IgxGridComponent implements OnInit, OnDestroy, AfterContentInit, Af
         }
     }
 
-    public selectedRows() {
-        return this.selectionAPI.get_selection(this.id);
+    public selectedRows(): any[] {
+        return this.selectionAPI.get_selection(this.id) || [];
     }
 
     public selectRows(rowIDs: any[], clearCurrentSelection?: boolean) {


### PR DESCRIPTION
Closes #1298, #1295, #1297 .

Fix selectedRows() to return an empty array if no rows are selected.
Fix selectAllRows() to properly pass the grid primaryKey to the selectionAPI.
FIx checkHeaderChecboxStatus() to properly set the state of the row-selection header checkbox when called programatically.