### PR TITLE
Fix - Combo - itemHeight default change, min-height removed

### DIFF
--- a/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
@@ -1629,19 +1629,19 @@ describe('igxCombo', () => {
             fix.detectChanges();
             expect(combo.collapsed).toBeFalsy();
             // NOTE: Minimum itemHeight is 2 rem, per Material Design Guidelines
-            expect(combo.itemHeight).toEqual(32); // Default value for itemHeight
-            expect(combo.itemsMaxHeight).toEqual(320); // Default value for itemsMaxHeight
+            expect(combo.itemHeight).toEqual(48); // Default value for itemHeight
+            expect(combo.itemsMaxHeight).toEqual(480); // Default value for itemsMaxHeight
             const dropdownItems = fix.debugElement.queryAll(By.css('.' + CSS_CLASS_DROPDOWNLISTITEM));
             const dropdownList = fix.debugElement.query(By.css('.' + CSS_CLASS_CONTENT));
-            expect(dropdownList.nativeElement.clientHeight).toEqual(320);
-            expect(dropdownItems[0].nativeElement.clientHeight).toEqual(32);
+            expect(dropdownList.nativeElement.clientHeight).toEqual(480);
+            expect(dropdownItems[0].nativeElement.clientHeight).toEqual(48);
 
             combo.itemHeight = 47;
             tick();
             fix.detectChanges();
             expect(combo.itemHeight).toEqual(47);
-            expect(combo.itemsMaxHeight).toEqual(320);
-            expect(dropdownList.nativeElement.clientHeight).toEqual(320);
+            expect(combo.itemsMaxHeight).toEqual(480);
+            expect(dropdownList.nativeElement.clientHeight).toEqual(480);
             expect(dropdownItems[0].nativeElement.clientHeight).toEqual(47);
 
             combo.itemsMaxHeight = 438;

--- a/projects/igniteui-angular/src/lib/combo/combo.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.ts
@@ -496,7 +496,7 @@ export class IgxComboComponent implements AfterViewInit, ControlValueAccessor, O
      * ```
      */
     @Input()
-    public itemHeight = 32;
+    public itemHeight = 48;
 
     /**
      * @hidden

--- a/projects/igniteui-angular/src/lib/combo/combo.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.ts
@@ -464,7 +464,7 @@ export class IgxComboComponent implements AfterViewInit, ControlValueAccessor, O
      * ```
     */
     @Input()
-    public itemsMaxHeight = 320;
+    public itemsMaxHeight = 480;
 
     /**
      * Configures the drop down list width

--- a/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-theme.scss
@@ -162,17 +162,6 @@
 @mixin igx-drop-down($theme) {
     @include igx-root-css-vars($theme);
 
-    $desktop-item-height: 32px;
-    $mobile-item-height: 48px;
-
-    $desktop-item-padding: 24px;
-    $mobile-item-padding: 16px;
-
-    $desktop-header-padding: 16px;
-    $mobile-header-padding: 8px;
-
-    $mobile-break-point: 600px;
-
     $dd-shadow: igx-elevation($elevations, 3);
 
     %igx-drop-down {
@@ -193,23 +182,16 @@
         justify-content: flex-start;
         align-items: center;
         width: 100%;
-        height: rem($desktop-item-height);
-        line-height: rem($desktop-item-height);
-        min-height: rem($desktop-item-height);
+        height: rem(32px);
+        line-height: rem(32px);
+        min-height: rem(32px);
         white-space: nowrap;
-
-        @media only screen and (max-width: $mobile-break-point) {
-            height: rem($mobile-item-height);
-            line-height: rem($mobile-item-height);
-            min-height: rem($mobile-item-height);
-        }
     }
 
     %igx-drop-down__item {
         color: --var($theme, 'item-text-color');
         cursor: pointer;
-        height: rem($desktop-item-height);
-        padding: 0 rem($desktop-item-padding);
+        padding: 0 rem(24px);
 
         &:focus {
             outline: 0;
@@ -235,10 +217,7 @@
         font-size: rem(13px);
         color: --var($theme, 'header-text-color');
         pointer-events: none;
-        padding: 0 rem($desktop-header-padding);
-        @media only screen and (max-width: $mobile-break-point) {
-            padding: 0 rem($mobile-header-padding);
-        }
+        padding: 0 rem(16px);
     }
 
     %igx-drop-down__item--focused {

--- a/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-theme.scss
@@ -208,10 +208,8 @@
     %igx-drop-down__item {
         color: --var($theme, 'item-text-color');
         cursor: pointer;
+        height: rem($desktop-item-height);
         padding: 0 rem($desktop-item-padding);
-        @media only screen and (max-width: $mobile-break-point) {
-            padding: 0 rem($mobile-item-padding);
-        }
 
         &:focus {
             outline: 0;


### PR DESCRIPTION
Closes #2504.

Combo items had min-height: 48px set through CSS and itemHeight (style.heigh) set to 32px through HostBinding in component definition. The itemHeight property is used in IgxForOf, but if itemHeight < 48 (min-height), this led to unreachable items in the virtualized combo drop-down list 

