### PR TITLE
Fix calls for methods specific to IE11 throwing errors when typedoc is built.

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/dragdrop/dragdrop.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/dragdrop/dragdrop.directive.ts
@@ -748,9 +748,9 @@ export class IgxDragDirective implements OnInit, OnDestroy {
         // using window.pageXOffset for IE9 compatibility
         const viewPortX = pageX - window.pageXOffset;
         const viewPortY = pageY - window.pageYOffset;
-        if (document.msElementsFromPoint) {
+        if (document['msElementsFromPoint']) {
             // Edge and IE special snowflakes
-            return document.msElementsFromPoint(viewPortX, viewPortY);
+            return document['msElementsFromPoint'](viewPortX, viewPortY);
         } else {
             // Other browsers like Chrome, Firefox, Opera
             return document.elementsFromPoint(viewPortX, viewPortY);

--- a/projects/igniteui-angular/src/lib/directives/scroll-inertia/scroll_inertia.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/scroll-inertia/scroll_inertia.directive.ts
@@ -46,10 +46,10 @@ export class IgxScrollInertiaDirective implements OnInit {
     private _lastMovedX;
     private _lastMovedY;
     private _gestureObject;
-    private setPointerCaptureFName = typeof Element.prototype.msSetPointerCapture === 'function' ?
+    private setPointerCaptureFName = typeof Element.prototype['msSetPointerCapture'] === 'function' ?
     'msSetPointerCapture' :
     'setPointerCapture';
-    private releasePointerCaptureFName = typeof Element.prototype.msReleasePointerCapture === 'function' ?
+    private releasePointerCaptureFName = typeof Element.prototype['msReleasePointerCapture'] === 'function' ?
     'msReleasePointerCapture' :
     'releasePointerCapture';
     private _pointer;


### PR DESCRIPTION
Closes #2736

PS: Please test if drag/drop and virtualization touch scroll work as intended on Internet Explorer.