### PR TITLE
test(igxOverlay): add test for component with 100% width / height, #1685

### DIFF
--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -1746,6 +1746,26 @@ describe('igxOverlay', () => {
         xit('Css should not leak: From shown components to igx-overlay.', () => {
             // TO DO
         });
+
+        it('Components with 100% width/height should use their initial container\'s properties when placed inside of the overlay element',
+        fakeAsync(() => {
+            const fixture = TestBed.createComponent(WidthTestOverlayComponent);
+            fixture.detectChanges();
+            expect(fixture.componentInstance.customComponent).toBeDefined();
+            expect(fixture.componentInstance.customComponent.nativeElement.style.width).toEqual('100%');
+            expect(fixture.componentInstance.customComponent.nativeElement.getBoundingClientRect().width).toEqual(420);
+            expect(fixture.componentInstance.customComponent.nativeElement.style.height).toEqual('100%');
+            expect(fixture.componentInstance.customComponent.nativeElement.getBoundingClientRect().height).toEqual(280);
+            fixture.componentInstance.buttonElement.nativeElement.click();
+            tick();
+            const overlayContent = document.getElementsByClassName(CLASS_OVERLAY_CONTENT)[0] as HTMLElement;
+            const overlayChild = overlayContent.lastElementChild as HTMLElement;
+            expect(overlayChild).toBeDefined();
+            expect(overlayChild.style.width).toEqual('100%');
+            expect(overlayChild.getBoundingClientRect().width).toEqual(420);
+            expect(overlayChild.style.height).toEqual('100%');
+            expect(overlayChild.getBoundingClientRect().height).toEqual(280);
+        }));
     });
 });
 
@@ -1867,13 +1887,49 @@ export class TopLeftOffsetComponent {
     }
 }
 
+@Component({
+    template: `<div style="width: 420px; height: 280px;">
+    <button class='300_button' igxToggle #button (click)=\'click($event)\'>Show Overlay</button>
+        <div #myCustomComponent class="customList" style="width: 100%; height: 100%;">
+            Some Content
+        </div>
+    <div>`,
+    styles: [`button {
+        position: absolute;
+        top: 300px;
+        left: 300px;
+        width: 100px;
+        height: 60px;
+        border: 0px;
+    }`]
+})
+export class WidthTestOverlayComponent {
+
+    constructor(@Inject(IgxOverlayService) public overlay: IgxOverlayService) { }
+
+    @ViewChild('button') buttonElement: ElementRef;
+    @ViewChild('myCustomComponent') customComponent: ElementRef;
+    click(event) {
+        const overlaySettings: OverlaySettings = {
+            positionStrategy: new ConnectedPositioningStrategy(),
+            scrollStrategy: new NoOpScrollStrategy(),
+            closeOnOutsideClick: true,
+            modal: false
+        };
+
+        overlaySettings.positionStrategy.settings.target = this.buttonElement.nativeElement;
+        this.overlay.show(this.customComponent, overlaySettings);
+    }
+}
+
 const DYNAMIC_COMPONENTS = [
     EmptyPageComponent,
     SimpleRefComponent,
     SimpleDynamicComponent,
     SimpleBigSizeComponent,
     DownRightButtonComponent,
-    TopLeftOffsetComponent
+    TopLeftOffsetComponent,
+    WidthTestOverlayComponent
 ];
 
 const DIRECTIVE_COMPONENTS = [

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -695,8 +695,10 @@ describe('igxOverlay', () => {
                 const componentEl = overlayWrapper.children[0].children[0];
                 const wrapperRect = overlayWrapper.getBoundingClientRect();
                 const componentRect = componentEl.getBoundingClientRect();
-                expect(wrapperRect.width / 2).toEqual(componentRect.left);
-                expect(wrapperRect.height / 2).toEqual(componentRect.top);
+                expect(componentRect.left).toBeLessThan(0);
+                expect(wrapperRect.width / 2).toEqual(componentRect.left + componentRect.width / 2);
+                expect(componentRect.top).toBeLessThan(0);
+                expect(wrapperRect.height / 2).toEqual(componentRect.top + componentRect.height / 2);
                 hasScrollbar = document.body.scrollHeight > document.body.clientHeight;
                 expect(hasScrollbar).toBeTruthy();
             });

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -645,23 +645,21 @@ describe('igxOverlay', () => {
             }
         }));
 
