### PR TITLE
6.1.x - Expose column auto size API feature request

### DIFF
--- a/projects/igniteui-angular/src/lib/core/utils.ts
+++ b/projects/igniteui-angular/src/lib/core/utils.ts
@@ -39,3 +39,71 @@ export const enum DisplayDensity {
     cosy = 'cosy',
     compact = 'compact'
 }
+
+/**
+ *@hidden
+* Returns the actual size of the node content, using Range
+* ```typescript
+* let range = document.createRange();
+* let column = this.grid.columnList.filter(c => c.field === 'ID')[0];
+*
+* let size = valToPxlsUsingRange(range, column.cells[0].nativeElement);
+* ```
+ */
+export function valToPxlsUsingRange(range: Range, node: any): number {
+    let overflow = null;
+    if (isIE() || isEdge()) {
+        overflow = node.style.overflow;
+        // we need that hack - otherwise content won't be measured correctly in IE/Edge
+        node.style.overflow = 'visible';
+    }
+
+    range.selectNodeContents(node);
+    const width = range.getBoundingClientRect().width;
+
+    if (isIE() || isEdge()) {
+        // we need that hack - otherwise content won't be measured correctly in IE/Edge
+        node.style.overflow = overflow;
+    }
+
+    return width;
+}
+/**
+ *@hidden
+* Returns the actual size of the node content, using Canvas
+* ```typescript
+* let ctx = document.createElement('canvas').getContext('2d');
+* let column = this.grid.columnList.filter(c => c.field === 'ID')[0];
+*
+* let size = valToPxlsUsingCanvas(ctx, column.cells[0].nativeElement);
+* ```
+ */
+export function valToPxlsUsingCanvas(canvas2dCtx: any, node: any): number {
+    const s = this.grid.document.defaultView.getComputedStyle(node);
+
+    // need to set the font to get correct width
+    canvas2dCtx.font = s.fontSize + ' ' + s.fontFamily;
+
+    return canvas2dCtx.measureText(node.textContent).width;
+}
+/**
+ *@hidden
+ */
+export function isIE (): boolean {
+  return navigator.appVersion.indexOf('Trident/') > 0;
+}
+/**
+ *@hidden
+ */
+export function isEdge (): boolean {
+    const edgeBrowser = /Edge[\/\s](\d+\.\d+)/.test(navigator.userAgent);
+    return edgeBrowser;
+}
+
+/**
+ *@hidden
+ */
+export function isFirefox (): boolean {
+    const firefoxBrowser = /Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent);
+    return firefoxBrowser;
+}

--- a/projects/igniteui-angular/src/lib/grid/column-resizing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grid/column-resizing.spec.ts
@@ -1,7 +1,8 @@
 import { Component, DebugElement, OnInit, ViewChild } from '@angular/core';
-import { async, discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { async, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IgxAvatarModule } from '../avatar/avatar.component';
 import { Calendar } from '../calendar';
 import { IgxGridComponent } from './grid.component';
@@ -10,6 +11,7 @@ import { UIInteractions } from '../test-utils/ui-interactions.spec';
 import { GridTemplateStrings, ColumnDefinitions, EventSubscriptions } from '../test-utils/template-strings.spec';
 import { SampleTestData } from '../test-utils/sample-test-data.spec';
 import { IColumnResized } from '../test-utils/grid-interfaces.spec';
+import { MultiColumnHeadersComponent } from '../test-utils/grid-samples.spec';
 
 describe('IgxGrid - Deferred Column Resizing', () => {
     const COLUMN_HEADER_CLASS = '.igx-grid__th';
@@ -21,18 +23,20 @@ describe('IgxGrid - Deferred Column Resizing', () => {
                 PinnedColumnsComponent,
                 GridFeaturesComponent,
                 LargePinnedColGridComponent,
-                NullColumnsComponent
+                NullColumnsComponent,
+                MultiColumnHeadersComponent
             ],
             imports: [
                 FormsModule,
                 IgxAvatarModule,
+                NoopAnimationsModule,
                 IgxGridModule.forRoot()
             ]
         })
             .compileComponents();
     }));
 
