### PR TITLE
chore(tabs): Fixed API docs typo

### DIFF
--- a/projects/igniteui-angular/src/lib/tabs/tabs.component.ts
+++ b/projects/igniteui-angular/src/lib/tabs/tabs.component.ts
@@ -69,7 +69,7 @@ export class IgxTabsComponent implements AfterViewInit, OnDestroy {
     /**
      * An @Input property that sets the value of the `selectedIndex`.
      * Default value is 0.
-     * *```html
+     * ```html
      * <igx-tabs selectedIndex="1">
      * ```
      */
@@ -335,11 +335,11 @@ export class IgxTabsComponent implements AfterViewInit, OnDestroy {
     }
 }
 
-    /**
-    * The IgxTabsModule provides the {@link IgxTabsComponent}, {@link IgxTabsGroupComponent},
-    *{@link IgxTabItemComponent}, {@link IgxTabItemTemplateDirective}, {@link IgxRightButtonStyleDirective}
-    * and {@link IgxLeftButtonStyleDirective} inside your application.
-    */
+/**
+* The IgxTabsModule provides the {@link IgxTabsComponent}, {@link IgxTabsGroupComponent},
+*{@link IgxTabItemComponent}, {@link IgxTabItemTemplateDirective}, {@link IgxRightButtonStyleDirective}
+* and {@link IgxLeftButtonStyleDirective} inside your application.
+*/
 @NgModule({
     declarations: [IgxTabsComponent,
         IgxTabsGroupComponent,


### PR DESCRIPTION
Navigate to [selectedIndex](https://staging.infragistics.local/products/ignite-ui-angular/docs/typescript/classes/igxtabscomponent.html#selectedindex) property.

HTML code snippet is not rendered.

![api_typo](https://user-images.githubusercontent.com/11226391/43773781-8617ce10-9a4f-11e8-84e9-3410f8460662.png)


