### PR TITLE
Refresh filter dialog on 'opening' event instead of on 'opened' - 6.1.x

### DIFF
--- a/projects/igniteui-angular/src/lib/grid/grid-filtering-ui.spec.ts
+++ b/projects/igniteui-angular/src/lib/grid/grid-filtering-ui.spec.ts
@@ -22,7 +22,7 @@ describe('IgxGrid - Filtering actions', () => {
                 BrowserAnimationsModule,
                 IgxGridModule.forRoot()]
         })
-        .compileComponents();
+            .compileComponents();
     }));
 
     afterEach(() => {
@@ -1286,15 +1286,18 @@ describe('IgxGrid - Filtering actions', () => {
 
         filterIcon.nativeElement.click();
         fix.detectChanges();
-        tick(100);
+        tick();
+        fix.detectChanges();
 
         sendInput(input, 0, fix);
         fix.detectChanges();
-        tick(100);
+        tick();
+        fix.detectChanges();
 
         grid.nativeElement.click();
         fix.detectChanges();
-        tick(100);
+        tick();
+        fix.detectChanges();
 
         expect(gridFilteringToggle.nativeElement.classList.contains('igx-filtering__toggle--filtered')).toBeTruthy();
     }));
@@ -1334,14 +1337,14 @@ describe('IgxGrid - Filtering actions', () => {
 
         discardPeriodicTasks();
     }));
