### PR TITLE
fix(igxGrid): When the summaries are enabled for all the columns, if …

### DIFF
--- a/projects/igniteui-angular/src/lib/grid/grid.component.html
+++ b/projects/igniteui-angular/src/lib/grid/grid.component.html
@@ -94,6 +94,9 @@
 
 <div class="igx-grid__tfoot" role="rowgroup" [style.width.px]='calcWidth' #tfoot>
     <div *ngIf="hasSummarizedColumns" class="igx-grid__summaries" [style.height.px]="summariesHeight" [style.marginLeft.px]="summariesMargin" role="row" #summaries>
+        <ng-container *ngIf="groupingExpressions.length > 0">
+            <div class="igx-grid__row-indentation igx-grid__row-indentation--level-{{groupingExpressions.length}}"></div>
+        </ng-container>
         <ng-container *ngIf="pinnedColumns.length > 0">
             <igx-grid-summary [gridID]="id" *ngFor="let col of pinnedColumns"  [column]="col" [style.min-width.px]="col.width" [style.flex-basis.px]='col.width'></igx-grid-summary>
         </ng-container>


### PR DESCRIPTION
…a user groups by a column, the summaries get displaced to the left.

Related to #1408
