### PR TITLE
#1798 Should not persist combo scroll position

### DIFF
--- a/projects/igniteui-angular/src/lib/combo/combo-dropdown.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo-dropdown.component.ts
@@ -16,7 +16,6 @@ import { IgxForOfDirective } from '../directives/for-of/for_of.directive';
 })
 export class IgxComboDropDownComponent extends IgxDropDownBase {
     private _children: QueryList<IgxDropDownItemBase>;
-    private _scrollPosition = 0;
     constructor(
         protected elementRef: ElementRef,
         protected cdr: ChangeDetectorRef,
@@ -308,7 +307,6 @@ export class IgxComboDropDownComponent extends IgxDropDownBase {
      */
     onToggleOpened() {
         this.parentElement.triggerCheck();
-        this.verticalScrollContainer.getVerticalScroll().scrollTop = this._scrollPosition;
         this.parentElement.searchInput.nativeElement.focus();
         this.onOpened.emit();
     }
@@ -322,7 +320,7 @@ export class IgxComboDropDownComponent extends IgxDropDownBase {
     }
 
     onToggleClosing() {
+        this.verticalScrollContainer.scrollTo(0);
         super.onToggleClosing();
-        this._scrollPosition = this.verticalScrollContainer.getVerticalScroll().scrollTop;
     }
 }

--- a/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
@@ -500,7 +500,7 @@ describe('igxCombo', () => {
             tick();
             expect(combo.collapsed).toEqual(true);
         }));
-        it('Should restore position of dropdown scroll after opening', fakeAsync(() => {
+        it('Should NOT restore position of dropdown scroll after opening', fakeAsync(() => {
             const fix = TestBed.createComponent(IgxComboSampleComponent);
             fix.detectChanges();
             const combo = fix.componentInstance.combo;
@@ -531,7 +531,7 @@ describe('igxCombo', () => {
             expect(combo.dropdown.onToggleOpening).toHaveBeenCalledTimes(2);
             expect(combo.dropdown.onToggleOpened).toHaveBeenCalledTimes(2);
             vContainerScrollHeight = combo.dropdown.verticalScrollContainer.getVerticalScroll().scrollHeight;
-            expect(combo.dropdown.verticalScrollContainer.getVerticalScroll().scrollTop).toEqual(vContainerScrollHeight / 2);
+            expect(combo.dropdown.verticalScrollContainer.getVerticalScroll().scrollTop).toEqual(0);
         }));
         it('Dropdown button should open/close dropdown list', async(() => {
             const fixture = TestBed.createComponent(IgxComboTestComponent);
@@ -2785,7 +2785,7 @@ describe('igxCombo', () => {
         expect(combo.collapsed).toEqual(true);
     }));
 
-    it('Should restore position of dropdown scroll after opening', fakeAsync(() => {
+    it('Should NOT restore position of dropdown scroll after opening', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxComboSampleComponent);
         fix.detectChanges();
         const combo = fix.componentInstance.combo;
@@ -2816,7 +2816,7 @@ describe('igxCombo', () => {
         expect(combo.dropdown.onToggleOpening).toHaveBeenCalledTimes(2);
         expect(combo.dropdown.onToggleOpened).toHaveBeenCalledTimes(2);
         vContainerScrollHeight = combo.dropdown.verticalScrollContainer.getVerticalScroll().scrollHeight;
-        expect(combo.dropdown.verticalScrollContainer.getVerticalScroll().scrollTop).toEqual(vContainerScrollHeight / 2);
+        expect(combo.dropdown.verticalScrollContainer.getVerticalScroll().scrollTop).toEqual(0);
     }));
 
     it(`Should handle enter keydown on "Add Item" properly`, async(() => {

--- a/src/app/combo/combo.sample.ts
+++ b/src/app/combo/combo.sample.ts
@@ -51,11 +51,11 @@ export class ComboSampleComponent implements OnInit {
             'West North Central 01': ['Missouri', 'Nebraska', 'North Dakota', 'South Dakota'],
             'West North Central 02': ['Iowa', 'Kansas', 'Minnesota'],
             'South Atlantic 01': ['Delaware', 'Florida', 'Georgia', 'Maryland'],
-            'South Atlantic 02': ['North Carolina', 'South Carolina', 'Virginia', 'District of Columbia', 'West Virginia'],
+            'South Atlantic 02': ['North Carolina', 'South Carolina', 'Virginia', 'West Virginia'],
             'South Atlantic 03': ['District of Columbia', 'West Virginia'],
             'East South Central 01': ['Alabama', 'Kentucky'],
             'East South Central 02': ['Mississippi', 'Tennessee'],
-            'West South Central': ['Arkansas', 'Louisiana', 'Oklahome', 'Texas'],
+            'West South Central': ['Arkansas', 'Louisiana', 'Oklahomа', 'Texas'],
             'Mountain': ['Arizona', 'Colorado', 'Idaho', 'Montana', 'Nevada', 'New Mexico', 'Utah', 'Wyoming'],
             'Pacific 01': ['Alaska', 'California'],
             'Pacific 02': ['Hawaii', 'Oregon', 'Washington']


### PR DESCRIPTION
Closes #1798 

Additional information related to this pull request:
When you scroll combo drop down, and then close it, then the scroll position will not be preserved.