-    it('Define grid with resizable columns.', fakeAsync(() => {
+    it('should define grid with resizable columns.', fakeAsync(() => {
         const fixture = TestBed.createComponent(ResizableColumnsComponent);
         fixture.detectChanges();
 
@@ -87,11 +91,9 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         expect(grid.columns[2].cells[0].value).toEqual('Wilson');
-
-        discardPeriodicTasks();
     }));
 
-    it('Resize column outside grid view.', fakeAsync(() => {
+    it('should resize column outside grid view.', fakeAsync(() => {
         const fixture = TestBed.createComponent(ResizableColumnsComponent);
         fixture.detectChanges();
 
@@ -115,11 +117,9 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         expect(grid.columns[0].width).toEqual('700px');
-
-        discardPeriodicTasks();
     }));
 
-    it('Resize column with preset min and max widths.', fakeAsync(() => {
+    it('should resize column with preset min and max widths.', fakeAsync(() => {
         const fixture = TestBed.createComponent(ResizableColumnsComponent);
         fixture.detectChanges();
 
@@ -160,11 +160,9 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         expect(grid.columns[1].width).toEqual('88px');
-
-        discardPeriodicTasks();
     }));
 
-    it('Resize sortable columns.', fakeAsync(() => {
+    it('should resize sortable columns.', fakeAsync(() => {
         const fixture = TestBed.createComponent(GridFeaturesComponent);
         fixture.detectChanges();
 
@@ -198,11 +196,9 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         expect(grid.columns[2].cells[0].value).toEqual(1000);
-
-        discardPeriodicTasks();
     }));
 
-    it('Resize pinned columns.', fakeAsync(() => {
+    it('should resize pinned columns.', fakeAsync(() => {
         const fixture = TestBed.createComponent(PinnedColumnsComponent);
         fixture.detectChanges();
 
@@ -242,11 +238,9 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         expect(grid.columns[0].width).toEqual('100px');
-
-        discardPeriodicTasks();
     }));
 
-    it('Resize columns with initial width of null.', fakeAsync(() => {
+    it('should resize columns with initial width of null.', fakeAsync(() => {
         const fixture = TestBed.createComponent(NullColumnsComponent);
         fixture.detectChanges();
 
@@ -316,11 +310,9 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         expect(grid.columns[1].width).toEqual('88px');
-
-        discardPeriodicTasks();
     }));
 
-    it('Resize pinned column with preset max width.', fakeAsync(() => {
+    it('should resize pinned column with preset max width.', fakeAsync(() => {
         const fixture = TestBed.createComponent(PinnedColumnsComponent);
         fixture.detectChanges();
 
@@ -348,15 +340,12 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         expect(grid.columns[1].width).toEqual('150px');
-
-        discardPeriodicTasks();
     }));
 
-    it('Autoresize column on double click.', fakeAsync(() => {
+    it('should autoresize column on double click.', fakeAsync(() => {
         const fixture = TestBed.createComponent(GridFeaturesComponent);
         fixture.detectChanges();
 
-        const dblclick = new Event('dblclick');
         const grid = fixture.componentInstance.grid;
         const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
 
@@ -364,102 +353,98 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         expect(grid.columns[1].width).toEqual('150px');
         expect(grid.columns[2].width).toEqual('150px');
 
-        headers[0].componentInstance.resizeArea.nativeElement.dispatchEvent(dblclick);
+        let resizeArea = headers[0].componentInstance.resizeArea.nativeElement;
+        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 148, 5);
         tick();
         fixture.detectChanges();
 
         expect(grid.columns[0].width).toEqual('100px');
 
-        headers[1].componentInstance.resizeArea.nativeElement.dispatchEvent(dblclick);
+        resizeArea = headers[1].componentInstance.resizeArea.nativeElement;
+        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 248, 5);
         tick();
         fixture.detectChanges();
 
         expect(grid.columns[1].width).toEqual('207px');
 
-        headers[2].componentInstance.resizeArea.nativeElement.dispatchEvent(dblclick);
+        resizeArea = headers[2].componentInstance.resizeArea.nativeElement;
+        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 305, 5);
         tick();
         fixture.detectChanges();
 
         expect(grid.columns[2].width).toEqual('97px');
 
-        headers[3].componentInstance.resizeArea.nativeElement.dispatchEvent(dblclick);
+        resizeArea = headers[3].componentInstance.resizeArea.nativeElement;
+        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 400, 5);
         tick();
         fixture.detectChanges();
 
         expect(grid.columns[3].width).toEqual('88px');
 
-        headers[5].componentInstance.resizeArea.nativeElement.dispatchEvent(dblclick);
+        resizeArea = headers[5].componentInstance.resizeArea.nativeElement;
+        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 486, 5);
         tick();
         fixture.detectChanges();
 
         expect(grid.columns[5].width).toEqual('89px');
-
-        discardPeriodicTasks();
     }));
 
-    it('Autoresize column wilth preset max width.', fakeAsync(() => {
+    it('should autoresize column wilth preset max width.', fakeAsync(() => {
         const fixture = TestBed.createComponent(LargePinnedColGridComponent);
         fixture.detectChanges();
 
-        const dblclick = new Event('dblclick');
         const grid = fixture.componentInstance.grid;
         const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
 
         expect(grid.columns[4].cells[0].nativeElement.getBoundingClientRect().width).toEqual(48);
         expect(grid.columns[4].maxWidth).toEqual('100px');
 
-        headers[4].componentInstance.resizeArea.nativeElement.dispatchEvent(dblclick);
+        const resizeArea = headers[4].componentInstance.resizeArea.nativeElement;
+        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 498, 5);
         tick();
         fixture.detectChanges();
 
         expect(grid.columns[4].width).toEqual('100px');
-
-        discardPeriodicTasks();
     }));
 
-    it('Autoresize templated column on double click.', fakeAsync(() => {
+    it('should autoresize templated column on double click.', fakeAsync(() => {
         const fixture = TestBed.createComponent(GridFeaturesComponent);
         fixture.detectChanges();
 
-        const dblclick = new Event('dblclick');
         const grid = fixture.componentInstance.grid;
         const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
 
         expect(grid.columns[5].width).toEqual('150px');
 
-        headers[5].componentInstance.resizeArea.nativeElement.dispatchEvent(dblclick);
+        const resizeArea = headers[5].componentInstance.resizeArea.nativeElement;
+        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 898, 5);
         tick();
         fixture.detectChanges();
 
         expect(grid.columns[5].width).toEqual('89px');
-
-        discardPeriodicTasks();
     }));
 
-    it('Autoresize pinned column on double click.', fakeAsync(() => {
+    it('should autoresize pinned column on double click.', fakeAsync(() => {
         const fixture = TestBed.createComponent(LargePinnedColGridComponent);
         fixture.detectChanges();
 
-        const dblclick = new Event('dblclick');
         const grid = fixture.componentInstance.grid;
         const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
 
         expect(grid.columns[2].width).toEqual('100px');
 
-        headers[2].componentInstance.resizeArea.nativeElement.dispatchEvent(dblclick);
+        const resizeArea = headers[2].componentInstance.resizeArea.nativeElement;
+        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 298, 5);
         tick();
         fixture.detectChanges();
 
         expect(grid.columns[2].width).toEqual('97px');
-
-        discardPeriodicTasks();
     }));
 
-    it('Autoresize pinned column on double click - edge case.', fakeAsync(() => {
+    it('should autoresize pinned column on double click - edge case.', fakeAsync(() => {
         const fixture = TestBed.createComponent(LargePinnedColGridComponent);
         fixture.detectChanges();
 
-        const dblclick = new Event('dblclick');
         const grid = fixture.componentInstance.grid;
         const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
 
@@ -467,7 +452,8 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         expect(grid.columns[1].width).toEqual('100px');
         expect(grid.columns[2].width).toEqual('100px');
 
-        headers[1].componentInstance.resizeArea.nativeElement.dispatchEvent(dblclick);
+        const resizeArea = headers[1].componentInstance.resizeArea.nativeElement;
+        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 198, 5);
         tick();
         fixture.detectChanges();
 
@@ -492,55 +478,51 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         expect(grid.columns[0].width).toEqual('280px');
         expect(grid.columns[1].width).toEqual('100px');
         expect(grid.columns[2].width).toEqual('100px');
-
-        discardPeriodicTasks();
     }));
 
-    // it("onColumnResized is fired with correct event args.", fakeAsync(() => {
-    //     const fixture = TestBed.createComponent(GridFeaturesComponent);
-    //     fixture.detectChanges();
+    it('should fire onColumnResized with correct event args.', fakeAsync(() => {
+        const fixture = TestBed.createComponent(GridFeaturesComponent);
+        fixture.detectChanges();
 
-    //     const dblclick = new Event("dblclick");
-    //     const grid = fixture.componentInstance.grid;
-    //     const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
+        const grid = fixture.componentInstance.grid;
+        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
 
-    //     expect(grid.columns[0].width).toEqual("150px");
-    //     expect(fixture.componentInstance.count).toEqual(0);
+        expect(grid.columns[0].width).toEqual('150px');
+        expect(fixture.componentInstance.count).toEqual(0);
 
-    //     const headerResArea = headers[0].nativeElement.children[1];
-    //     UIInteractions.simulateMouseEvent("mousedown", headerResArea, 150, 5);
-    //     tick();
-    //     fixture.detectChanges();
+        const headerResArea = headers[0].nativeElement.children[2];
+        UIInteractions.simulateMouseEvent('mousedown', headerResArea, 150, 5);
+        tick();
+        fixture.detectChanges();
 
-    //     const resizer = headers[0].nativeElement.children[1].children[0];
-    //     expect(resizer).toBeDefined();
-    //     UIInteractions.simulateMouseEvent("mousemove", resizer, 300, 5);
-    //     tick();
+        const resizer = headers[0].nativeElement.children[2].children[0];
+        expect(resizer).toBeDefined();
+        UIInteractions.simulateMouseEvent('mousemove', resizer, 300, 5);
+        tick();
 
-    //     UIInteractions.simulateMouseEvent("mouseup", resizer, 300, 5);
-    //     tick();
-    //     fixture.detectChanges();
+        UIInteractions.simulateMouseEvent('mouseup', resizer, 300, 5);
+        tick();
+        fixture.detectChanges();
 
-    //     expect(grid.columns[0].width).toEqual("300px");
-    //     expect(fixture.componentInstance.count).toEqual(1);
-    //     expect(fixture.componentInstance.column).toBe(grid.columns[0]);
-    //     expect(fixture.componentInstance.prevWidth).toEqual("150");
-    //     expect(fixture.componentInstance.newWidth).toEqual("300px");
+        expect(grid.columns[0].width).toEqual('300px');
+        expect(fixture.componentInstance.count).toEqual(1);
+        expect(fixture.componentInstance.column).toBe(grid.columns[0]);
+        expect(fixture.componentInstance.prevWidth).toEqual('150');
+        expect(fixture.componentInstance.newWidth).toEqual('300px');
 
-    //     expect(grid.columns[1].width).toEqual("150px");
+        expect(grid.columns[1].width).toEqual('150px');
 
-    //     headers[1].componentInstance.resizeArea.nativeElement.dispatchEvent(dblclick);
-    //     tick();
-    //     fixture.detectChanges();
+        const resizeArea = headers[1].componentInstance.resizeArea.nativeElement;
+        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 198, 5);
+        tick();
+        fixture.detectChanges();
 
-    //     expect(grid.columns[1].width).toEqual("207px");
-    //     expect(fixture.componentInstance.count).toEqual(2);
-    //     expect(fixture.componentInstance.column).toBe(grid.columns[1]);
-    //     expect(fixture.componentInstance.prevWidth).toEqual("150");
-    //     expect(fixture.componentInstance.newWidth).toEqual("207px");
-
-    //     discardPeriodicTasks();
-    // }));
+        expect(grid.columns[1].width).toEqual('207px');
+        expect(fixture.componentInstance.count).toEqual(2);
+        expect(fixture.componentInstance.column).toBe(grid.columns[1]);
+        expect(fixture.componentInstance.prevWidth).toEqual('150');
+        expect(fixture.componentInstance.newWidth).toEqual('207px');
+    }));
 
     it('should update grid after resizing a column to be bigger.', fakeAsync(() => {
         const fixture = TestBed.createComponent(ResizableColumnsComponent);
@@ -585,8 +567,6 @@ describe('IgxGrid - Deferred Column Resizing', () => {
 
         expect(hScrollVisible).toBe(true);
         expect(colsRendered.length).toEqual(4);
-
-        discardPeriodicTasks();
     }));
 
     it('should recalculate grid heights after resizing so the horizontal scrollbar appears.', fakeAsync(() => {
@@ -632,8 +612,112 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         // Should 243 - 18, because the horizontal scrollbar has 18px height
         expect(grid.calcHeight).toEqual(expectedHeight - 18);
         expect(hScrollVisible).toBe(true);
+    }));
 
-        discardPeriodicTasks();
+    it('should autosize column programmatically.', fakeAsync(() => {
+        const fixture = TestBed.createComponent(LargePinnedColGridComponent);
+        fixture.detectChanges();
+
+        const column = fixture.componentInstance.grid.columnList.filter(c => c.field === 'ID')[0];
+        expect(column.width).toEqual('100px');
+
+        column.autosize();
+        tick();
+        fixture.detectChanges();
+
+        expect(column.width).toEqual('63px');
+    }));
+
+    it('should autosize pinned column programmatically.', fakeAsync(() => {
+        const fixture = TestBed.createComponent(LargePinnedColGridComponent);
+        fixture.detectChanges();
+
+        const column = fixture.componentInstance.grid.columnList.filter(c => c.field === 'Released')[0];
+        expect(column.width).toEqual('100px');
+
+        column.autosize();
+        tick();
+        fixture.detectChanges();
+
+        expect(column.width).toEqual('102px');
+    }));
+
+    it('should autosize last pinned column programmatically.', fakeAsync(() => {
+        const fixture = TestBed.createComponent(LargePinnedColGridComponent);
+        fixture.detectChanges();
+
+        const column = fixture.componentInstance.grid.columnList.filter(c => c.field === 'Items')[0];
+        expect(column.width).toEqual('100px');
+
+        column.autosize();
+        tick();
+        fixture.detectChanges();
+
+        expect(column.width).toEqual('97px');
+    }));
+
+    it('should autosize templated column programmatically.', fakeAsync(() => {
+        const fixture = TestBed.createComponent(GridFeaturesComponent);
+        fixture.detectChanges();
+
+        const column = fixture.componentInstance.grid.columnList.filter(c => c.field === 'Category')[0];
+        expect(column.width).toEqual('150px');
+
+        column.autosize();
+        tick();
+        fixture.detectChanges();
+
+        expect(column.width).toEqual('89px');
+    }));
+
+    it('should autosize filtarable/sortable/resizable/movable column programmatically.', fakeAsync(() => {
+        const fixture = TestBed.createComponent(MultiColumnHeadersComponent);
+        fixture.detectChanges();
+
+        const column = fixture.componentInstance.grid.columnList.filter(c => c.field === 'Missing')[0];
+        expect(column.width).toEqual('100px');
+
+        column.autosize();
+        tick();
+        fixture.detectChanges();
+        expect(column.width).toEqual('133px');
+    }));
+
+    it('should autosize MCHs programmatically.', fakeAsync(() => {
+        const fixture = TestBed.createComponent(MultiColumnHeadersComponent);
+        fixture.detectChanges();
+
+        let column = fixture.componentInstance.grid.columnList.filter(c => c.field === 'CompanyName')[0];
+        expect(column.width).toEqual('130px');
+
+        column.autosize();
+        tick();
+        fixture.detectChanges();
+        expect(column.width).toEqual('257px');
+
+        column = fixture.componentInstance.grid.columnList.filter(c => c.field === 'ContactName')[0];
+        expect(column.width).toEqual('100px');
+
+        column.autosize();
+        tick();
+        fixture.detectChanges();
+        expect(column.width).toEqual('159px');
+
+        column = fixture.componentInstance.grid.columnList.filter(c => c.field === 'Region')[0];
+        expect(column.width).toEqual('150px');
+
+        column.autosize();
+        tick();
+        fixture.detectChanges();
+        expect(column.width).toEqual('90px');
+
+        column = fixture.componentInstance.grid.columnList.filter(c => c.field === 'Country')[0];
+        expect(column.width).toEqual('90px');
+
+        column.autosize();
+        tick();
+        fixture.detectChanges();
+        expect(column.width).toEqual('116px');
     }));
 });
 

--- a/projects/igniteui-angular/src/lib/grid/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grid/column.component.ts
@@ -28,6 +28,9 @@ import {
     IFilteringExpressionsTree, IgxBooleanFilteringOperand, IgxNumberFilteringOperand, IgxDateFilteringOperand,
     IgxStringFilteringOperand
 } from '../../public_api';
+import { IgxGridHeaderComponent } from './grid-header.component';
+import { valToPxlsUsingRange } from '../core/utils';
+
 /**
  * **Ignite UI for Angular Column** -
  * [Documentation](https://www.infragistics.com/products/ignite-ui-angular/angular/components/grid.html#columns-configuration)
@@ -963,6 +966,99 @@ export class IgxColumnComponent implements AfterContentInit {
         }
     }
 
+     /**
+     * Returns a reference to the header of the column.
+     * ```typescript
+     * let column = this.grid.columnList.filter(c => c.field === 'ID')[0];
+     * let headerCell = column.headerCell;
+     * ```
+     * @memberof IgxColumnComponent
+     */
+    get headerCell(): IgxGridHeaderComponent {
+        if (this.grid.headerList.length > 0) {
+            return flatten(this.grid.headerList.toArray()).find((h) => h.column === this);
+        }
+    }
+
+     /**
+     * Autosize the column to the longest currently visible cell value, including the header cell.
+     * ```typescript
+     * @ViewChild('grid') grid: IgxGridComponent;
+     *
+     * let column = this.grid.columnList.filter(c => c.field === 'ID')[0];
+     * column.autosize();
+     * ```
+     * @memberof IgxColumnComponent
+     */
+    public autosize() {
+        if (!this.columnGroup) {
+             this.width = this.getLargestCellWidth();
+             this.grid.markForCheck();
+            this.grid.reflow();
+        }
+    }
+
+     /**
+     * @hidden
+     * Returns the size (in pixels) of the longest currently visible cell, including the header cell.
+     * ```typescript
+     * @ViewChild('grid') grid: IgxGridComponent;
+     *
+     * let column = this.grid.columnList.filter(c => c.field === 'ID')[0];
+     * let size = column.getLargestCellWidth();
+     * ```
+     * @memberof IgxColumnComponent
+     */
+    public getLargestCellWidth(): string {
+        const range = this.grid.document.createRange();
+        const largest = new Map<number, number>();
+
+         if (this.cells.length > 0) {
+            let cellsContentWidths = [];
+            if (this.cells[0].nativeElement.children.length > 0) {
+                this.cells.forEach((cell) => cellsContentWidths.push(Math.max(...Array.from(cell.nativeElement.children)
+                    .map((child) => valToPxlsUsingRange(range, child)))));
+            } else {
+                cellsContentWidths = this.cells.map((cell) => valToPxlsUsingRange(range, cell.nativeElement));
+            }
+
+            const index = cellsContentWidths.indexOf(Math.max(...cellsContentWidths));
+            const cellStyle = this.grid.document.defaultView.getComputedStyle(this.cells[index].nativeElement);
+            const cellPadding = parseFloat(cellStyle.paddingLeft) + parseFloat(cellStyle.paddingRight) +
+                parseFloat(cellStyle.borderRightWidth);
+
+            largest.set(Math.max(...cellsContentWidths), cellPadding);
+        }
+
+         if (this.headerCell) {
+            let headerCell;
+            const titleIndex = this.grid.hasMovableColumns ? 1 : 0;
+            if (this.headerTemplate && this.headerCell.elementRef.nativeElement.children[titleIndex].children.length > 0) {
+                headerCell =  Math.max(...Array.from(this.headerCell.elementRef.nativeElement.children[titleIndex].children)
+                    .map((child) => valToPxlsUsingRange(range, child)));
+            } else {
+                headerCell = valToPxlsUsingRange(range, this.headerCell.elementRef.nativeElement.children[titleIndex]);
+            }
+
+            if (this.sortable || this.filterable) {
+                headerCell += this.headerCell.elementRef.nativeElement.children[titleIndex + 1].getBoundingClientRect().width;
+            }
+
+            const headerStyle = this.grid.document.defaultView.getComputedStyle(this.headerCell.elementRef.nativeElement);
+            const headerPadding = parseFloat(headerStyle.paddingLeft) + parseFloat(headerStyle.paddingRight) +
+                parseFloat(headerStyle.borderRightWidth);
+            largest.set(headerCell, headerPadding);
+         }
+
+        const largestCell = Math.max(...Array.from(largest.keys()));
+        const width = Math.ceil(largestCell + largest.get(largestCell));
+
+        if (Number.isNaN(width)) {
+            return this.width;
+        } else {
+            return width + 'px';
+        }
+    }
 }
 
 

--- a/projects/igniteui-angular/src/lib/grid/grid-header.component.html
+++ b/projects/igniteui-angular/src/lib/grid/grid-header.component.html
@@ -28,8 +28,7 @@
     </div>
 
     <span *ngIf="!column.columnGroup" [attr.draggable]="false" [style.cursor]="resizeCursor" #resizeArea
-        class="igx-grid__th-resize-handle"
-        (dblclick)="onResizeAreaDblClick()">
+        class="igx-grid__th-resize-handle">
 
         <div *ngIf="showResizer" igxResizer
             class="igx-grid__th-resize-line"

--- a/projects/igniteui-angular/src/lib/grid/grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grid/grid.component.ts
@@ -50,6 +50,7 @@ import { IgxGridSortingPipe, IgxGridPreGroupingPipe } from './grid.pipes';
 import { IgxGridGroupByRowComponent } from './groupby-row.component';
 import { IgxGridRowComponent } from './row.component';
 import { DataUtil, IFilteringOperation, IFilteringExpressionsTree, FilteringExpressionsTree } from '../../public_api';
+import { IgxGridHeaderComponent } from './grid-header.component';
 
 let NEXT_ID = 0;
 const DEBOUNCE_TIME = 16;
@@ -1175,6 +1176,12 @@ export class IgxGridComponent implements OnInit, OnDestroy, AfterContentInit, Af
      */
     @ContentChildren(IgxColumnComponent, { read: IgxColumnComponent, descendants: true })
     public columnList: QueryList<IgxColumnComponent>;
+
+    /**
+     * @hidden
+     */
+    @ViewChildren(IgxGridHeaderComponent, { read: IgxGridHeaderComponent })
+    public headerList: QueryList<IgxGridHeaderComponent>;
 
     /**
      * @hidden

--- a/projects/igniteui-angular/src/lib/test-utils/grid-samples.spec.ts
+++ b/projects/igniteui-angular/src/lib/test-utils/grid-samples.spec.ts
@@ -646,6 +646,13 @@ export class MovableColumnsLargeComponent extends GridAutoGenerateComponent {
     }
 }
 
+@Component({
+    template: `${GridTemplateStrings.declareGrid(`height="800px"`, '', ColumnDefinitions.multiColHeadersColumns)}`
+})
+export class MultiColumnHeadersComponent extends BasicGridComponent {
+    data = SampleTestData.contactInfoDataFull();
+}
+
 
 @Component({
     template: `${GridTemplateStrings.declareBasicGridWithColumns(ColumnDefinitions.nameAvatar)}`

--- a/projects/igniteui-angular/src/lib/test-utils/template-strings.spec.ts
+++ b/projects/igniteui-angular/src/lib/test-utils/template-strings.spec.ts
@@ -329,6 +329,32 @@ export class ColumnDefinitions {
         </igx-column>
     `;
 
+    public static multiColHeadersColumns = `
+        <igx-column [width]="'100px'" [movable]="true" [resizable]="true"
+                    [sortable]="true" [filterable]="true" field="Missing"></igx-column>
+        <igx-column-group [movable]="true" header="General Information">
+            <igx-column [movable]="true" [width]="'130px'" [filterable]="true" [sortable]="true" field="CompanyName"></igx-column>
+            <igx-column-group [movable]="true" header="Person Details">
+                <igx-column [movable]="true" [width]="'100px'" field="ContactName"></igx-column>
+                <igx-column [movable]="true" [filterable]="true" [sortable]="true" field="ContactTitle"></igx-column>
+            </igx-column-group>
+        </igx-column-group>
+        <igx-column [movable]="true" [resizable]="true" field="ID"></igx-column>
+        <igx-column-group [movable]="true" header="Address Information">
+            <igx-column field="Country" [width]="'90px'">
+                <ng-template igxHeader let-column>
+                    {{ column.field }}
+                </ng-template>
+                <ng-template igxCell let-cell="cell" let-val let-row>
+                    {{val}}
+                </ng-template>
+            </igx-column>
+            <igx-column [movable]="true" [width]="'150px'" field="Region"></igx-column>
+            <igx-column [movable]="true" field="City"></igx-column>
+            <igx-column [movable]="true" field="Address"></igx-column>
+        </igx-column-group>
+    `;
+
     public static contactInfoGroupableColumns = `
     <igx-column [movable]="true" [hasSummary]="true" [resizable]="true"
                 [pinned]="true" field="Missing"></igx-column>


### PR DESCRIPTION
Closes #2025 .

1. Expose `autosize()` method on `IgxColumnComponent`.
2. Fix #2025.
3. Expose two helper methods (in utils) for measuring string length: using Range and using Canvas. Current implementation of auto sizing uses the one with Range.

