### PR TITLE
#1981 Nav drawer height use only 100% from styles

### DIFF
--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
@@ -268,6 +268,36 @@ describe('Navigation Drawer', () => {
             });
         }));
 
+        it('should stay at 100% parent height when pinned', async(() => {
+            const template = `<div>
+                               <igx-nav-drawer [pin]="pin" pinThreshold="false" [enableGestures]="enableGestures"></igx-nav-drawer>
+                              </div>`;
+            TestBed.overrideComponent(TestComponentPin, { set: { template }});
+            TestBed.compileComponents()
+            .then(() => {
+                const fixture = TestBed.createComponent(TestComponentPin);
+                const windowHeight = window.innerHeight;
+                const aside = fixture.debugElement.query((x) => x.nativeNode.nodeName === 'ASIDE').nativeElement;
+                const container = fixture.debugElement.query(By.css('div')).nativeElement;
+
+                fixture.componentInstance.pin = false;
+                fixture.detectChanges();
+                expect(aside.clientHeight).toEqual(windowHeight);
+
+                fixture.componentInstance.pin = true;
+                fixture.detectChanges();
+                expect(aside.clientHeight).toEqual(container.clientHeight);
+
+                container.style.height =  `${windowHeight - 50}px`;
+                expect(aside.clientHeight).toEqual(windowHeight - 50);
+
+                // unpin :
+                fixture.componentInstance.pin = false;
+                fixture.detectChanges();
+                expect(aside.clientHeight).toEqual(windowHeight);
+            });
+        }));
+
         it('should toggle on edge swipe gesture', (done) => {
             let fixture: ComponentFixture<TestComponentDIComponent>;
 

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
@@ -413,8 +413,6 @@ export class IgxNavigationDrawerComponent implements
         this.updateEdgeZone();
         this.checkPinThreshold();
 
-        // need to set height without absolute positioning
-        this.ensureDrawerHeight();
         this.ensureEvents();
 
         // TODO: apply platform-safe Ruler from http://plnkr.co/edit/81nWDyreYMzkunihfRgX?p=preview
@@ -445,7 +443,6 @@ export class IgxNavigationDrawerComponent implements
         }
         if (changes.pin && changes.pin.currentValue !== undefined) {
             this.pin = !!(this.pin && this.pin.toString() === 'true');
-            this.ensureDrawerHeight();
             if (this.pin) {
                 this._touchManager.destroy();
                 this._gesturesAttached = false;
@@ -545,19 +542,6 @@ export class IgxNavigationDrawerComponent implements
     }
 
     /**
-     * @hidden
-     */
-    protected ensureDrawerHeight() {
-        if (this.pin) {
-            // TODO: nested in content?
-            // setElementStyle warning https://github.com/angular/angular/issues/6563
-            this.renderer.setElementStyle(this.drawer, 'height', window.innerHeight + 'px');
-        } else {
-            this.renderer.setElementStyle(this.drawer, 'height', '');
-        }
-    }
-
-    /**
      * Get the Drawer width for specific state. Will attempt to evaluate requested state and cache.
      *
      * @hidden
@@ -641,7 +625,6 @@ export class IgxNavigationDrawerComponent implements
             this._resizeObserver = fromEvent(window, 'resize').pipe(debounce(() => interval(150)))
                 .subscribe((value) => {
                     this.checkPinThreshold();
-                    this.ensureDrawerHeight();
                 });
         }
     }


### PR DESCRIPTION
Closes #1981.

Additional information related to this pull request:
Removed logic that took window's height blindly. Styles already apply 100% - that'll correctly take the window size when the drawer is fixed (not pinned) and whatever is the closest block parent's height otherwise, which is entirely up to the app now.

This will allow the drawer to be pinned inside layouts even between headers/footers.