### PR TITLE
Fix - Combo - itemHeight default change, min-height removed

### DIFF
--- a/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
@@ -1626,19 +1626,19 @@ describe('igxCombo', () => {
             fix.detectChanges();
             expect(combo.collapsed).toBeFalsy();
             // NOTE: Minimum itemHeight is 2 rem, per Material Design Guidelines (for mobile only)
-            expect(combo.itemHeight).toEqual(32); // Default value for itemHeight
-            expect(combo.itemsMaxHeight).toEqual(320); // Default value for itemsMaxHeight
+            expect(combo.itemHeight).toEqual(48); // Default value for itemHeight
+            expect(combo.itemsMaxHeight).toEqual(480); // Default value for itemsMaxHeight
             const dropdownItems = fix.debugElement.queryAll(By.css('.' + CSS_CLASS_DROPDOWNLISTITEM));
             const dropdownList = fix.debugElement.query(By.css('.' + CSS_CLASS_CONTENT));
-            expect(dropdownList.nativeElement.clientHeight).toEqual(320);
+            expect(dropdownList.nativeElement.clientHeight).toEqual(480);
             expect(dropdownItems[0].nativeElement.clientHeight).toEqual(48);
 
             combo.itemHeight = 48;
             tick();
             fix.detectChanges();
             expect(combo.itemHeight).toEqual(48);
-            expect(combo.itemsMaxHeight).toEqual(320);
-            expect(dropdownList.nativeElement.clientHeight).toEqual(320);
+            expect(combo.itemsMaxHeight).toEqual(480);
+            expect(dropdownList.nativeElement.clientHeight).toEqual(480);
             expect(dropdownItems[0].nativeElement.clientHeight).toEqual(48);
 
             combo.itemsMaxHeight = 438;

--- a/projects/igniteui-angular/src/lib/combo/combo.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.ts
@@ -552,7 +552,7 @@ export class IgxComboComponent implements AfterViewInit, ControlValueAccessor, O
      * ```
     */
     @Input()
-    public itemsMaxHeight = 320;
+    public itemsMaxHeight = 480;
 
     /**
      * Configures the drop down list width

--- a/projects/igniteui-angular/src/lib/combo/combo.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.ts
@@ -584,7 +584,7 @@ export class IgxComboComponent implements AfterViewInit, ControlValueAccessor, O
      * ```
      */
     @Input()
-    public itemHeight = 32;
+    public itemHeight = 48;
 
     /**
      * @hidden

--- a/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-theme.scss
@@ -204,14 +204,7 @@
         color: --var($theme, 'item-text-color');
         cursor: pointer;
         height: rem($desktop-item-height);
-        min-height: rem($desktop-item-height);
         padding: 0 rem($desktop-item-padding);
-
-        @media only screen and (max-width: $mobile-break-point) {
-            height: rem($mobile-item-height);
-            min-height: rem($mobile-item-height);
-            padding: 0 rem($mobile-item-padding);
-        }
 
         &:focus {
             outline: 0;


### PR DESCRIPTION
Closes #2504 

Combo items had min-height: 48px set through CSS and itemHeight (style.heigh) set to 32px through HostBinding in component definition. The itemHeight property is used in IgxForOf, but if itemHeight < 48 (min-height), this led to unreachable items in the virtualized combo drop-down list

This is [merged in 6.1.x](https://github.com/IgniteUI/igniteui-angular/pull/2545) but a PR to master wasn't created.