### PR TITLE
fix(themes): wrong colors in light variant themes

### DIFF
--- a/demos/app/input/sample.component.html
+++ b/demos/app/input/sample.component.html
@@ -10,7 +10,7 @@
                 <h4 class="form-title">Personal Info</h4>
 
                 <igx-input-group>
-                    <input igxInput name="firstName" type="text" [(ngModel)]="user.firstName" required disabled/>
+                    <input igxInput name="firstName" type="text" [(ngModel)]="user.firstName" required disabled="disabled"/>
                     <label igxLabel for="firstName">First Name</label>
                 </igx-input-group>
 

--- a/src/core/styles/components/checkbox/_checkbox-theme.scss
+++ b/src/core/styles/components/checkbox/_checkbox-theme.scss
@@ -30,7 +30,8 @@
     $fill-color: null,
     $tick-color: null,
     $disabled-color: null,
-    $light: false
+    $light: false,
+    $variant: 'dark'
 ) {
     $name: 'igx-checkbox';
 
@@ -45,7 +46,7 @@
 
     $light-theme: (
         name: $name,
-        label-color: igx-color($palette, 'grays', 600),
+        label-color: #fff,
         empty-color: rgba(255, 255, 255, .7),
         fill-color: igx-color($palette, 'secondary', 500),
         tick-color: #000,
@@ -61,7 +62,8 @@
         fill-color: $fill-color,
         tick-color: $tick-color,
         disabled-color: $disabled-color,
-        light: $light
+        light: $light,
+        variant: $variant
     ));
 }
 

--- a/src/core/styles/components/checkbox/_checkbox-theme.scss
+++ b/src/core/styles/components/checkbox/_checkbox-theme.scss
@@ -30,7 +30,6 @@
     $fill-color: null,
     $tick-color: null,
     $disabled-color: null,
-    $light: false,
     $variant: 'dark'
 ) {
     $name: 'igx-checkbox';
@@ -53,7 +52,10 @@
         disabled-color: rgba(255, 255, 255, .3)
     );
 
-    $default-theme: if($light == false or $variant == 'dark', $dark-theme, $light-theme);
+    $default-theme: map-get((
+        dark: $dark-theme,
+        light: $light-theme
+    ), $variant);
 
     @return extend($default-theme, (
         palette: $palette,
@@ -62,7 +64,6 @@
         fill-color: $fill-color,
         tick-color: $tick-color,
         disabled-color: $disabled-color,
-        light: $light,
         variant: $variant
     ));
 }

--- a/src/core/styles/components/input/_input-group-theme.scss
+++ b/src/core/styles/components/input/_input-group-theme.scss
@@ -190,7 +190,9 @@
 
         success-secondary-color: $success-secondary-color,
         warning-secondary-color: $warning-secondary-color,
-        error-secondary-color: $error-secondary-color
+        error-secondary-color: $error-secondary-color,
+
+        variant: $variant
     ));
 }
 

--- a/src/core/styles/components/input/_input-group-theme.scss
+++ b/src/core/styles/components/input/_input-group-theme.scss
@@ -155,7 +155,10 @@
         error-secondary-color: igx-color($palette, 'error')
     );
 
