### PR TITLE
[DO NOT MERGE] build(demos): switch to hmr for the demos app

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -49,18 +49,9 @@
                         },
                         "hmr": {
                             "fileReplacements": [{
-                                "replace": "src/environments/environments.ts",
+                                "replace": "src/environments/environment.ts",
                                 "with": "src/environments/environment.hmr.ts"
-                            }],
-                            "optimization": true,
-                            "outputHashing": "all",
-                            "sourceMap": true,
-                            "extractCss": true,
-                            "namedChunks": false,
-                            "aot": true,
-                            "extractLicenses": false,
-                            "vendorChunk": false,
-                            "buildOptimizer": true
+                            }]
                         }
                     }
                 },
@@ -72,6 +63,11 @@
                     "configurations": {
                         "production": {
                             "browserTarget": "igniteui-dev-demos:build:production"
+                        },
+                        "hmr": {
+                            "hmr": true,
+                            "hmrWarning": false,
+                            "browserTarget": "igniteui-dev-demos:build:hmr"
                         }
                     }
                 },

--- a/angular.json
+++ b/angular.json
@@ -46,6 +46,21 @@
                             "extractLicenses": true,
                             "vendorChunk": false,
                             "buildOptimizer": true
+                        },
+                        "hmr": {
+                            "fileReplacements": [{
+                                "replace": "src/environments/environments.ts",
+                                "with": "src/environments/environment.hmr.ts"
+                            }],
+                            "optimization": true,
+                            "outputHashing": "all",
+                            "sourceMap": true,
+                            "extractCss": true,
+                            "namedChunks": false,
+                            "aot": true,
+                            "extractLicenses": false,
+                            "vendorChunk": false,
+                            "buildOptimizer": true
                         }
                     }
                 },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -110,20 +110,6 @@ gulp.task('copy-git-hooks', () => {
         './.git/hooks/prepare-commit-msg');
 });
 
-gulp.task('watch', () => {
-    gulp.watch('./projects/igniteui-angular/src/lib/**/*', () => {
-        try {
-            spawnSync('npm run build:lib', {
-                stdio: 'inherit',
-                shell: true,
-                cwd: process.cwd()
-            });
-        } catch (err) {
-            console.error(`Exception: ${err}`);
-        }
-    });
-});
-
 gulp.task('copy-migrations', () => {
     return gulp.src([
             './projects/igniteui-angular/migrations/**/*.json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -497,6 +497,12 @@
         "tslib": "^1.9.0"
       }
     },
+    "@angularclass/hmr": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@angularclass/hmr/-/hmr-2.1.3.tgz",
+      "integrity": "sha1-NOZY7T2jfyOwogDi2lqJvpK7IJ8=",
+      "dev": true
+    },
     "@gulp-sourcemaps/identity-map": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@gulp-sourcemaps/identity-map/-/identity-map-1.0.1.tgz",
@@ -699,6 +705,12 @@
         "@types/glob": "*",
         "@types/node": "*"
       }
+    },
+    "@types/webpack-env": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.13.6.tgz",
+      "integrity": "sha512-5Th3OsZ4gTRdr9Mho83BQ23cex4sRhOR4XTG+m+cJc0FhtUBK9Vn62hBJ+pnQYnSxoPOsKoAPOx6FcphxBC8ng==",
+      "dev": true
     },
     "@webassemblyjs/ast": {
       "version": "1.4.3",
@@ -1217,6 +1229,12 @@
         "micromatch": "^3.1.4",
         "normalize-path": "^2.1.1"
       }
+    },
+    "ap": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ap/-/ap-0.2.0.tgz",
+      "integrity": "sha1-rglCYAspkS8NKxTsYMRejzMLYRA=",
+      "dev": true
     },
     "app-root-path": {
       "version": "2.1.0",
@@ -3239,6 +3257,23 @@
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
       "dev": true
+    },
+    "consolidate": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/consolidate/-/consolidate-0.13.1.tgz",
+      "integrity": "sha1-npUDVo60hQiJ2m7YeoUsjdLRP2Q=",
+      "dev": true,
+      "requires": {
+        "bluebird": "^2.9.26"
+      },
+      "dependencies": {
+        "bluebird": {
+          "version": "2.11.0",
+          "resolved": "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
+          "integrity": "sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=",
+          "dev": true
+        }
+      }
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -9418,6 +9453,12 @@
         "es5-ext": "~0.10.2"
       }
     },
