### PR TITLE
Improve Azure Pipelines build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Ignite UI for Angular - from Infragistics
 
+[![Build Status](https://dev.azure.com/IgniteUI/igniteui-angular/_apis/build/status/IgniteUI.igniteui-angular)](https://dev.azure.com/IgniteUI/igniteui-angular/_build/latest?definitionId=3)
 [![Build Status](https://travis-ci.org/IgniteUI/igniteui-angular.svg?branch=master)](https://travis-ci.org/IgniteUI/igniteui-angular)
 [![Coverage Status](https://coveralls.io/repos/github/IgniteUI/igniteui-angular/badge.svg?branch=master)](https://coveralls.io/github/IgniteUI/igniteui-angular?branch=master)
 [![npm version](https://badge.fury.io/js/igniteui-angular.svg)](https://badge.fury.io/js/igniteui-angular)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,16 +22,17 @@ steps:
 - script: npm run test:lib:azure
   displayName: 'Run tests'
 
-- script: npm run test:migration
-  displayName: 'Run migrations'
-
 - script: cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js
-  condition: eq(variables['system.teamProject'], 'igniteui-angular')
+  condition: and(succeeded(), eq(variables['system.teamProject'], 'igniteui-angular'))
   displayName: 'Code coverage @ Coveralls'
   env:
     COVERALLS_REPO_TOKEN: $(coveralls.repoToken)
 
+- script: npm run test:migration
+  displayName: 'Run migrations'
+
 - task: PublishTestResults@2
+  condition: succeededOrFailed()
   inputs:
     testRunner: 'JUnit'
     testResultsFiles: '**/TESTS-*.xml' 


### PR DESCRIPTION
#2605 

- Deploy code coverage to Coveralls only in case the test run succeeds;
- Deploy test run results regardless whether the test are failing or not;
- Add build status badge in Readme.md

