### PR TITLE
fix(git-hooks): throws when git is not initialized

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -44,7 +44,7 @@ gulp.task('build-style', () => {
 
 gulp.task('copy-git-hooks', () => {
 
-    if (process.env.TRAVIS || process.env.CI) {
+    if (process.env.TRAVIS || process.env.CI || !fs.existsSync('.git')) {
         return;
     }
 


### PR DESCRIPTION
Closes #2023

