### PR TITLE
chore(tabs): Fixed disabled initial value to false

### DIFF
--- a/projects/igniteui-angular/src/lib/tabs/tabs-group.component.ts
+++ b/projects/igniteui-angular/src/lib/tabs/tabs-group.component.ts
@@ -50,7 +50,7 @@ export class IgxTabsGroupComponent implements AfterContentInit, AfterViewChecked
     *```
     */
     @Input()
-    public disabled: boolean;
+    public disabled = false;
 
     /**
      * @hidden

--- a/projects/igniteui-angular/src/lib/tabs/tabs.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/tabs/tabs.component.spec.ts
@@ -59,8 +59,8 @@ describe('IgxTabs', () => {
         fixture.detectChanges();
 
         tabItems = tabs.tabs.toArray();
-        expect(tabItems[0].disabled).toBeFalsy();
-        expect(tabItems[1].disabled).toBeFalsy();
+        expect(tabItems[0].disabled).toBe(false);
+        expect(tabItems[1].disabled).toBe(false);
     });
 
     it('should initialize set/get properties', () => {


### PR DESCRIPTION
Open the following [sample](https://stackblitz.com/edit/angular-zr35pg-zyhd8n), click the button and observe the console log.

Actual result: tabs group `disabled` property returns **undefined**
Expected result: `disabled` property should return **false** when the tabs group is not disabled

