### PR TITLE
Fix - Grid - Summary section was incorrectly displayed when selection is enabled - 6.1.x

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-component.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-component.scss
@@ -78,6 +78,10 @@
         }
     }
 
+    @include e(summaries-patch) {
+        @extend %grid-summaries-patch !optional;
+    }
+
     @include e(tr, $m: odd) {
         @extend %grid-row--odd !optional;
     }

--- a/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
@@ -839,6 +839,11 @@
         background: inherit;
     }
 
+    %grid-summaries-patch {
+        background: inherit;
+        position: relative;
+        z-index: 1;
+    }
 
     // Column moving
     %igx-grid__th-drop-indicator-left,

--- a/projects/igniteui-angular/src/lib/grid/grid.component.html
+++ b/projects/igniteui-angular/src/lib/grid/grid.component.html
@@ -94,9 +94,15 @@
 
 
 <div class="igx-grid__tfoot" role="rowgroup" [style.width.px]='calcWidth' #tfoot>
-    <div *ngIf="hasSummarizedColumns" class="igx-grid__summaries" [style.height.px]="summariesHeight" [style.marginLeft.px]="summariesMargin" role="row" #summaries>
+    <div *ngIf="hasSummarizedColumns" class="igx-grid__summaries" [style.height.px]="summariesHeight" role="row" #summaries>
         <ng-container *ngIf="groupingExpressions.length > 0">
             <div class="igx-grid__row-indentation igx-grid__row-indentation--level-{{groupingExpressions.length}}"></div>
+        </ng-container>
+        <ng-container *ngIf="rowSelectable">
+            <div style="position: relative; z-index: 1; background-color: inherit;"
+            [style.min-width.px]="summariesMargin" 
+            [style.flex-basis.px]="summariesMargin"
+            ></div>
         </ng-container>
         <ng-container *ngIf="pinnedColumns.length > 0">
             <igx-grid-summary [gridID]="id" *ngFor="let col of notGroups(pinnedColumns)"  [column]="col" [style.min-width.px]="col.width" [style.flex-basis.px]='col.width'></igx-grid-summary>

--- a/projects/igniteui-angular/src/lib/grid/grid.component.html
+++ b/projects/igniteui-angular/src/lib/grid/grid.component.html
@@ -98,8 +98,9 @@
         <ng-container *ngIf="groupingExpressions.length > 0">
             <div class="igx-grid__row-indentation igx-grid__row-indentation--level-{{groupingExpressions.length}}"></div>
         </ng-container>
-        <ng-container *ngIf="rowSelectable">
-            <div style="position: relative; z-index: 1; background-color: inherit;"
+        <ng-container *ngIf="summariesMargin">
+            <div
+            class="igx-grid__summaries-patch"
             [style.min-width.px]="summariesMargin" 
             [style.flex-basis.px]="summariesMargin"
             ></div>


### PR DESCRIPTION
Closes #2522.  

There already was a calculation in place for the offset needed when `[rowSelectable]="true"`. The offset was placed as a margin and on the `.igx-grid__summaries` row in the `tfoot`. 
After a discussion with @zdrawku , @damyanpetev , @ChronosSF  we decided to go with the following approach:
Add a `div` container with the appropriate styles at the start of the summaries container in case `[rowSelectable]="true"`. This keeps the structure understandable and the container should not interfere with future enhancements.

Another possible fix is adding `overflow-x: hidden` to the `.igx-grid__summaries` class. While this works and does not interfere with virtualization and rendering of the grid, we decided to go against it.