+    "lunr": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.3.tgz",
+      "integrity": "sha512-rlAEsgU9Bnavca2w1WJ6+6cdeHMXNyadcersyk3ZpuhgWb5HBNj8l4WwJz9PjksAhYDlpQffCVXPctOn+wCIVA==",
+      "dev": true
+    },
     "magic-string": {
       "version": "0.22.5",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
@@ -9674,6 +9715,12 @@
           "dev": true
         }
       }
+    },
+    "merge": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
+      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
@@ -9938,6 +9985,12 @@
         "snapdragon": "^0.8.1",
         "to-regex": "^3.0.1"
       }
+    },
+    "ncp": {
+      "version": "1.0.1",
+      "resolved": "http://registry.npmjs.org/ncp/-/ncp-1.0.1.tgz",
+      "integrity": "sha1-0VNn5cuHQyuhF9K/gP30Wuz7QkY=",
+      "dev": true
     },
     "negotiator": {
       "version": "0.6.1",
@@ -15080,6 +15133,63 @@
         }
       }
     },
+    "themeleon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/themeleon/-/themeleon-3.0.2.tgz",
+      "integrity": "sha1-gCvzxCjA77fSEkDilBIngEy2X6s=",
+      "dev": true,
+      "requires": {
+        "ap": "^0.2.0",
+        "consolidate": "^0.13.0",
+        "fs-extra": "^0.13.0",
+        "glob": "^4.3.1",
+        "merge": "^1.2.0",
+        "q": "^1.1.2"
+      },
+      "dependencies": {
+        "fs-extra": {
+          "version": "0.13.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.13.0.tgz",
+          "integrity": "sha1-3K/BDyy1GE8jYLX//wYmc3BTlDM=",
+          "dev": true,
+          "requires": {
+            "jsonfile": "^2.0.0",
+            "ncp": "^1.0.1",
+            "rimraf": "^2.2.8"
+          }
+        },
+        "glob": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+          "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
+          "dev": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^2.0.1",
+            "once": "^1.3.0"
+          }
+        },
+        "jsonfile": {
+          "version": "2.4.0",
+          "resolved": "http://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+          "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6"
+          }
+        },
+        "minimatch": {
+          "version": "2.0.10",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz",
+          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^1.0.0"
+          }
+        }
+      }
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -16694,9 +16804,9 @@
       }
     },
     "webpack-sources": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
