### PR TITLE
fix(grid): deny pinning column to another level area via api #1775

### DIFF
--- a/projects/igniteui-angular/src/lib/grid/column-group.spec.ts
+++ b/projects/igniteui-angular/src/lib/grid/column-group.spec.ts
@@ -805,7 +805,7 @@ describe('IgxGrid - multi-column headers', () => {
         expect(grid.rowList.first.cells.first.value).toMatch('Sales Representative');
         expect(grid.rowList.first.cells.toArray()[1].value).toMatch('Maria Anders');
         expect(grid.rowList.first.cells.toArray()[2].value).toMatch('Alfreds Futterkiste');
-        expect(grid.rowList.first.cells.toArray()[3].value).toMatch('ALFKI'); 
+        expect(grid.rowList.first.cells.toArray()[3].value).toMatch('ALFKI');
      });
 
      xit('Should move column group.', () => {

--- a/projects/igniteui-angular/src/lib/grid/grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grid/grid.component.ts
@@ -1099,6 +1099,9 @@ export class IgxGridComponent implements OnInit, OnDestroy, AfterContentInit, Af
     }
 
     public moveColumn(column: IgxColumnComponent, dropTarget: IgxColumnComponent) {
+        if (column.level !== dropTarget.level) {
+            return;
+        }
 
         if (column.level) {
             this._moveChildColumns(column.parent, column, dropTarget);


### PR DESCRIPTION
Closes #1775 
2nd Issue: Try to pin a child header into the pinned arera via API - should not be possible

- [x] bug fix
- [x] test