### PR TITLE
fix(igxGrid): sync for column widths to the minimum dom width they can take #1293

### DIFF
--- a/src/grid/grid.component.ts
+++ b/src/grid/grid.component.ts
@@ -48,6 +48,7 @@ let NEXT_ID = 0;
 const DEBOUNCE_TIME = 16;
 const DEFAULT_SUMMARY_HEIGHT = 36.36;
 const MINIMUM_COLUMN_WIDTH = 136;
+const MINIMUM_DOM_COLUMN_WIDTH = 50;
 
 export interface IGridCellEventArgs {
     cell: IgxGridCellComponent;
@@ -1040,6 +1041,10 @@ export class IgxGridComponent implements OnInit, OnDestroy, AfterContentInit, Af
             column.index = index;
             if (!column.width) {
                 column.width = this.columnWidth;
+            }
+            if (column.width !== null &&
+                (typeof column.width === "number" || column.width.endsWith("px"))) {
+                column.width = Math.max(parseInt(column.width, 10), MINIMUM_DOM_COLUMN_WIDTH) + "px";
             }
             if (cb) {
                 cb(column);

--- a/src/grid/grid.pinning.spec.ts
+++ b/src/grid/grid.pinning.spec.ts
@@ -519,6 +519,7 @@ describe("IgxGrid - Column Pinning ", () => {
         expect(grid.pinnedColumns.length).toEqual(1);
         expect(grid.unpinnedColumns.length).toEqual(9);
     });
+
     it("should allow hiding columns in the unpinned area.", () => {
 
         const fix = TestBed.createComponent(GridPinningComponent);
@@ -602,7 +603,19 @@ describe("IgxGrid - Column Pinning ", () => {
         expect(grid.columns[6].pinned).toBe(true);
         expect(grid.unpinnedWidth).toBeGreaterThanOrEqual(grid.unpinnedAreaMinWidth);
     });
+
+    it("should not misalign the scrollbar when columns are narrower than possible", () => {
+        const fix = TestBed.createComponent(GridPinningComponent);
+        const grid = fix.componentInstance.instance;
+        fix.componentInstance.columns[1].width = 15;
+        fix.detectChanges();
+        grid.columns[1].pin();
+        fix.detectChanges();
+        const cell = grid.getCellByColumn(0, "CompanyName");
+        expect(grid.pinnedWidth).toEqual(cell.nativeElement.getBoundingClientRect().width);
+    });
 });
+
 @Component({
     template: `
         <igx-grid


### PR DESCRIPTION
Closes #1293 .  

This is a fix suggestion which has the drawback of having to specify this minimum width in the code with a constant (and there will be another with the dense theme). However, applying a custom style that reduces the paddings will make this code wrong.

Another approach could be to get the width with something like `getBoundingClientRect` once a cell from the column is rendered but that's not particularly angular-ish.

We could also just have this as a limitation - that columns should not have widths specified that are lower than the total width of paddings and borders.

@rkaraivanov @kdinev what do you think?

