### PR TITLE
Combo - Add Item with groupKey properly handle grouping

### DIFF
--- a/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
@@ -2091,6 +2091,38 @@ describe('igxCombo', () => {
                 expect(document.activeElement).toEqual(combo.searchInput.nativeElement);
             });
         }));
+
+        it('Should properly add items to the defaultFallbackGroup', fakeAsync(() => {
+            const fix = TestBed.createComponent(IgxComboSampleComponent);
+            fix.detectChanges();
+            const combo = fix.componentInstance.combo;
+            combo.toggle();
+            tick();
+            const comboSearch = combo.searchInput.nativeElement;
+            const fallBackGroup = combo.defaultFallbackGroup;
+            const initialDataLength = combo.data.length + 0;
+            expect(combo.filteredData.filter((e) => e[combo.groupKey]  === undefined  )).toEqual([]);
+            combo.searchValue = 'My Custom Item 1';
+            tick();
+            combo.addItemToCollection();
+            tick();
+            combo.searchValue = 'My Custom Item 2';
+            combo.addItemToCollection();
+            tick();
+            combo.searchValue = 'My Custom Item 3';
+            combo.addItemToCollection();
+            tick();
+            combo.searchValue = 'My Custom Item';
+            comboSearch.value = 'My Custom Item';
+            comboSearch.dispatchEvent(new Event('input'));
+            fix.detectChanges();
+            tick();
+            debugger;
+            expect(combo.data.length).toEqual(initialDataLength + 3);
+            expect(combo.dropdown.items.length).toEqual(4); // Add Item button is included
+            expect(combo.dropdown.headers.length).toEqual(1);
+            expect(combo.dropdown.headers[0].element.nativeElement.innerText).toEqual(fallBackGroup);
+        }));
     });
 
     describe('Filtering tests: ', () => {

--- a/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
@@ -2117,7 +2117,6 @@ describe('igxCombo', () => {
             comboSearch.dispatchEvent(new Event('input'));
             fix.detectChanges();
             tick();
-            debugger;
             expect(combo.data.length).toEqual(initialDataLength + 3);
             expect(combo.dropdown.items.length).toEqual(4); // Add Item button is included
             expect(combo.dropdown.headers.length).toEqual(1);

--- a/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
@@ -2292,7 +2292,8 @@ describe('igxCombo', () => {
             expect(combo.data.length).toEqual(initialData.length + 1);
             expect(combo.onAddition.emit).toHaveBeenCalledTimes(1);
             expect(combo.data[combo.data.length - 1]).toEqual({
-                field: 'myItem'
+                field: 'myItem',
+                region: 'Other'
             });
             combo.onAddition.subscribe((e) => {
                 e.addedItem.region = 'exampleRegion';
@@ -2654,7 +2655,7 @@ describe('igxCombo', () => {
                 fix.detectChanges();
                 return fix.whenStable();
             }).then(() => {
-                expect(combo.selectedItems()).toEqual([{ field: 'New' }]);
+                expect(combo.selectedItems()).toEqual([{ field: 'New', region: 'Other'}]);
                 expect(combo.comboInput.nativeElement.value).toEqual('New');
                 fix.debugElement.query(By.css('.' + CSS_CLASS_CLEARBUTTON)).nativeElement.click(mockEvent);
                 return fix.whenStable();

--- a/projects/igniteui-angular/src/lib/combo/combo.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.ts
@@ -1054,6 +1054,9 @@ export class IgxComboComponent implements AfterViewInit, ControlValueAccessor, O
             [this.valueKey]: newValue,
             [this.displayKey]: newValue
         } : newValue;
+        if (this.groupKey || this.groupKey === 0) {
+            Object.assign(addedItem, { [this.groupKey] : this.defaultFallbackGroup});
+        }
         const oldCollection = this.data;
         const newCollection = [...this.data];
         newCollection.push(addedItem);

--- a/projects/igniteui-angular/src/lib/combo/combo.pipes.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.pipes.ts
@@ -84,10 +84,7 @@ export class IgxComboGroupingPipe implements PipeTransform {
         let currentHeader = null;
         for (let i = 0; i < collection.length; i++) {
             let insertFlag = 0;
-            if (!collection[i][groupKey] && currentHeader !== this.combo.defaultFallbackGroup) {
-                currentHeader = this.combo.defaultFallbackGroup;
-                insertFlag = 1;
-            } else if (currentHeader !== collection[i][groupKey]) {
+            if (currentHeader !== collection[i][groupKey]) {
                 currentHeader = collection[i][groupKey];
                 insertFlag = 1;
             }


### PR DESCRIPTION
Closes #1892 .  

Add the default falllback group of the combo to the object being added to the collection in addItemToCollection() instead of in the grouping pipe.

To verify in the Combo DevSample, first remove the onAddition() handler

