### PR TITLE
#2013 Apply flex order when drawer is pinned to the right

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/navdrawer/_navdrawer-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/navdrawer/_navdrawer-theme.scss
@@ -157,10 +157,16 @@
         z-index: 0;
     }
 
+    %aside--collapsed--right {
+        transform: translate3d(300px, 0, 0);
+        box-shadow: none;
+    }
+
     %igx-nav-drawer__aside--collapsed {
         transform: none;
         width: 0;
         overflow: hidden;
+        border: none;
     }
 
     %aside--collapsed {
@@ -173,11 +179,6 @@
         right: 0;
         border-right: none;
         border-left: 1px solid --var($theme, 'border-color');
-    }
-
-    %aside--collapsed--right {
-        transform: translate3d(300px, 0, 0);
-        box-shadow: none;
     }
 
     %aside--mini {

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
@@ -298,6 +298,35 @@ describe('Navigation Drawer', () => {
             });
         }));
 
+        it('should set flex-basis and order when pinned', async(() => {
+            const template =  `<igx-nav-drawer [pin]="pin" pinThreshold="false"></igx-nav-drawer>`;
+            TestBed.overrideComponent(TestComponentPin, { set: { template }});
+            TestBed.compileComponents()
+            .then(() => {
+                const fixture = TestBed.createComponent(TestComponentPin);
+                const drawer = fixture.componentInstance.viewChild;
+                drawer.isOpen = true;
+                fixture.detectChanges();
+                const drawerElem = fixture.debugElement.query((x) => x.nativeNode.nodeName === 'IGX-NAV-DRAWER').nativeElement;
+
+                expect(drawer.pin).toBeTruthy();
+                expect(drawerElem.style.flexBasis).toEqual(drawer.width);
+                expect(drawerElem.style.order).toEqual('0');
+
+                drawer.width = '345px';
+                drawer.position = 'right';
+                fixture.detectChanges();
+                expect(drawerElem.style.flexBasis).toEqual(drawer.width);
+                expect(drawerElem.style.order).toEqual('1');
+
+                fixture.componentInstance.pin = false;
+                fixture.detectChanges();
+                expect(drawer.pin).toBeFalsy();
+                expect(drawerElem.style.flexBasis).toEqual('0px');
+                expect(drawerElem.style.order).toEqual('0');
+            });
+        }));
+
         it('should toggle on edge swipe gesture', (done) => {
             let fixture: ComponentFixture<TestComponentDIComponent>;
 

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
@@ -76,7 +76,6 @@ export class IgxNavigationDrawerComponent implements
 
     /**
      * Position of the Navigation Drawer. Can be "left"(default) or "right".
-     * Only has effect when not pinned.
      *
      * ```typescript
      * // get
@@ -285,6 +284,12 @@ export class IgxNavigationDrawerComponent implements
         }
 
         return '0px';
+    }
+
+    /** @hidden */
+    @HostBinding('style.order')
+    get isPinnedRight() {
+        return this.pin && this.position === 'right' ?  '1' : '0';
     }
 
     private _gesturesAttached = false;


### PR DESCRIPTION
Closes #2013  .  

Additional information related to this pull request:
Order allows the drawer to shift to the right in a flex container
