### PR TITLE
fix(igxGrid): Using Math.round when calculating startIndex, because f…

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
@@ -564,7 +564,7 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
         const embeddedViewCopy = Object.assign([], this._embeddedViews);
 
         const count = this.isRemote ? this.totalItemCount : this.igxForOf.length;
-        const currIndex = Math.floor(ratio * count);
+        const currIndex = Math.round(ratio * count);
         let endingIndex = this.state.chunkSize + currIndex;
 
         // We update the startIndex before recalculating the chunkSize.


### PR DESCRIPTION
…loat multiplication sometimes produces wrong results and needs rounding.

Closes #2076 
