### PR TITLE
slider - track min/maxValue when lower/upperBound is undefined #920

### DIFF
--- a/projects/igniteui-angular/src/lib/slider/slider.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/slider/slider.component.spec.ts
@@ -630,10 +630,6 @@ describe('IgxSlider', () => {
 
         const slider = fixture.componentInstance.slider;
 
-        fixture.componentInstance.slider.value = 5;
-        fixture.detectChanges();
-
-        expect(slider.value).toBe(5);
         expect(slider.minValue).toBe(0);
         expect(slider.maxValue).toBe(10);
         expect(slider.lowerBound).toBe(0);
@@ -644,14 +640,13 @@ describe('IgxSlider', () => {
         fixture.componentInstance.changeMaxValue(8);
         fixture.detectChanges();
 
-        expect(slider.value).toBe(5);
         expect(slider.minValue).toBe(5);
         expect(slider.maxValue).toBe(8);
         expect(slider.lowerBound).toBe(5);
         expect(slider.upperBound).toBe(8);
     });
 
-    it('should track min/maxValue and reset the value if lower/upperBound are undefined (issue #920)', () => {
+    it('should track min/maxValue and invalidate the value if lower/upperBound are undefined (issue #920)', () => {
         const fixture = TestBed.createComponent(SliderTestComponent);
         fixture.detectChanges();
 
@@ -689,9 +684,6 @@ describe('IgxSlider', () => {
 
         const slider = fixture.componentInstance.slider;
 
-        fixture.componentInstance.slider.value = 5;
-        fixture.detectChanges();
-
         fixture.componentInstance.slider.lowerBound = 3;
         fixture.componentInstance.slider.upperBound = 8;
         fixture.detectChanges();
@@ -701,7 +693,6 @@ describe('IgxSlider', () => {
         fixture.componentInstance.changeMaxValue(9);
         fixture.detectChanges();
 
-        expect(slider.value).toBe(5);
         expect(slider.minValue).toBe(2);
         expect(slider.maxValue).toBe(9);
         expect(slider.lowerBound).toBe(3);
@@ -716,18 +707,10 @@ describe('IgxSlider', () => {
         fixture.componentInstance.type = SliderType.RANGE;
         fixture.detectChanges();
 
-        fixture.componentInstance.slider.value = {
-            lower: 6,
-            upper: 8
-        };
-        fixture.detectChanges();
-
         expect(slider.minValue).toBe(0);
         expect(slider.maxValue).toBe(10);
         expect(slider.lowerBound).toBe(0);
         expect(slider.upperBound).toBe(10);
-        expect((slider.value as IRangeSliderValue).lower).toBe(6);
-        expect((slider.value as IRangeSliderValue).upper).toBe(8);
 
         fixture.componentInstance.changeMinValue(5);
         fixture.detectChanges();
@@ -738,11 +721,9 @@ describe('IgxSlider', () => {
         expect(slider.maxValue).toBe(8);
         expect(slider.lowerBound).toBe(5);
         expect(slider.upperBound).toBe(8);
-        expect((slider.value as IRangeSliderValue).lower).toBe(6);
-        expect((slider.value as IRangeSliderValue).upper).toBe(8);
     });
 
-    it('should track min/maxValue and reset the value if lower/upperBound are undefined - range slider (issue #920)', () => {
+    it('should track min/maxValue and invalidate the value if lower/upperBound are undefined - range slider (issue #920)', () => {
         const fixture = TestBed.createComponent(SliderTestComponent);
         fixture.detectChanges();
 

--- a/projects/igniteui-angular/src/lib/slider/slider.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/slider/slider.component.spec.ts
@@ -5,12 +5,13 @@ import {IgxSliderComponent, IgxSliderModule, IRangeSliderValue, SliderType} from
 
 declare var Simulator: any;
 
-describe('IgxSlider', () => {
+fdescribe('IgxSlider', () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             declarations: [
                 SliderInitializeTestComponent,
-                SliderMinMaxComponent
+                SliderMinMaxComponent,
+                SliderTestComponent
             ],
             imports: [
                 IgxSliderModule
@@ -622,6 +623,149 @@ describe('IgxSlider', () => {
         expect(slider.minValue).toEqual(fix.componentInstance.minValue);
         expect(slider.maxValue).toEqual(fix.componentInstance.maxValue);
     });
+
+    it('should track min/maxValue if lower/upperBound are undefined (issue #920)', () => {
+        const fixture = TestBed.createComponent(SliderTestComponent);
+        fixture.detectChanges();
+
+        const slider = fixture.componentInstance.slider;
+
+        fixture.componentInstance.slider.value = 5;
+        fixture.detectChanges();
+
+        expect(slider.value).toBe(5);
+        expect(slider.minValue).toBe(0);
+        expect(slider.maxValue).toBe(10);
+        expect(slider.lowerBound).toBe(0);
+        expect(slider.upperBound).toBe(10);
+
+        fixture.componentInstance.changeMinValue(5);
+        fixture.detectChanges();
+        fixture.componentInstance.changeMaxValue(8);
+        fixture.detectChanges();
+
+        expect(slider.value).toBe(5);
+        expect(slider.minValue).toBe(5);
+        expect(slider.maxValue).toBe(8);
+        expect(slider.lowerBound).toBe(5);
+        expect(slider.upperBound).toBe(8);
+    });
+
+    it('should track min/maxValue and reset the value if lower/upperBound are undefined (issue #920)', () => {
+        const fixture = TestBed.createComponent(SliderTestComponent);
+        fixture.detectChanges();
+
+        const slider = fixture.componentInstance.slider;
+
+        fixture.componentInstance.slider.value = 5;
+        fixture.detectChanges();
+
+        fixture.componentInstance.changeMinValue(6);
+        fixture.detectChanges();
+
+        expect(slider.value).toBe(6);
+        expect(slider.minValue).toBe(6);
+        expect(slider.maxValue).toBe(10);
+        expect(slider.lowerBound).toBe(6);
+        expect(slider.upperBound).toBe(10);
+
+        fixture.componentInstance.slider.value = 9;
+        fixture.detectChanges();
+        expect(slider.value).toBe(9);
+
+        fixture.componentInstance.changeMaxValue(8);
+        fixture.detectChanges();
+
+        expect(slider.value).toBe(8);
+        expect(slider.minValue).toBe(6);
+        expect(slider.maxValue).toBe(8);
+        expect(slider.lowerBound).toBe(6);
+        expect(slider.upperBound).toBe(8);
+    });
+
+    it('should stop tracking min/maxValue if lower/upperBound is set from outside (issue #920)', () => {
+        const fixture = TestBed.createComponent(SliderTestComponent);
+        fixture.detectChanges();
+
+        const slider = fixture.componentInstance.slider;
+
+        fixture.componentInstance.slider.value = 5;
+        fixture.detectChanges();
+
+        fixture.componentInstance.slider.lowerBound = 3;
+        fixture.componentInstance.slider.upperBound = 8;
+        fixture.detectChanges();
+
+        fixture.componentInstance.changeMinValue(2);
+        fixture.detectChanges();
+        fixture.componentInstance.changeMaxValue(9);
+        fixture.detectChanges();
+
+        expect(slider.value).toBe(5);
+        expect(slider.minValue).toBe(2);
+        expect(slider.maxValue).toBe(9);
+        expect(slider.lowerBound).toBe(3);
+        expect(slider.upperBound).toBe(8);
+    });
+
+    it('should track min/maxValue if lower/upperBound are undefined - range slider (issue #920)', () => {
+        const fixture = TestBed.createComponent(SliderTestComponent);
+        fixture.detectChanges();
+
+        const slider = fixture.componentInstance.slider;
+        fixture.componentInstance.type = SliderType.RANGE;
+        fixture.detectChanges();
+
+        fixture.componentInstance.slider.value = {
+            lower: 6,
+            upper: 8
+        };
+        fixture.detectChanges();
+
+        expect(slider.minValue).toBe(0);
+        expect(slider.maxValue).toBe(10);
+        expect(slider.lowerBound).toBe(0);
+        expect(slider.upperBound).toBe(10);
+        expect((slider.value as IRangeSliderValue).lower).toBe(6);
+        expect((slider.value as IRangeSliderValue).upper).toBe(8);
+
+        fixture.componentInstance.changeMinValue(5);
+        fixture.detectChanges();
+        fixture.componentInstance.changeMaxValue(8);
+        fixture.detectChanges();
+
+        expect(slider.minValue).toBe(5);
+        expect(slider.maxValue).toBe(8);
+        expect(slider.lowerBound).toBe(5);
+        expect(slider.upperBound).toBe(8);
+        expect((slider.value as IRangeSliderValue).lower).toBe(6);
+        expect((slider.value as IRangeSliderValue).upper).toBe(8);
+    });
+
+    it('should track min/maxValue and reset the value if lower/upperBound are undefined - range slider (issue #920)', () => {
+        const fixture = TestBed.createComponent(SliderTestComponent);
+        fixture.detectChanges();
+
+        const slider = fixture.componentInstance.slider;
+        fixture.componentInstance.type = SliderType.RANGE;
+        fixture.detectChanges();
+
+        fixture.componentInstance.slider.value = {
+            lower: 2,
+            upper: 9
+        };
+
+        fixture.componentInstance.changeMinValue(5);
+        fixture.componentInstance.changeMaxValue(7);
+        fixture.detectChanges();
+
+        expect(slider.minValue).toBe(5);
+        expect(slider.maxValue).toBe(7);
+        expect(slider.lowerBound).toBe(5);
+        expect(slider.upperBound).toBe(7);
+        expect((slider.value as IRangeSliderValue).lower).toBe(5);
+        expect((slider.value as IRangeSliderValue).upper).toBe(7);
+    });
 });
 @Component({
     selector: 'igx-slider-test-component',
@@ -642,4 +786,29 @@ export class SliderMinMaxComponent {
 
     public minValue = 150;
     public maxValue = 300;
+}
+
+@Component({
+    selector: 'igx-slider-test-component',
+    template: `<div>
+                    <igx-slider #slider [minValue]="minValue"
+                                        [maxValue]="maxValue"
+                                        [type]="type">
+                    </igx-slider>
+                </div>`
+})
+class SliderTestComponent {
+    @ViewChild(IgxSliderComponent) public slider: IgxSliderComponent;
+
+    minValue = 0;
+    maxValue = 10;
+    type = SliderType.SLIDER;
+
+    changeMinValue(val: number) {
+        this.minValue = val;
+    }
+
+    changeMaxValue(val: number) {
+        this.maxValue = val;
+    }
 }

--- a/projects/igniteui-angular/src/lib/slider/slider.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/slider/slider.component.spec.ts
@@ -5,7 +5,7 @@ import {IgxSliderComponent, IgxSliderModule, IRangeSliderValue, SliderType} from
 
 declare var Simulator: any;
 
-fdescribe('IgxSlider', () => {
+describe('IgxSlider', () => {
     beforeEach(async(() => {
         TestBed.configureTestingModule({
             declarations: [

--- a/projects/igniteui-angular/src/lib/slider/slider.component.ts
+++ b/projects/igniteui-angular/src/lib/slider/slider.component.ts
@@ -177,6 +177,8 @@ export class IgxSliderComponent implements ControlValueAccessor, OnInit, AfterVi
     private _upperBound?: number;
     private _lowerValue: number;
     private _upperValue: number;
+    private _trackUpperBound: boolean;
+    private _trackLowerBound: boolean;
 
     private _onChangeCallback: (_: any) => void = noop;
     private _onTouchedCallback: () => void = noop;
@@ -226,11 +228,14 @@ export class IgxSliderComponent implements ControlValueAccessor, OnInit, AfterVi
     public set maxValue(value: number) {
         if (value <= this._minValue) {
             this._maxValue = this._minValue + 1;
-
-            return;
+        } else {
+            this._maxValue = value;
         }
 
-        this._maxValue = value;
+        if (this._trackUpperBound) {
+            this._upperBound = this._maxValue;
+        }
+        this.resetValue();
     }
 
     /**
@@ -258,10 +263,14 @@ export class IgxSliderComponent implements ControlValueAccessor, OnInit, AfterVi
     public set minValue(value: number) {
         if (value >= this.maxValue) {
             this._minValue = this.maxValue - 1;
-            return;
+        } else {
+            this._minValue = value;
         }
 
-        this._minValue = value;
+        if (this._trackLowerBound) {
+            this._lowerBound = this._minValue;
+        }
+        this.resetValue();
     }
 
     /**
@@ -287,6 +296,10 @@ export class IgxSliderComponent implements ControlValueAccessor, OnInit, AfterVi
      */
     @Input()
     public set lowerBound(value: number) {
+        if (this._trackLowerBound) {
+            this._trackLowerBound = false;
+        }
+
         if (value >= this.upperBound) {
             this._lowerBound = this.minValue;
             return;
@@ -318,6 +331,10 @@ export class IgxSliderComponent implements ControlValueAccessor, OnInit, AfterVi
      */
     @Input()
     public set upperBound(value: number) {
+        if (this._trackUpperBound) {
+            this._trackUpperBound = false;
+        }
+
         if (value <= this.lowerBound) {
             this._upperBound = this.maxValue;
 
@@ -463,10 +480,12 @@ export class IgxSliderComponent implements ControlValueAccessor, OnInit, AfterVi
     public ngOnInit() {
         if (this.lowerBound === undefined) {
             this.lowerBound = this.minValue;
+            this._trackLowerBound = true;
         }
 
         if (this.upperBound === undefined) {
             this.upperBound = this.maxValue;
+            this._trackUpperBound = true;
         }
 
         if (this.isRange) {
@@ -698,6 +717,54 @@ export class IgxSliderComponent implements ControlValueAccessor, OnInit, AfterVi
             () => this.isActiveLabel = false,
             this.thumbLabelVisibilityDuration
         );
+    }
+
+    private resetValue() {
+        if (!this.isRange) {
+            if (this.value >= this._lowerBound && this.value <= this._upperBound) {
+                this.value = this.value;
+            } else if (this.value < this._lowerBound) {
+                this.value = this._lowerBound;
+            } else if (this.value > this._upperBound) {
+                this.value = this._upperBound;
+            }
+        } else {
+            if ((this.value as IRangeSliderValue).lower >= this._lowerBound &&
+                (this.value as IRangeSliderValue).lower <= this._upperBound) {
+                    this.value = {
+                        lower: (this.value as IRangeSliderValue).lower,
+                        upper: (this.value as IRangeSliderValue).upper
+                    };
+            } else if ((this.value as IRangeSliderValue).lower < this._lowerBound) {
+                this.value = {
+                    lower: this._lowerBound,
+                    upper: (this.value as IRangeSliderValue).upper
+                };
+            } else if ((this.value as IRangeSliderValue).lower > this._upperBound) {
+                this.value = {
+                    lower: (this.value as IRangeSliderValue).lower,
+                    upper: this._upperBound
+                };
+            }
+
+            if ((this.value as IRangeSliderValue).upper >= this._lowerBound &&
+                (this.value as IRangeSliderValue).upper <= this._upperBound) {
+                    this.value = {
+                        lower: (this.value as IRangeSliderValue).lower,
+                        upper: (this.value as IRangeSliderValue).upper
+                    };
+            } else if ((this.value as IRangeSliderValue).upper < this._lowerBound) {
+                this.value = {
+                    lower: this._lowerBound,
+                    upper: (this.value as IRangeSliderValue).upper
+                };
+            } else if ((this.value as IRangeSliderValue).upper > this._upperBound) {
+                this.value = {
+                    lower: (this.value as IRangeSliderValue).lower,
+                    upper: this._upperBound
+                };
+            }
+        }
     }
 
     private generateTickMarks(color: string, interval: number) {

--- a/projects/igniteui-angular/src/lib/slider/slider.component.ts
+++ b/projects/igniteui-angular/src/lib/slider/slider.component.ts
@@ -235,7 +235,7 @@ export class IgxSliderComponent implements ControlValueAccessor, OnInit, AfterVi
         if (this._trackUpperBound) {
             this._upperBound = this._maxValue;
         }
-        this.resetValue();
+        this.invalidateValue();
     }
 
     /**
@@ -270,7 +270,7 @@ export class IgxSliderComponent implements ControlValueAccessor, OnInit, AfterVi
         if (this._trackLowerBound) {
             this._lowerBound = this._minValue;
         }
-        this.resetValue();
+        this.invalidateValue();
     }
 
     /**
@@ -719,48 +719,42 @@ export class IgxSliderComponent implements ControlValueAccessor, OnInit, AfterVi
         );
     }
 
-    private resetValue() {
+    private invalidateValue() {
         if (!this.isRange) {
             if (this.value >= this._lowerBound && this.value <= this._upperBound) {
-                this.value = this.value;
+                this.positionHandlesAndUpdateTrack();
             } else if (this.value < this._lowerBound) {
                 this.value = this._lowerBound;
             } else if (this.value > this._upperBound) {
                 this.value = this._upperBound;
             }
         } else {
-            if ((this.value as IRangeSliderValue).lower >= this._lowerBound &&
-                (this.value as IRangeSliderValue).lower <= this._upperBound) {
-                    this.value = {
-                        lower: (this.value as IRangeSliderValue).lower,
-                        upper: (this.value as IRangeSliderValue).upper
-                    };
-            } else if ((this.value as IRangeSliderValue).lower < this._lowerBound) {
+            const value = this.value as IRangeSliderValue;
+
+            if (value.lower >= this._lowerBound && value.lower <= this._upperBound) {
+                this.positionHandlesAndUpdateTrack();
+            } else if (value.lower < this._lowerBound) {
                 this.value = {
                     lower: this._lowerBound,
-                    upper: (this.value as IRangeSliderValue).upper
+                    upper: value.upper
                 };
-            } else if ((this.value as IRangeSliderValue).lower > this._upperBound) {
+            } else if (value.lower > this._upperBound) {
                 this.value = {
-                    lower: (this.value as IRangeSliderValue).lower,
+                    lower: value.lower,
                     upper: this._upperBound
                 };
             }
 
-            if ((this.value as IRangeSliderValue).upper >= this._lowerBound &&
-                (this.value as IRangeSliderValue).upper <= this._upperBound) {
-                    this.value = {
-                        lower: (this.value as IRangeSliderValue).lower,
-                        upper: (this.value as IRangeSliderValue).upper
-                    };
-            } else if ((this.value as IRangeSliderValue).upper < this._lowerBound) {
+            if (value.upper >= this._lowerBound && value.upper <= this._upperBound) {
+                this.positionHandlesAndUpdateTrack();
+            } else if (value.upper < this._lowerBound) {
                 this.value = {
                     lower: this._lowerBound,
-                    upper: (this.value as IRangeSliderValue).upper
+                    upper: value.upper
                 };
-            } else if ((this.value as IRangeSliderValue).upper > this._upperBound) {
+            } else if (value.upper > this._upperBound) {
                 this.value = {
-                    lower: (this.value as IRangeSliderValue).lower,
+                    lower: value.lower,
                     upper: this._upperBound
                 };
             }


### PR DESCRIPTION
Closes #920 .

The fix covers the following scenarios:
1. If upper/lowerBound are undefined on initialization, then upperBound/lowerBound will change whenever maxValue/minValue change.
If upperBound/lowerBound are set from outside however, we stop updating them when maxValue/minValue change.
2. Whenever maxValue/minValue change, we take care that value is updated respectively, so that we avoid thumb flickering on focus.
