### PR TITLE
Add check for focusedItem in drop-down selectItem

### DIFF
--- a/projects/igniteui-angular/src/lib/drop-down/drop-down.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down.component.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ContentChildren, DebugElement, ViewChild, OnInit } from '@angular/core';
+import { Component, ContentChildren, DebugElement, ViewChild, OnInit, ElementRef } from '@angular/core';
 import { async, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -32,7 +32,8 @@ describe('IgxDropDown ', () => {
                 IgxDropDownTestDisabledAnyComponent,
                 IgxDropDownTestEmptyListComponent,
                 IgxDropDownWithScrollComponent,
-                DoubleIgxDropDownComponent
+                DoubleIgxDropDownComponent,
+                InputWithDropdownDirectiveComponent
             ],
             imports: [
                 IgxDropDownModule,
@@ -878,6 +879,42 @@ describe('IgxDropDown ', () => {
         expect(dropdown1.selectedItem).toEqual(dropdown1.items[5]);
         expect(dropdown2.selectedItem).toEqual(dropdown2.items[3]);
     }));
+
+    it('Should properly handle OnEnterKeyDown when the dropdown is not visible', fakeAsync(() => {
+        const fixture = TestBed.createComponent(InputWithDropdownDirectiveComponent);
+        fixture.detectChanges();
+        const dropdown = fixture.componentInstance.dropdown;
+        const inputElement = fixture.componentInstance.inputElement.nativeElement;
+        expect(dropdown).toBeDefined();
+        expect(inputElement).toBeDefined();
+        expect(dropdown.focusedItem).toEqual(null);
+        expect(dropdown.selectedItem).toEqual(null);
+        spyOn(dropdown, 'selectItem').and.callThrough();
+        expect(dropdown.selectItem).toHaveBeenCalledTimes(0);
+        expect(dropdown.collapsed).toEqual(true);
+        inputElement.click();
+        tick();
+        expect(dropdown.selectItem).toHaveBeenCalledTimes(0);
+        expect(dropdown.collapsed).toEqual(true);
+        expect(dropdown.focusedItem).toEqual(null);
+        inputElement.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
+        tick();
+        expect(dropdown.selectItem).toHaveBeenCalledTimes(1);
+        expect(dropdown.selectItem).toHaveBeenCalledWith(null);
+        expect(dropdown.selectedItem).toEqual(null);
+        expect(dropdown.collapsed).toEqual(true);
+        dropdown.toggle();
+        tick();
+        expect(dropdown.collapsed).toEqual(false);
+        expect(dropdown.focusedItem).toEqual(dropdown.items[0]);
+        const dropdownItem = dropdown.items[0];
+        inputElement.dispatchEvent(new KeyboardEvent('keydown', {key: 'Enter'}));
+        tick();
+        expect(dropdown.selectItem).toHaveBeenCalledTimes(2);
+        expect(dropdown.selectItem).toHaveBeenCalledWith(dropdownItem);
+        expect(dropdown.selectedItem).toEqual(dropdownItem);
+        expect(dropdown.collapsed).toEqual(true);
+    }));
 });
 
 @Component({
@@ -1131,4 +1168,27 @@ class DoubleIgxDropDownComponent implements OnInit {
             this.items.push({ field: 'Item ' + index });
         }
     }
+}
+
+@Component({
+    template: ` <input #inputElement [igxDropDownItemNavigation]="dropdownElement" class='test-input' type='text' value='Focus Me!'/>
+    <igx-drop-down #dropdownElement [width]="'400px'" [height]="'400px'">
+        <igx-drop-down-item *ngFor="let item of items">
+            {{ item.field }}
+        </igx-drop-down-item>
+    </igx-drop-down>`
+})
+class InputWithDropdownDirectiveComponent {
+    @ViewChild(IgxDropDownComponent, { read: IgxDropDownComponent })
+    public dropdown: IgxDropDownComponent;
+
+    @ViewChild(`inputElement`)
+    public inputElement: ElementRef;
+
+    public items: any[] = [
+        { field: 'Nav1' },
+        { field: 'Nav2' },
+        { field: 'Nav3' },
+        { field: 'Nav4' }
+    ];
 }

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down.component.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down.component.ts
@@ -450,14 +450,12 @@ export class IgxDropDownBase implements OnInit, IToggleView {
         }
     }
 
-    public selectItem(item?) {
-        if (!item) {
-            item = this._focusedItem ? this._focusedItem : null;
+    public selectItem(item: IgxDropDownItemBase) {
+        if (item === null) {
+            return;
         }
-        if (item) {
-            this.setSelectedItem(item.index);
-            this.toggleDirective.close();
-        }
+        this.setSelectedItem(item.index);
+        this.toggleDirective.close();
     }
 
     protected changeSelectedItem(newSelection?: IgxDropDownItemBase) {
@@ -566,7 +564,7 @@ export class IgxDropDownItemNavigationDirective {
             event.preventDefault();
             return;
         }
-        this.target.selectItem();
+        this.target.selectItem(this.target.focusedItem);
         event.preventDefault();
     }
 

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down.component.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down.component.ts
@@ -452,10 +452,12 @@ export class IgxDropDownBase implements OnInit, IToggleView {
 
     public selectItem(item?) {
         if (!item) {
-            item = this._focusedItem;
+            item = this._focusedItem ? this._focusedItem : null;
         }
-        this.setSelectedItem(this._focusedItem.index);
-        this.toggleDirective.close();
+        if (item) {
+            this.setSelectedItem(item.index);
+            this.toggleDirective.close();
+        }
     }
 
     protected changeSelectedItem(newSelection?: IgxDropDownItemBase) {


### PR DESCRIPTION
Closes #1895  .  

SelectItem was expecting that the drop-down would always be visible (and therefore it would have a focusedItem).
Add check to selectItem function in IgxDropDownComponent

