### PR TITLE
Properly export icon component and service

### DIFF
--- a/projects/igniteui-angular/src/lib/icon/index.ts
+++ b/projects/igniteui-angular/src/lib/icon/index.ts
@@ -18,3 +18,6 @@ export class IgxIconModule {
         };
     }
 }
+
+export * from './icon.component';
+export * from './icon.service';

--- a/projects/igniteui-angular/src/public_api.ts
+++ b/projects/igniteui-angular/src/public_api.ts
@@ -62,7 +62,6 @@ export * from './lib/dialog/dialog.component';
 export * from './lib/drop-down/drop-down.component';
 export * from './lib/grid/index';
 export * from './lib/icon/index';
-export * from './lib/icon/icon.service';
 export * from './lib/input-group/index';
 export * from './lib/list/index';
 export * from './lib/navbar/navbar.component';


### PR DESCRIPTION
Closes #2072.  

IgxIconComponent wasn't properly exported and that causes warnings in visual editors (VS Code, Stackblitz, etc.)