-        it('The shown component is in the center of igx-overlay (visible window) - default.', () => {
+        it('The shown component is in the center of igx-overlay (visible window) - default.', fakeAsync(() => {
             const fixture = TestBed.createComponent(EmptyPageComponent);
             fixture.detectChanges();
             fixture.componentInstance.overlay.show(SimpleDynamicComponent);
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                const overlayDiv = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
-                const overlayWrapper = overlayDiv.children[0] as HTMLElement;
-                const componentEl = overlayWrapper.children[0].children[0];
-                const wrapperRect = overlayWrapper.getBoundingClientRect();
-                const componentRect = componentEl.getBoundingClientRect();
-                expect(wrapperRect.width / 2).toEqual(componentRect.left);
-                expect(wrapperRect.height / 2).toEqual(componentRect.top);
-                expect(componentRect.left).toEqual(componentRect.right - componentRect.width);
-                expect(componentRect.top).toEqual(componentRect.bottom - componentRect.height);
-            });
-        });
+            tick();
+            const overlayDiv = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
+            const overlayWrapper = overlayDiv.children[0] as HTMLElement;
+            const componentEl = overlayWrapper.children[0].children[0];
+            const wrapperRect = overlayWrapper.getBoundingClientRect();
+            const componentRect = componentEl.getBoundingClientRect();
+            expect(wrapperRect.width / 2 - componentRect.width / 2).toEqual(componentRect.left);
+            expect(wrapperRect.height / 2 - componentRect.height / 2).toEqual(componentRect.top);
+            expect(componentRect.left).toEqual(componentRect.right - componentRect.width);
+            expect(componentRect.top).toEqual(componentRect.bottom - componentRect.height);
+        }));
 
         it('When adding a new instance of a component with the same options, it is rendered exactly on top of the previous one.', () => {
             const fixture = TestBed.createComponent(EmptyPageComponent);
@@ -1748,24 +1746,24 @@ describe('igxOverlay', () => {
         });
 
         it('Components with 100% width/height should use their initial container\'s properties when placed inside of the overlay element',
-        fakeAsync(() => {
-            const fixture = TestBed.createComponent(WidthTestOverlayComponent);
-            fixture.detectChanges();
-            expect(fixture.componentInstance.customComponent).toBeDefined();
-            expect(fixture.componentInstance.customComponent.nativeElement.style.width).toEqual('100%');
-            expect(fixture.componentInstance.customComponent.nativeElement.getBoundingClientRect().width).toEqual(420);
-            expect(fixture.componentInstance.customComponent.nativeElement.style.height).toEqual('100%');
-            expect(fixture.componentInstance.customComponent.nativeElement.getBoundingClientRect().height).toEqual(280);
-            fixture.componentInstance.buttonElement.nativeElement.click();
-            tick();
-            const overlayContent = document.getElementsByClassName(CLASS_OVERLAY_CONTENT)[0] as HTMLElement;
-            const overlayChild = overlayContent.lastElementChild as HTMLElement;
-            expect(overlayChild).toBeDefined();
-            expect(overlayChild.style.width).toEqual('100%');
-            expect(overlayChild.getBoundingClientRect().width).toEqual(420);
-            expect(overlayChild.style.height).toEqual('100%');
-            expect(overlayChild.getBoundingClientRect().height).toEqual(280);
-        }));
+            fakeAsync(() => {
+                const fixture = TestBed.createComponent(WidthTestOverlayComponent);
+                fixture.detectChanges();
+                expect(fixture.componentInstance.customComponent).toBeDefined();
+                expect(fixture.componentInstance.customComponent.nativeElement.style.width).toEqual('100%');
+                expect(fixture.componentInstance.customComponent.nativeElement.getBoundingClientRect().width).toEqual(420);
+                expect(fixture.componentInstance.customComponent.nativeElement.style.height).toEqual('100%');
+                expect(fixture.componentInstance.customComponent.nativeElement.getBoundingClientRect().height).toEqual(280);
+                fixture.componentInstance.buttonElement.nativeElement.click();
+                tick();
+                const overlayContent = document.getElementsByClassName(CLASS_OVERLAY_CONTENT)[0] as HTMLElement;
+                const overlayChild = overlayContent.lastElementChild as HTMLElement;
+                expect(overlayChild).toBeDefined();
+                expect(overlayChild.style.width).toEqual('100%');
+                expect(overlayChild.getBoundingClientRect().width).toEqual(420);
+                expect(overlayChild.style.height).toEqual('100%');
+                expect(overlayChild.getBoundingClientRect().height).toEqual(280);
+            }));
     });
 });
 

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
@@ -87,6 +87,8 @@ export class IgxOverlayService {
         }
 
         this._overlays.find(c => c.id === id).initialSize = size as DOMRect;
+        contentElement.style.width = size.width + 'px';
+        contentElement.style.height = size.height + 'px';
         overlaySettings.positionStrategy.position(contentElement, size, document, true);
         const animationBuilder = this.builder.build(overlaySettings.positionStrategy.settings.openAnimation);
         const animationPlayer = animationBuilder.create(element);


### PR DESCRIPTION
Closes #1685.  

Add initially measure width and height to overlay_content to assure that the shown element still wraps width and height if they are set to 100%.

