### PR TITLE
refactor(themes): import ripple theme in ripple dependent components

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/card/_card-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/card/_card-theme.scss
@@ -194,7 +194,7 @@
         display: flex;
         flex-flow: row nowrap;
 
-        .igx-button--icon {
+        %igx-button--icon {
             color: --var($theme, 'actions-text-color');
         }
     }

--- a/projects/igniteui-angular/src/lib/core/styles/components/checkbox/_checkbox-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/checkbox/_checkbox-theme.scss
@@ -1,3 +1,6 @@
+@import '../ripple/ripple-theme';
+@import '../ripple/ripple-component';
+
 ////
 /// @group themes
 /// @access public

--- a/projects/igniteui-angular/src/lib/core/styles/components/radio/_radio-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/radio/_radio-theme.scss
@@ -1,3 +1,6 @@
+@import '../ripple/ripple-theme';
+@import '../ripple/ripple-component';
+
 ////
 /// @group themes
 /// @access public

--- a/projects/igniteui-angular/src/lib/core/styles/components/switch/_switch-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/switch/_switch-theme.scss
@@ -1,3 +1,6 @@
+@import '../ripple/ripple-theme';
+@import '../ripple/ripple-component';
+
 ////
 /// @group themes
 /// @access public


### PR DESCRIPTION
When using the igx-radio, igx-checkbox, or igx-switch themes on their own, the ripple Sass compiler complains of a missing igx-ripple-theme dependency. To remedy for that, the before-mentioned component themes now import the igx-ripple-theme and igx-ripple-component dependencies.  