### PR TITLE
Overlay tests cleaup and async

### DIFF
--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -1029,6 +1029,7 @@ describe('igxOverlay', () => {
             expect(elementRect).toEqual(element.getBoundingClientRect());
             expect(document.documentElement.scrollTop).toEqual(100);
             expect(document.documentElement.scrollLeft).toEqual(50);
+            document.body.removeChild(dummy);
         }));
 
         it('closingScrollStrategy: no scrolling possible. The component changes ' +
@@ -1255,6 +1256,7 @@ describe('igxOverlay', () => {
                     expect(contentWrapper.style.left).toBe(expectedLeftForPoint[i]);
                 }
             }
+            document.body.removeChild(contentWrapper);
         });
 
         it('Connected strategy position method. Position component based on Element', () => {
@@ -1303,6 +1305,7 @@ describe('igxOverlay', () => {
                     }
                 }
             }
+            document.body.removeChild(contentWrapper);
         });
 
         // 1.3 AutoPosition (fit the shown component into the visible window.)

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -581,13 +581,14 @@ describe('igxOverlay', () => {
 
             overlayDiv = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
             expect(overlayDiv).toBeDefined();
+            fixture.componentInstance.hide();
         }));
     });
 
     describe('Integration tests: ', () => {
         // 1. Positioning Strategies
         // 1.1 Global (show components in the window center - default).
-        it('igx-overlay is rendered on top of all other views/components (any previously existing html on the page) etc.', () => {
+        it('igx-overlay is rendered on top of all other views/components (any previously existing html on the page) etc.', fakeAsync(() => {
             const fixture = TestBed.createComponent(EmptyPageComponent);
             fixture.detectChanges();
             const overlaySettings: OverlaySettings = {
@@ -605,13 +606,12 @@ describe('igxOverlay', () => {
             };
             overlaySettings.positionStrategy = new GlobalPositionStrategy(positionSettings);
             fixture.componentInstance.overlay.show(SimpleDynamicComponent, overlaySettings);
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                const overlayDiv = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
-                const wrapper = overlayDiv.children[0];
-                expect(wrapper.classList).toContain(CLASS_OVERLAY_WRAPPER);
-            });
-        });
+            tick();
+            fixture.detectChanges();
+            const overlayDiv = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
+            const wrapper = overlayDiv.children[0];
+            expect(wrapper.classList).toContain(CLASS_OVERLAY_WRAPPER);
+        }));
 
         it('igx-overlay covers the whole window 100% width and height', () => {
             const fixture = TestBed.createComponent(EmptyPageComponent);
@@ -705,48 +705,44 @@ describe('igxOverlay', () => {
             expect(componentRect.top).toEqual(componentRect.bottom - componentRect.height);
         }));
 
-        it('When adding a new instance of a component with the same options, it is rendered exactly on top of the previous one.', () => {
+        it('should display a new instance of the same component/options exactly on top of the previous one.', fakeAsync(() => {
             const fixture = TestBed.createComponent(EmptyPageComponent);
             fixture.detectChanges();
             fixture.componentInstance.overlay.show(SimpleDynamicComponent);
             fixture.componentInstance.overlay.show(SimpleDynamicComponent);
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                const overlayDiv = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
-                const overlayWrapper_1 = overlayDiv.children[0];
-                const componentEl_1 = overlayWrapper_1.children[0].children[0];
-                const overlayWrapper_2 = overlayDiv.children[1];
-                const componentEl_2 = overlayWrapper_2.children[0].children[0];
-                const componentRect_1 = componentEl_1.getBoundingClientRect();
-                const componentRect_2 = componentEl_2.getBoundingClientRect();
-                expect(componentRect_1.left).toEqual(componentRect_2.left);
-                expect(componentRect_1.top).toEqual(componentRect_2.top);
-                expect(componentRect_1.width).toEqual(componentRect_2.width);
-                expect(componentRect_1.height).toEqual(componentRect_2.height);
-            });
-        });
+            tick();
+            const overlayDiv = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
+            const overlayWrapper_1 = overlayDiv.children[0];
+            const componentEl_1 = overlayWrapper_1.children[0].children[0];
+            const overlayWrapper_2 = overlayDiv.children[1];
+            const componentEl_2 = overlayWrapper_2.children[0].children[0];
+            const componentRect_1 = componentEl_1.getBoundingClientRect();
+            const componentRect_2 = componentEl_2.getBoundingClientRect();
+            expect(componentRect_1.left).toEqual(componentRect_2.left);
+            expect(componentRect_1.top).toEqual(componentRect_2.top);
+            expect(componentRect_1.width).toEqual(componentRect_2.width);
+            expect(componentRect_1.height).toEqual(componentRect_2.height);
+        }));
 
-        it('If the shown component is bigger than the visible window, than it should be centered and scrollbars should appear.', () => {
+        it('should show a component bigger than the visible window as centered and scrollbars should appear', fakeAsync(() => {
             const fixture = TestBed.createComponent(EmptyPageComponent);
             fixture.detectChanges();
             let hasScrollbar = document.body.scrollHeight > document.body.clientHeight;
             expect(hasScrollbar).toBeFalsy();
             fixture.componentInstance.overlay.show(SimpleBigSizeComponent);
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                const overlayDiv = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
-                const overlayWrapper = overlayDiv.children[0];
-                const componentEl = overlayWrapper.children[0].children[0];
-                const wrapperRect = overlayWrapper.getBoundingClientRect();
-                const componentRect = componentEl.getBoundingClientRect();
-                expect(componentRect.left).toBeLessThan(0);
-                expect(wrapperRect.width / 2).toEqual(componentRect.left + componentRect.width / 2);
-                expect(componentRect.top).toBeLessThan(0);
-                expect(wrapperRect.height / 2).toEqual(componentRect.top + componentRect.height / 2);
-                hasScrollbar = document.body.scrollHeight > document.body.clientHeight;
-                expect(hasScrollbar).toBeTruthy();
-            });
-        });
+            tick();
+            const overlayDiv = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
+            const overlayWrapper = overlayDiv.children[0];
+            const componentEl = overlayWrapper.children[0].children[0];
+            const wrapperRect = overlayWrapper.getBoundingClientRect();
+            const componentRect = componentEl.getBoundingClientRect();
+            expect(componentRect.left).toBeLessThan(0);
+            expect(wrapperRect.width / 2).toEqual(componentRect.left + componentRect.width / 2);
+            expect(componentRect.top).toBeLessThan(0);
+            expect(wrapperRect.height / 2).toEqual(componentRect.top + componentRect.height / 2);
+            hasScrollbar = document.body.scrollHeight > document.body.clientHeight;
+            expect(hasScrollbar).toBeTruthy();
+        }));
         // 1.1.1 Global Css
         it('css class should be applied on igx-overlay component div wrapper.' +
             'Test defaults: When no positionStrategy is passed use GlobalPositionStrategy with default PositionSettings and css class',
@@ -781,7 +777,7 @@ describe('igxOverlay', () => {
         }));
 
         // 1.2 ConnectedPositioningStrategy(show components based on a specified position base point, horizontal and vertical alignment)
