### PR TITLE
Fix for 2467

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/chip/_chip-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/chip/_chip-theme.scss
@@ -336,8 +336,7 @@
     %igx-chip__text {
         color: --var($theme, 'text-color');
         font-size: rem(12px);
-        flex: 1 0 0;
-        text-align: center;
+        flex: 1 0 0%;
 
         @include ellipsis();
 

--- a/projects/igniteui-angular/src/lib/core/styles/components/chip/_chip-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/chip/_chip-theme.scss
@@ -282,7 +282,7 @@
         transition: $transition;
         background: --var($theme, 'chip-background');
         border: 1px solid transparent;
-        justify-content: space-between;
+        justify-content: center;
 
         &:hover,
         &:focus{
@@ -336,8 +336,14 @@
     %igx-chip__text {
         color: --var($theme, 'text-color');
         font-size: rem(12px);
-        margin-right: rem(16px);
+        flex: 1 0 0;
+        text-align: center;
+
         @include ellipsis();
+
+        + %igx-chip__remove-icon {
+            margin-left: rem(16px);
+        }
     }
 
     %igx-icon-display {
@@ -352,6 +358,7 @@
         &%igx-chip__order-icon {
             color: --var($theme, 'order-icon-color');
             margin-right: rem(4px);
+            margin-left: rem(16px);
         }
 
         &%igx-chip__remove-icon {


### PR DESCRIPTION
Closes #2467   

Additional information related to this pull request: 
I remove the margin after the text, but if we want to centre the text inside the chip we need to check if there is only text and add some class to make it centre.

This is what happens if I add text-align: center. It happens, because we have min-width on the chip. It's ok when we don't have icons, but if we have, the text should be left aligned, otherwise it looks odd.
https://drive.google.com/file/d/1RWk9QvJ_tyg-vWD8h7jGSBA6PVLCPa2s/view