-    $default-theme: if($variant == 'dark', $dark-theme, $light-theme);
+    $default-theme: map-get((
+        dark: $dark-theme,
+        light: $light-theme
+    ), $variant);
 
     @return extend($default-theme, (
         palette: $palette,

--- a/src/core/styles/components/radio/_radio-theme.scss
+++ b/src/core/styles/components/radio/_radio-theme.scss
@@ -10,7 +10,6 @@
 /// @param {Color} $empty-color [null] - The unchecked border color.
 /// @param {Color} $fill-color [null] - The checked border and dot colors.
 /// @param {Color} $disabled-color [null] - The disabled border and dot colors.
-/// @param {Bool} $light [null] - Determines the default color scheme - light or not.
 /// @param {String} $variant ['dark'] - Determines the default color scheme - could be 'light' or 'dark'.
 ///
 /// @requires extend
@@ -28,7 +27,6 @@
     $fill-color: null,
     $disabled-color: null,
 
-    $light: false,
     $variant: 'dark'
 ) {
     $name: 'igx-radio';
@@ -49,7 +47,10 @@
         disabled-color: rgba(255, 255, 255, .3)
     );
 
-    $default-theme: if($light == false or $variant == 'dark', $dark-theme, $light-theme);
+    $default-theme: map-get((
+        dark: $dark-theme,
+        light: $light-theme
+    ), $variant);
 
     @return extend($default-theme, (
         palette: $palette,

--- a/src/core/styles/components/radio/_radio-theme.scss
+++ b/src/core/styles/components/radio/_radio-theme.scss
@@ -43,7 +43,7 @@
 
     $light-theme: (
         name: $name,
-        label-color: igx-color($palette, 'grays', 600),
+        label-color: #fff,
         empty-color: rgba(255, 255, 255, .7),
         fill-color: igx-color($palette, 'secondary', 500),
         disabled-color: rgba(255, 255, 255, .3)
@@ -57,6 +57,7 @@
         empty-color: $empty-color,
         fill-color: $fill-color,
         disabled-color: $disabled-color,
+        variant: $variant
     ));
 }
 

--- a/src/core/styles/components/slider/_slider-theme.scss
+++ b/src/core/styles/components/slider/_slider-theme.scss
@@ -10,7 +10,6 @@
 /// @param {Color} $thumb-color [null] - The color of the thumb.
 /// @param {Color} $label-background-color [null] - The background color of the bubble label.
 /// @param {Color} $label-text-color [null] - The text color of the bubble label.
-/// @param {Bool} $light [false] - Determines the default color scheme - light or dark.
 /// @param {Bool} $variant ['dark'] - Determines the default color scheme - can be 'light' or 'dark'.
 ///
 /// @requires extend
@@ -32,7 +31,6 @@
     $label-background-color: null,
     $label-text-color: null,
 
-    $light: false,
     $variant: 'dark'
 ) {
     $name: 'igx-slider';
@@ -63,7 +61,10 @@
         disabled-base-track-color: rgba(#fff, .3)
     );
 
-    $default-theme: if($light == false or $variant == 'dark', $dark-theme, $light-theme);
+    $default-theme: map-get((
+        dark: $dark-theme,
+        light: $light-theme
+    ), $variant);
 
     @if not($label-text-color) and not($label-background-color) {
         $label-text-color: text-contrast(map-get($default-theme, 'label-background-color'));

--- a/src/core/styles/components/slider/_slider-theme.scss
+++ b/src/core/styles/components/slider/_slider-theme.scss
@@ -78,7 +78,8 @@
         track-color: $track-color,
         thumb-color: $thumb-color,
         label-background-color: $label-background-color,
-        label-text-color: $label-text-color
+        label-text-color: $label-text-color,
+        variant: $variant
     ));
 }
 

--- a/src/core/styles/components/switch/_switch-theme.scss
+++ b/src/core/styles/components/switch/_switch-theme.scss
@@ -12,7 +12,6 @@
 /// @param {Color} $track-off-color [null] - The color of the track when the switch is off.
 /// @param {Color} $thumb-disabled-color [null] - The color of the thumb when the switch is disabled.
 /// @param {Color} $track-disabled-color [null] - The color of the track when the switch is disabled.
-/// @param {Bool} $light [false] - Determines the default color scheme - light or not.
 /// @param {String} $variant ['dark'] - Determines the default color scheme - could be 'light' or 'dark'.
 ///
 /// @requires extend
@@ -39,7 +38,6 @@
     $label-color: null,
     $label-disabled-color: null,
 
-    $light: false,
     $variant: 'dark'
 ) {
     $name: 'igx-switch';
@@ -76,7 +74,10 @@
         thumb-disabled-color: #6c6c6c
     );
 
-    $default-theme: if($light == false or $variant == 'dark', $dark-theme, $light-theme);
+    $default-theme: map-get((
+        dark: $dark-theme,
+        light: $light-theme
+    ), $variant);
 
     @return extend($default-theme, (
         palette: $palette,
@@ -93,7 +94,6 @@
         label-color: $label-color,
         label-disabled-color: $label-disabled-color,
 
-        light: $light,
         variant: $variant
     ));
 }

--- a/src/core/styles/components/switch/_switch-theme.scss
+++ b/src/core/styles/components/switch/_switch-theme.scss
@@ -69,7 +69,7 @@
         thumb-off-color: #bdbdbd,
         track-off-color: rgba(255, 255, 255, .3),
 
-        label-color: igx-color($palette, grays, 600),
+        label-color: #fff,
         label-disabled-color: rgba(255, 255, 255, .3),
 
         track-disabled-color: #424242,
@@ -93,7 +93,8 @@
         label-color: $label-color,
         label-disabled-color: $label-disabled-color,
 
-        light: $light
+        light: $light,
+        variant: $variant
     ));
 }
 


### PR DESCRIPTION
Fix label colors for switch, radio, and the checkbox themes. Explose the
variant to the produces theme map for all themes with multiple theme
variants.

Closes #1326