### PR TITLE
Fix - Sort icon on a table object is not cleared when exporting second time or later

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -6,9 +6,13 @@ export function cloneArray(array, deep?: boolean) {
     }
     let i = array.length;
     while (i--) {
-        arr[i] = deep ? JSON.parse(JSON.stringify(array[i])) : array[i];
+        arr[i] = deep ? cloneObject(array[i]) : array[i];
     }
     return arr;
+}
+
+export function cloneObject(object: any) {
+    return JSON.parse(JSON.stringify(object));
 }
 
 export const enum KEYCODES {

--- a/src/services/excel/excel-exporter-grid.spec.ts
+++ b/src/services/excel/excel-exporter-grid.spec.ts
@@ -520,6 +520,28 @@ describe("Excel Exporter", () => {
         });
     }));
 
+    it("shouldn't affect grid sort expressions", async(() => {
+        const fix = TestBed.createComponent(GridDeclarationComponent);
+        fix.detectChanges();
+
+        const grid = fix.componentInstance.grid1;
+        grid.columns[1].header = "My header";
+        grid.columns[1].sortable = true;
+        grid.sort("Name");
+        const sortField = grid.sortingExpressions[0].fieldName;
+
+        fix.whenStable().then(() => {
+            fix.detectChanges();
+            getExportedData(grid, options).then((wrapper) => {
+                fix.detectChanges();
+                getExportedData(grid, options).then((wrapper2) => {
+                    const sortFieldAfterExport = grid.sortingExpressions[0].fieldName;
+                    expect(sortField).toBe(sortFieldAfterExport);
+                });
+            });
+        });
+    }));
+
     async function getExportedData(grid: IgxGridComponent, exportOptions: IgxExcelExporterOptions) {
         const exportData = await new Promise<JSZipWrapper>((resolve) => {
             exporter.onExportEnded.subscribe((value) => {

--- a/src/services/exporter-common/base-export-service.ts
+++ b/src/services/exporter-common/base-export-service.ts
@@ -3,6 +3,7 @@ import {
     Output
 } from "@angular/core";
 
+import { cloneObject } from "../../core/utils";
 import { DataUtil } from "../../data-operations/data-util";
 
 import { ExportUtilities } from "./export-utilities";
@@ -178,7 +179,7 @@ export abstract class IgxBaseExporter {
                 expressions: grid.sortingExpressions
             };
 
-            this._sort = grid.sortingExpressions[0];
+            this._sort = cloneObject(grid.sortingExpressions[0]);
 
             data =  DataUtil.sort(data, sortingState);
         }

--- a/src/services/exporter-common/components-declarations.ts
+++ b/src/services/exporter-common/components-declarations.ts
@@ -2,8 +2,6 @@ import { Component, ViewChild } from "@angular/core";
 import { IgxGridComponent } from "../../grid/grid.component";
 import { ExportTestDataService } from "../excel/test-data.service";
 
-const sampleData = new ExportTestDataService().simpleGridData;
-
 @Component({
     template: `
     <igx-grid #grid1 [data]="data">


### PR DESCRIPTION
Closes #1314 Closes #1315 

Clone the grid sort expression in order to prevent changes in it, while exporting, to affect the grid.