-      "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.2.0.tgz",
+      "integrity": "sha512-9BZwxR85dNsjWz3blyxdOhTgtnQvv3OEs5xofI0wPYTwu5kaWxS08UuD1oI7WLBLpRO+ylf0ofnXLXWmGb2WMw==",
       "dev": true,
       "requires": {
         "source-list-map": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.0",
     "scripts": {
         "ng": "ng",
-        "start": "ng serve --open --hmr --hmr-warning=false",
+        "start": "ng serve --open --configuration hmr",
         "build": "ng build",
         "test": "ng test",
         "lint": "ng lint",
@@ -48,9 +48,11 @@
         "@angular/cli": "~6.1.1",
         "@angular/compiler-cli": "^6.1.0",
         "@angular/language-service": "^6.1.0",
+        "@angularclass/hmr": "^2.1.3",
         "@types/jasmine": "~2.8.8",
         "@types/jasminewd2": "~2.0.3",
         "@types/node": "~10.5.4",
+        "@types/webpack-env": "^1.13.6",
         "browser-sync": "^2.24.6",
         "codelyzer": "~4.4.2",
         "coveralls": "^3.0.2",
@@ -85,6 +87,7 @@
         "tslint": "~5.11.0",
         "typedoc": "^0.12.0",
         "typedoc-plugin-localization": "^1.0.4",
-        "typescript": "~2.7.2"
+        "typescript": "~2.7.2",
+        "webpack-sources": "1.2.0"
     }
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.0.0",
     "scripts": {
         "ng": "ng",
-        "start": "ng serve",
+        "start": "ng serve --open --hmr --hmr-warning=false",
         "build": "ng build",
         "test": "ng test",
         "lint": "ng lint",
@@ -12,7 +12,7 @@
         "test:lib:azure": "ng test igniteui-angular --watch=false --no-progress --code-coverage --karma-config=./projects/igniteui-angular/karma.azure.conf.js",
         "test:lib:watch": "ng test igniteui-angular",
         "test:migration": "node -r ts-node/register ./node_modules/jasmine/bin/jasmine.js ./projects/igniteui-angular/migrations/**/*.spec.ts",
-        "build:lib": "ng build igniteui-angular --prod && gulp build-style && gulp watch",
+        "build:lib": "ng build igniteui-angular --prod && gulp build-style",
         "build:style": "gulp build-style",
         "build:migration": "gulp copy-migrations && tsc --listEmittedFiles --project ./projects/igniteui-angular/migrations/tsconfig.json",
         "build:docs:export": "gulp typedoc-build:export",

--- a/projects/igniteui-angular/src/lib/core/styles/themes/_core.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/themes/_core.scss
@@ -10,6 +10,7 @@
 @import '../base/normalize';
 @import './utilities';
 
+
 // Common component modules
 @import '../components/_common/igx-control';
 @import '../components/_common/igx-display-container';

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, OnInit, ViewChild, HostBinding } from '@angular/core';
 import { Router, NavigationStart } from '@angular/router';
 import { filter } from 'rxjs/operators';
 import { IgxNavigationDrawerComponent, IgxIconService } from 'igniteui-angular';
@@ -12,6 +12,9 @@ export class AppComponent implements OnInit {
 
     @ViewChild('navdrawer', { read: IgxNavigationDrawerComponent })
     navdrawer;
+
+    @HostBinding('attr.id')
+    appId = 'igniteui-demo-app';
 
     drawerState = {
         enableGestures: true,

--- a/src/app/drop-down/drop-down.sample.scss
+++ b/src/app/drop-down/drop-down.sample.scss
@@ -3,7 +3,7 @@
     -moz-user-select: none;     /* Firefox all */
     -ms-user-select: none;      /* IE 10+ */
     user-select: none;          /* Likely future */
-    
+
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -15,14 +15,14 @@ button {
 }
 
 // Import the IgniteUI themes library first
-@import '../../../dist/igniteui-angular/lib/core/styles/themes/index';
+@import '../../../projects/igniteui-angular/src/lib/core/styles/themes/index';
 
 :host {
     // Change theme palette to purple.
     $new-drop-down-theme: igx-drop-down-theme(
         $palette: igx-palette(#09f, purple)
     );
-    
+
     // Pass the theme to a to the `igx-drop-down` mixin
     @include igx-drop-down($new-drop-down-theme);
 

--- a/src/app/overlay/overlay-animation.sample.scss
+++ b/src/app/overlay/overlay-animation.sample.scss
@@ -1,5 +1,5 @@
 // Import the IgniteUI themes library first
-@import '../../../dist/igniteui-angular/lib/core/styles/themes/index';
+@import '../../../projects/igniteui-angular/src/lib/core/styles/themes/index';
 
 $new-card-theme: igx-card-theme(
     $background: royalblue

--- a/src/app/pageHeading/pageHeading.styles.scss
+++ b/src/app/pageHeading/pageHeading.styles.scss
@@ -1,6 +1,6 @@
-@import '../../../dist/igniteui-angular/lib/core/styles/themes/utilities';
-@import '../../../dist/igniteui-angular/lib/core/styles/components/button/button-theme';
-@import '../../../dist/igniteui-angular/lib/core/styles/components/button/button-component';
+@import '../../../projects/igniteui-angular/src/lib/core/styles/themes/utilities';
+@import '../../../projects/igniteui-angular/src/lib/core/styles/components/button/button-theme';
+@import '../../../projects/igniteui-angular/src/lib/core/styles/components/button/button-component';
 @import '../../styles/app-palettes';
 
 $button-background: igx-contrast-color($default-palette, 'primary');

--- a/src/app/styleguide/colors/color.sample.scss
+++ b/src/app/styleguide/colors/color.sample.scss
@@ -1,4 +1,4 @@
-@import '../../../../dist/igniteui-angular/lib/core/styles/themes/utilities';
+@import '../../../../projects/igniteui-angular/src/lib/core/styles/themes/utilities';
 @import '../../../styles/app-palettes';
 
 .sample-column {

--- a/src/environments/environment.hmr.ts
+++ b/src/environments/environment.hmr.ts
@@ -1,0 +1,4 @@
+export const environment = {
+    production: false,
+    hmr: true
+};

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,3 +1,4 @@
 export const environment = {
-  production: true
+    production: true,
+    hmr: false
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -1,9 +1,10 @@
 // This file can be replaced during build by using the `fileReplacements` array.
-// `ng build ---prod` replaces `environment.ts` with `environment.prod.ts`.
+// `ng build --prod` replaces `environment.ts` with `environment.prod.ts`.
 // The list of file replacements can be found in `angular.json`.
 
 export const environment = {
-  production: false
+    production: false,
+    hmr: false
 };
 
 /*

--- a/src/hmr.ts
+++ b/src/hmr.ts
@@ -1,0 +1,15 @@
+import { NgModuleRef, ApplicationRef } from '@angular/core';
+import { createNewHosts } from '@angularclass/hmr';
+
+export const hmrBootstrap = (module: any, bootstrap: () => Promise<NgModuleRef<any>>) => {
+    let ngModule: NgModuleRef<any>;
+    module.hot.accept();
+    bootstrap().then(mod => ngModule = mod);
+    module.hot.dispose(() => {
+        const appRef: ApplicationRef = ngModule.injector.get(ApplicationRef);
+        const elements = appRef.components.map(c => c.location.nativeElement);
+        const makeVisible = createNewHosts(elements);
+        ngModule.destroy();
+        makeVisible();
+    });
+};

--- a/src/index.html
+++ b/src/index.html
@@ -9,6 +9,6 @@
   <link rel="icon" type="image/x-icon" href="favicon.ico">
   <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.3.1/css/all.css" integrity="sha384-mzrmE5qonljUremFsqc01SB46JvROS7bZs3IO2EmfFsd15uHvIt+Y8vEf7N7fWAU" crossorigin="anonymous"></head>
 <body class="igx-typography">
-  <app-root id="igniteui-demo-app"></app-root>
+  <app-root></app-root>
 </body>
 </html>

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,9 +4,21 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
+import { hmrBootstrap } from './hmr';
+
 if (environment.production) {
-  enableProdMode();
+    enableProdMode();
 }
 
-platformBrowserDynamic().bootstrapModule(AppModule)
-  .catch(err => console.log(err));
+const bootstrap = () => platformBrowserDynamic().bootstrapModule(AppModule);
+
+if (environment.hmr) {
+    if (module['hot']) {
+        hmrBootstrap(module, bootstrap);
+    } else {
+        console.error('HMR is not enabled for webpack-dev-server!');
+        console.log('Are you using the --hmr flag for ng serve?');
+    }
+} else {
+    bootstrap().catch(err => console.log(err));
+}

--- a/src/styles/igniteui-theme.scss
+++ b/src/styles/igniteui-theme.scss
@@ -1,7 +1,7 @@
 @import url('https://fonts.googleapis.com/icon?family=Material+Icons');
 @import url('https://fonts.googleapis.com/css?family=Titillium+Web:300,400,600,700');
 
-@import '../../dist/igniteui-angular/lib/core/styles/themes/index';
+@import '../../projects/igniteui-angular/src/lib/core/styles/themes/index';
 @import 'app-palettes';
 @import 'app-layout';
 

--- a/src/tsconfig.app.json
+++ b/src/tsconfig.app.json
@@ -1,12 +1,14 @@
 {
-  "extends": "../tsconfig.json",
-  "compilerOptions": {
-    "outDir": "../out-tsc/app",
-    "module": "es2015",
-    "types": []
-  },
-  "exclude": [
-    "src/test.ts",
-    "**/*.spec.ts"
-  ]
+    "extends": "../tsconfig.json",
+    "compilerOptions": {
+        "outDir": "../out-tsc/app",
+        "module": "es2015",
+        "types": [
+            "node"
+        ]
+    },
+    "exclude": [
+        "src/test.ts",
+        "**/*.spec.ts"
+    ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,11 +18,13 @@
         ],
         "paths": {
             "igniteui-angular": [
-                "dist/igniteui-angular"
+                "projects/igniteui-angular/src/public_api.ts"
             ]
         }
     },
-    "exclude": ["dist"],
+    "exclude": [
+        "dist"
+    ],
     "typedocOptions": {
         "mode": "file",
         "out": "dist/igniteui-angular/docs/typescript",


### PR DESCRIPTION
The demos app no longer depends on a production build of IgniteUI for Angular. It instead uses the igniteui-angular project modules directly when compiling the app. This allows for hot module relaod (hmr) of project modules as well as for source mapping  of typescript and sass source files. Also, this eliminates the need for file watchers to trigger production builds, making the project build time a lot faster.

TL;DR
Effectively, to run the demos app you only need to run `npm start` now. No dist folder is needed.