-    
-    it('Should display populated filter dialog without redrawing it', async(() => {
+
+    it('Should display populated filter dialog without redrawing it', async () => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
-         const grid = fix.componentInstance.grid;
+        const grid = fix.componentInstance.grid;
         grid.width = '400px';
         grid.getColumnByName('ID').width = '50px';
-         // filter the ProductName by two conditions
+        // filter the ProductName by two conditions
         const filteringExpressionsTree = new FilteringExpressionsTree(FilteringLogic.And, 'ProductName');
         const expression = {
             fieldName: 'ProductName',
@@ -1356,38 +1359,39 @@ describe('IgxGrid - Filtering actions', () => {
         filteringExpressionsTree.filteringOperands.push(expression);
         filteringExpressionsTree.filteringOperands.push(expression1);
         grid.filter('ProductName', null, filteringExpressionsTree);
-         fix.detectChanges();
-         // scroll horizontally to the right, so ProductName column is out of view
+        fix.detectChanges();
+        // scroll horizontally to the right, so ProductName column is out of view
         const horScroll = grid.parentVirtDir.getHorizontalScroll();
         horScroll.scrollLeft = 1000;
         fix.detectChanges();
-         // scroll horizontally to the left, so ProductName is back in view
+        // scroll horizontally to the left, so ProductName is back in view
         horScroll.scrollLeft = 0;
         fix.detectChanges();
-         // click filter icon
+        // click filter icon
         const filterButton = fix.debugElement.queryAll(By.css('igx-grid-filter'))[0];
         const filterIcon = filterButton.query(By.css('igx-icon'));
         filterIcon.triggerEventHandler('mousedown', null);
         fix.detectChanges();
         filterIcon.nativeElement.click();
         fix.detectChanges();
-         fix.whenStable().then(() => {
-            const filterUI = fix.debugElement.query(By.css('.igx-filtering__options'));
-            // verify 'And' button is selected
-            const buttonGroup = filterUI.query(By.css('igx-buttongroup'));
-            const buttons = buttonGroup.queryAll(By.css('.igx-button-group__item'));
-            const andButton = buttons.filter((btn) => btn.nativeElement.textContent === 'And')[0];
-            expect(andButton).not.toBeNull();
-            expect(andButton).toBeDefined();
-            expect(andButton.nativeElement.classList.contains('igx-button-group__item--selected'))
-                .toBeTruthy('AndButton is not selected');
-             // verify both filter expression components are present
-            const filterExpressions = filterUI.queryAll(By.css('igx-grid-filter-expression'));
-            expect(filterExpressions).not.toBeNull();
-            expect(filterExpressions).toBeDefined();
-            expect(filterExpressions.length).toBe(2, 'not all filter-expression components are visible');
-        });
-    }));
+
+        await fix.whenStable();
+
+        const filterUI = fix.debugElement.query(By.css('.igx-filtering__options'));
+        // verify 'And' button is selected
+        const buttonGroup = filterUI.query(By.css('igx-buttongroup'));
+        const buttons = buttonGroup.queryAll(By.css('.igx-button-group__item'));
+        const andButton = buttons.filter((btn) => btn.nativeElement.textContent === 'And')[0];
+        expect(andButton).not.toBeNull();
+        expect(andButton).toBeDefined();
+        expect(andButton.nativeElement.classList.contains('igx-button-group__item--selected'))
+            .toBeTruthy('AndButton is not selected');
+        // verify both filter expression components are present
+        const filterExpressions = filterUI.queryAll(By.css('igx-grid-filter-expression'));
+        expect(filterExpressions).not.toBeNull();
+        expect(filterExpressions).toBeDefined();
+        expect(filterExpressions.length).toBe(2, 'not all filter-expression components are visible');
+    });
 });
 
 export class CustomFilter extends IgxFilteringOperand {
@@ -1510,7 +1514,7 @@ function sendInput(element, text, fix) {
 
 function verifyFilterUIPosition(filterUIContainer, grid) {
     const filterUiRightBorder = filterUIContainer.nativeElement.offsetParent.offsetLeft +
-    filterUIContainer.nativeElement.offsetLeft + filterUIContainer.nativeElement.offsetWidth;
+        filterUIContainer.nativeElement.offsetLeft + filterUIContainer.nativeElement.offsetWidth;
     expect(filterUiRightBorder).toBeLessThanOrEqual(grid.nativeElement.offsetWidth);
 }
 

--- a/projects/igniteui-angular/src/lib/grid/grid-filtering-ui.spec.ts
+++ b/projects/igniteui-angular/src/lib/grid/grid-filtering-ui.spec.ts
@@ -6,7 +6,7 @@ import { Calendar, ICalendarDate } from '../calendar/calendar';
 import { IgxInputDirective } from '../directives/input/input.directive';
 import { IgxGridComponent } from './grid.component';
 import { IgxGridModule } from './index';
-import { IgxFilteringOperand, IgxStringFilteringOperand } from '../../public_api';
+import { IgxFilteringOperand, IgxStringFilteringOperand, FilteringExpressionsTree, FilteringLogic } from '../../public_api';
 import { IgxButtonDirective } from '../directives/button/button.directive';
 import { UIInteractions } from '../test-utils/ui-interactions.spec';
 
@@ -1333,6 +1333,60 @@ describe('IgxGrid - Filtering actions', () => {
         expect(grid.rowList.length).toEqual(8);
 
         discardPeriodicTasks();
+    }));
+    
+    it('Should display populated filter dialog without redrawing it', async(() => {
+        const fix = TestBed.createComponent(IgxGridFilteringComponent);
+        fix.detectChanges();
+         const grid = fix.componentInstance.grid;
+        grid.width = '400px';
+        grid.getColumnByName('ID').width = '50px';
+         // filter the ProductName by two conditions
+        const filteringExpressionsTree = new FilteringExpressionsTree(FilteringLogic.And, 'ProductName');
+        const expression = {
+            fieldName: 'ProductName',
+            searchVal: 'Ignite',
+            condition: IgxStringFilteringOperand.instance().condition('startsWith')
+        };
+        const expression1 = {
+            fieldName: 'ProductName',
+            searchVal: 'Angular',
+            condition: IgxStringFilteringOperand.instance().condition('contains')
+        };
+        filteringExpressionsTree.filteringOperands.push(expression);
+        filteringExpressionsTree.filteringOperands.push(expression1);
+        grid.filter('ProductName', null, filteringExpressionsTree);
+         fix.detectChanges();
+         // scroll horizontally to the right, so ProductName column is out of view
+        const horScroll = grid.parentVirtDir.getHorizontalScroll();
+        horScroll.scrollLeft = 1000;
+        fix.detectChanges();
+         // scroll horizontally to the left, so ProductName is back in view
+        horScroll.scrollLeft = 0;
+        fix.detectChanges();
+         // click filter icon
+        const filterButton = fix.debugElement.queryAll(By.css('igx-grid-filter'))[0];
+        const filterIcon = filterButton.query(By.css('igx-icon'));
+        filterIcon.triggerEventHandler('mousedown', null);
+        fix.detectChanges();
+        filterIcon.nativeElement.click();
+        fix.detectChanges();
+         fix.whenStable().then(() => {
+            const filterUI = fix.debugElement.query(By.css('.igx-filtering__options'));
+            // verify 'And' button is selected
+            const buttonGroup = filterUI.query(By.css('igx-buttongroup'));
+            const buttons = buttonGroup.queryAll(By.css('.igx-button-group__item'));
+            const andButton = buttons.filter((btn) => btn.nativeElement.textContent === 'And')[0];
+            expect(andButton).not.toBeNull();
+            expect(andButton).toBeDefined();
+            expect(andButton.nativeElement.classList.contains('igx-button-group__item--selected'))
+                .toBeTruthy('AndButton is not selected');
+             // verify both filter expression components are present
+            const filterExpressions = filterUI.queryAll(By.css('igx-grid-filter-expression'));
+            expect(filterExpressions).not.toBeNull();
+            expect(filterExpressions).toBeDefined();
+            expect(filterExpressions.length).toBe(2, 'not all filter-expression components are visible');
+        });
     }));
 });
 

--- a/projects/igniteui-angular/src/lib/grid/grid-filtering.component.html
+++ b/projects/igniteui-angular/src/lib/grid/grid-filtering.component.html
@@ -7,7 +7,8 @@
 </div>
 
 <div igxToggle
-    (onOpened)="refresh()"
+    (onOpening)="refresh()"
+    (onOpened)="focusFirstInput()"
     (onClosed)="refresh()"
     #directive="toggle"
     class="igx-filtering__options">

--- a/projects/igniteui-angular/src/lib/grid/grid-filtering.component.ts
+++ b/projects/igniteui-angular/src/lib/grid/grid-filtering.component.ts
@@ -132,21 +132,22 @@ export class IgxGridFilterComponent implements OnInit, OnDestroy, DoCheck {
             const expr = this.gridAPI.get(this.gridID).filteringExpressionsTree.find(this.column.field);
 
             if (expr && expr instanceof FilteringExpressionsTree) {
-                this.expressionsList.toArray()[0].value = (expr.filteringOperands[0] as IFilteringExpression).searchVal;
-                this.expressionsList.toArray()[0].expression.condition = (expr.filteringOperands[0] as IFilteringExpression).condition;
+                const firstExpr = this.expressionsList.toArray()[0];
+                firstExpr.value = (expr.filteringOperands[0] as IFilteringExpression).searchVal;
+                firstExpr.expression.condition = (expr.filteringOperands[0] as IFilteringExpression).condition;
+                const secondExpr = this.expressionsList.toArray()[1];
                 if (expr.filteringOperands.length > 1) {
-                    if (this.expressionsList.toArray()[1]) {
-                        this.expressionsList.toArray()[1].value = (expr.filteringOperands[1] as IFilteringExpression).searchVal;
-                        this.expressionsList.toArray()[1].expression.condition =
+                    if (secondExpr) {
+                        secondExpr.value = (expr.filteringOperands[1] as IFilteringExpression).searchVal;
+                        secondExpr.expression.condition =
                             (expr.filteringOperands[1] as IFilteringExpression).condition;
                     }
                     this.isSecondConditionVisible = true;
                     this.logicOperators.selectedIndexes = [];
                     this.logicOperators.selectButton(expr.operator);
-                } else if (this.expressionsList.toArray()[1]) {
-                    const secondExpr = this.expressionsList.toArray()[1];
-                    this.expressionsList.toArray()[1].value = null;
-                    this.expressionsList.toArray()[1].expression.condition = secondExpr.getCondition(secondExpr.conditions[0]);
+                } else if (secondExpr) {
+                    secondExpr.value = null;
+                    secondExpr.expression.condition = secondExpr.getCondition(secondExpr.conditions[0]);
                 }
             } else {
                 this.expressionsList.forEach(el => {
@@ -259,6 +260,12 @@ export class IgxGridFilterComponent implements OnInit, OnDestroy, DoCheck {
         this._filter();
         const expr = grid.filteringExpressionsTree.find(this.column.field);
         grid.onFilteringDone.emit(expr as FilteringExpressionsTree);
+    }
+
+    public focusFirstInput(): void {
+        if (this.dialogShowing) {
+            this.expressionsList.toArray()[0].focusInput();
+        }
     }
 
     protected isFilteringApplied(): boolean {


### PR DESCRIPTION
Closes #2038 .

Refresh filter dialog on 'opening' event instead of on 'opened'. All changes to the refresh() method itself are purely cosmetic. The opened event is still handled only to focus the first input in the filter dialog.