### PR TITLE
chore(ng-update): migration compile error - export type enum

### DIFF
--- a/projects/igniteui-angular/migrations/common/UpdateChanges.ts
+++ b/projects/igniteui-angular/migrations/common/UpdateChanges.ts
@@ -217,7 +217,7 @@ export class UpdateChanges {
     }
 }
 
-enum BindingType {
+export enum BindingType {
     output,
     input
 }


### PR DESCRIPTION
Closes # .  

Additional information related to this pull request:

