### PR TITLE
Changing class descriptions.

### DIFF
--- a/projects/igniteui-angular/src/lib/core/navigation/nav.service.ts
+++ b/projects/igniteui-angular/src/lib/core/navigation/nav.service.ts
@@ -1,9 +1,8 @@
 import { IToggleView } from './IToggleView';
 
 /**
- * Common service to be injected between components where those implementing common
- * ToggleView interface can register and toggle directives can call their methods.
- * TODO: Track currently active? Events?
+ * Common service to be injected between components.
+ * Those components, implementing common `ToggleView` interface, can register and toggle directives can call their methods.
  */
 export class IgxNavigationService {
     private navs: { [id: string]: IToggleView; };

--- a/projects/igniteui-angular/src/lib/core/touch.ts
+++ b/projects/igniteui-angular/src/lib/core/touch.ts
@@ -4,8 +4,7 @@ import { DOCUMENT, ɵgetDOM as getDOM } from '@angular/platform-browser';
 const EVENT_SUFFIX = 'precise';
 
 /**
- * Touch gestures manager based on Hammer.js
- * Use with caution, this will track references for single manager per element. Very TBD. Much TODO.
+ *@hidden
  */
 @Injectable()
 export class HammerGesturesManager {


### PR DESCRIPTION
Closes  #2524. 

Changes to the description of the IgxNavigationService.

Hiding the HammerGesturesManager class, because it is for internal use and should not be public.

