### PR TITLE
build(watcher): use parent stdio and wrap process in try-catch

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,9 @@ const sourcemaps = require('gulp-sourcemaps');
 const postcss = require('gulp-postcss');
 const process = require('process');
 const fs = require('fs');
-const spawn = require('child_process').spawn;
+const {
+    spawn
+} = require('child_process');
 
 const STYLES = {
     SRC: './projects/igniteui-angular/src/lib/core/styles/themes/presets/*',
@@ -91,12 +93,15 @@ gulp.task('copy-git-hooks', () => {
 });
 
 gulp.task('watch', () => {
-    gulp.watch('./projects/igniteui-angular/src/lib/**/*', (e) => {
-        let child = spawn('npm', ['run', 'build:lib'], {
-            cwd: process.cwd()
-        });
-
-        child.stdout.on('data', data => console.info(data.toString()));
-        child.stderr.on('data', data => console.error(data.toString()));
+    gulp.watch('./projects/igniteui-angular/src/lib/**/*', () => {
+        try {
+            let child = spawn('npm run build:lib', {
+                stdio: 'inherit',
+                shell: true,
+                cwd: process.cwd()
+            });
+        } catch (err) {
+            console.error(`Exception: ${err}`);
+        }
     });
 });


### PR DESCRIPTION
When the child process emits the error it will exit, terminating the parent build process as a result. To fix that try to catch errors when spawning a new child process on file change. The child process now also inherits the stdio from its parent process to preserve I/O buffers. Also use current shell when spawning the child instance.
