### PR TITLE
Grid's filtering dialog fix

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
@@ -1308,6 +1308,7 @@
     }
 
     %igx-grid__filtering-outlet {
-        z-index: 99999;
+        z-index: 2;
+        position: fixed;
     }
 }


### PR DESCRIPTION
This is a known issue in MS Edge and MS Internet Explorer. MS said this was fixed in May 2018. However they still did not released this fix.

As a work around we are setting the position of filtering outlet now to fixed. Setting the position to fixed creates new stacking context and this allows filtering dialog to appears above the grid body. We should check when MS release their fix to remove this work around.

Closes #2508
