### PR TITLE
feat(toggle-action): set `overlaySettings` position target if empty

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/toggle/toggle.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/toggle/toggle.directive.spec.ts
@@ -4,7 +4,7 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IgxToggleActionDirective, IgxToggleDirective, IgxToggleModule, IgxOverlayOutletDirective } from './toggle.directive';
 import { IgxOverlayService, OverlaySettings, ConnectedPositioningStrategy,
-    AbsoluteScrollStrategy, AutoPositionStrategy } from '../../services';
+    AbsoluteScrollStrategy, AutoPositionStrategy, IPositionStrategy } from '../../services';
 import { CancelableEventArgs } from '../../core/utils';
 
 import { configureTestSuite } from '../../test-utils/configure-suite';
@@ -307,6 +307,34 @@ describe('IgxToggle', () => {
             fixture.detectChanges();
             fixture.componentInstance.toggleAction.onClick();
             expect(IgxToggleDirective.prototype.toggle).toHaveBeenCalledWith(settings);
+        });
+
+        it('should pass input overlaySettings from igxToggleAction and set position target if not provided', () => {
+            const fixture = TestBed.createComponent(IgxToggleActionTestComponent);
+            fixture.detectChanges();
+            const toggleSpy = spyOn(IgxToggleDirective.prototype, 'toggle');
+            const button = fixture.debugElement.query(By.directive(IgxToggleActionDirective)).nativeElement;
+
+            const settings = /*<OverlaySettings>*/{
+                positionStrategy: jasmine.any(ConnectedPositioningStrategy),
+                closeOnOutsideClick: true,
+                modal: false,
+                scrollStrategy: jasmine.any(AbsoluteScrollStrategy)
+            };
+            fixture.componentInstance.settings.positionStrategy  = new ConnectedPositioningStrategy();
+            fixture.detectChanges();
+
+            fixture.componentInstance.toggleAction.onClick();
+            expect(toggleSpy).toHaveBeenCalledWith(settings);
+            let positionStrategy = toggleSpy.calls.mostRecent().args[0].positionStrategy as IPositionStrategy;
+            expect(positionStrategy.settings.target).toBe(button);
+
+            fixture.componentInstance.settings.positionStrategy  = new ConnectedPositioningStrategy({ target: document.body });
+            fixture.detectChanges();
+
+            fixture.componentInstance.toggleAction.onClick();
+            positionStrategy = toggleSpy.calls.mostRecent().args[0].positionStrategy as IPositionStrategy;
+            expect(positionStrategy.settings.target).toBe(document.body);
         });
 
         it('Should fire toggle "onClosing" event when closing through closeOnOutsideClick', fakeAsync(() => {

--- a/projects/igniteui-angular/src/lib/directives/toggle/toggle.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/toggle/toggle.directive.ts
@@ -393,6 +393,9 @@ export class IgxToggleActionDirective implements OnInit {
         if (this.outlet) {
             this._overlayDefaults.outlet = this.outlet;
         }
+        if (this.overlaySettings && this.overlaySettings.positionStrategy && !this.overlaySettings.positionStrategy.settings.target) {
+            this.overlaySettings.positionStrategy.settings.target = this.element.nativeElement;
+        }
         this.target.toggle(Object.assign({}, this._overlayDefaults, this.overlaySettings));
     }
 }

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -1105,12 +1105,12 @@ describe('igxOverlay', () => {
                 expect(strategy.settings).toEqual(expectedDefaults);
             });
 
-        it(`Should use  target: new Point(0, 0) StartPoint:Left/Bottom, Direction Right/Bottom and openAnimation: scaleInVerTop,
+        it(`Should use  target: null StartPoint:Left/Bottom, Direction Right/Bottom and openAnimation: scaleInVerTop,
             closeAnimation: scaleOutVerTop as default options when using a ConnectedPositioningStrategy without passing options.`, () => {
                 const strategy = new ConnectedPositioningStrategy();
 
                 const expectedDefaults = {
-                    target: new Point(0, 0),
+                    target: null,
                     horizontalDirection: HorizontalAlignment.Right,
                     verticalDirection: VerticalAlignment.Bottom,
                     horizontalStartPoint: HorizontalAlignment.Left,

--- a/projects/igniteui-angular/src/lib/services/overlay/position/connected-positioning-strategy.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/position/connected-positioning-strategy.ts
@@ -4,7 +4,8 @@ import { scaleInVerTop, scaleOutVerTop } from '../../../animations/main';
 
 export class ConnectedPositioningStrategy implements IPositionStrategy {
   private _defaultSettings: PositionSettings = {
-    target: new Point(0, 0),
+    // default Point(0, 0) in getPointFromPositionsSettings
+    target: null,
     horizontalDirection: HorizontalAlignment.Right,
     verticalDirection: VerticalAlignment.Bottom,
     horizontalStartPoint: HorizontalAlignment.Left,


### PR DESCRIPTION
Related IgniteUI/igniteui-cli#369

Additional information related to this pull request:
If there are bound `overlaySettings` with `positionStrategy` that doesn't define a target, provide the toggle action element before opening.
This allows the config object to be created for targets that are created dynamically (async, ngIf, etc..).