-        it('igx-overlay is rendered on top of all other views/components (any previously existing html on the page) etc.', () => {
+        it('igx-overlay is rendered on top of all other views/components (any previously existing html on the page) etc.', fakeAsync(() => {
             const fixture = TestBed.createComponent(EmptyPageComponent);
             fixture.detectChanges();
             const overlaySettings: OverlaySettings = {
@@ -799,15 +795,13 @@ describe('igxOverlay', () => {
             };
             overlaySettings.positionStrategy = new ConnectedPositioningStrategy(positionSettings);
             fixture.componentInstance.overlay.show(SimpleDynamicComponent, overlaySettings);
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                const wrapper = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
-                expect(wrapper).toBeDefined();
-                expect(wrapper.classList).toContain(CLASS_OVERLAY_MAIN);
-            });
-        });
+            tick();
+            const wrapper = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
+            expect(wrapper).toBeDefined();
+            expect(wrapper.classList).toContain(CLASS_OVERLAY_MAIN);
+        }));
 
-        it('igx-overlay covers the whole window 100% width and height', () => {
+        it('igx-overlay covers the whole window 100% width and height', fakeAsync(() => {
             const fixture = TestBed.createComponent(EmptyPageComponent);
             fixture.detectChanges();
             const overlaySettings: OverlaySettings = {
@@ -825,14 +819,12 @@ describe('igxOverlay', () => {
             };
             overlaySettings.positionStrategy = new ConnectedPositioningStrategy(positionSettings);
             fixture.componentInstance.overlay.show(SimpleDynamicComponent, overlaySettings);
-            fixture.whenStable().then(() => {
-                fixture.detectChanges();
-                const wrapper = document.getElementsByClassName(CLASS_OVERLAY_WRAPPER)[0];
-                const body = document.getElementsByTagName('body')[0];
-                expect(wrapper.clientHeight).toEqual(body.clientHeight);
-                expect(wrapper.clientWidth).toEqual(body.clientWidth);
-            });
-        });
+            tick();
+            const wrapper = document.getElementsByClassName(CLASS_OVERLAY_WRAPPER)[0];
+            const body = document.getElementsByTagName('body')[0];
+            expect(wrapper.clientHeight).toEqual(body.clientHeight);
+            expect(wrapper.clientWidth).toEqual(body.clientWidth);
+        }));
 
         it('The shown component is inside the igx-overlay wrapper as a content last child.', fakeAsync(() => {
             const fixture = TestBed.createComponent(EmptyPageComponent);
@@ -1697,6 +1689,7 @@ describe('igxOverlay', () => {
             expect(elementRect).toEqual(element.getBoundingClientRect());
             expect(document.documentElement.scrollTop).toEqual(100);
             expect(document.documentElement.scrollLeft).toEqual(50);
+            overlay.hideAll();
         }));
 
         xit('The component shown in igx-overlay do not close.(example: expanded DropDown stays expanded during a scrolling attempt.)',
@@ -1812,6 +1805,7 @@ describe('igxOverlay', () => {
                 expect(overlayChild.getBoundingClientRect().width).toEqual(420);
                 expect(overlayChild.style.height).toEqual('100%');
                 expect(overlayChild.getBoundingClientRect().height).toEqual(280);
+                fixture.componentInstance.overlay.hideAll();
             }));
     });
 });


### PR DESCRIPTION
Clean leftover elements in body, adjust async and hide overlays that would leave handlers after the test

