### PR TITLE
Dkamburov/fixing 2607

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/dragdrop/dragdrop.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/dragdrop/dragdrop.directive.ts
@@ -389,8 +389,8 @@ export class IgxDragDirective implements OnInit, OnDestroy {
                 .subscribe((res) => this.onPointerDown(res));
 
                 fromEvent(this.element.nativeElement, 'pointermove').pipe(
-                    takeUntil(this._destroy),
-                    throttle(() => interval(0, animationFrameScheduler))
+                    throttle(() => interval(0, animationFrameScheduler)),
+                    takeUntil(this._destroy)
                 ).subscribe((res) => this.onPointerMove(res));
 
                 fromEvent(this.element.nativeElement, 'pointerup').pipe(takeUntil(this._destroy))
@@ -401,8 +401,8 @@ export class IgxDragDirective implements OnInit, OnDestroy {
                 .subscribe((res) => this.onPointerDown(res));
 
                 fromEvent(document.defaultView, 'touchmove').pipe(
-                    takeUntil(this._destroy),
-                    throttle(() => interval(0, animationFrameScheduler))
+                    throttle(() => interval(0, animationFrameScheduler)),
+                    takeUntil(this._destroy)
                 ).subscribe((res) => this.onPointerMove(res));
 
                 fromEvent(document.defaultView, 'touchend').pipe(takeUntil(this._destroy))
@@ -413,8 +413,8 @@ export class IgxDragDirective implements OnInit, OnDestroy {
                 .subscribe((res) => this.onPointerDown(res));
 
                 fromEvent(document.defaultView, 'mousemove').pipe(
-                    takeUntil(this._destroy),
-                    throttle(() => interval(0, animationFrameScheduler))
+                    throttle(() => interval(0, animationFrameScheduler)),
+                    takeUntil(this._destroy)
                 ).subscribe((res) => this.onPointerMove(res));
 
                 fromEvent(document.defaultView, 'mouseup').pipe(takeUntil(this._destroy))

--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
@@ -220,6 +220,24 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
         return this.totalItemCount !== null;
     }
 
+    /**
+     * @hidden
+     */
+    protected removeScrollEventListeners() {
+        if (this.igxForScrollOrientation === 'horizontal') {
+            this._zone.runOutsideAngular(() =>
+                this.getHorizontalScroll().removeEventListener('scroll', this.func)
+            );
+        } else {
+            const vertical = this.getVerticalScroll();
+            if (vertical) {
+                this._zone.runOutsideAngular(() =>
+                    vertical.removeEventListener('scroll', this.verticalScrollHandler)
+                );
+            }
+        }
+    }
+
     public verticalScrollHandler(event) {
         this.onScroll(event);
     }
@@ -298,9 +316,7 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
      * @hidden
      */
     public ngOnDestroy() {
-        if (this.hScroll) {
-            this.hScroll.removeEventListener('scroll', this.func);
-        }
+        this.removeScrollEventListeners();
     }
 
     /**
@@ -1072,18 +1088,7 @@ export class IgxGridForOfDirective<T> extends IgxForOfDirective<T> implements On
 
     ngOnInit() {
         super.ngOnInit();
-        if (this.igxForScrollOrientation === 'horizontal') {
-            this._zone.runOutsideAngular(() =>
-                this.getHorizontalScroll().removeEventListener('scroll', this.func)
-            );
-        } else {
-            const vertical = this.getVerticalScroll();
-            if (vertical) {
-                this._zone.runOutsideAngular(() =>
-                    vertical.removeEventListener('scroll', this.verticalScrollHandler)
-                );
-            }
-        }
+        this.removeScrollEventListeners();
     }
 
     ngOnChanges(changes: SimpleChanges) {

--- a/projects/igniteui-angular/src/lib/directives/scroll-inertia/scroll_inertia.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/scroll-inertia/scroll_inertia.directive.ts
@@ -1,8 +1,8 @@
-import { Directive, Input, ElementRef, NgZone, OnInit, NgModule } from '@angular/core';
+import { Directive, Input, ElementRef, NgZone, OnInit, NgModule, OnDestroy } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
 @Directive({ selector: '[igxScrollInertia]' })
-export class IgxScrollInertiaDirective implements OnInit {
+export class IgxScrollInertiaDirective implements OnInit, OnDestroy {
 
     constructor(private element: ElementRef, private _zone: NgZone) {
 
@@ -444,6 +444,28 @@ export class IgxScrollInertiaDirective implements OnInit {
     // Start inertia and continue it recursively
     this._touchInertiaAnimID = requestAnimationFrame(inertiaStep);
    }
+
+    ngOnDestroy() {
+        this._zone.runOutsideAngular(() => {
+            const targetElem = this.element.nativeElement.parentElement || this.element.nativeElement.parentNode;
+            targetElem.removeEventListener('wheel',
+                (evt) => { this.onWheel(evt); });
+            targetElem.removeEventListener('touchstart',
+                (evt) => { this.onTouchStart(evt); });
+            targetElem.removeEventListener('touchmove',
+                (evt) => { this.onTouchMove(evt); });
+            targetElem.removeEventListener('touchend',
+                (evt) => { this.onTouchEnd(evt); });
+            targetElem.removeEventListener('pointerdown',
+                (evt) => { this.onPointerDown(evt); });
+            targetElem.removeEventListener('pointerup',
+                (evt) => { this.onPointerUp(evt); });
+            targetElem.removeEventListener('MSGestureStart',
+                (evt) => { this.onMSGestureStart(evt); });
+            targetElem.removeEventListener('MSGestureChange',
+                (evt) => { this.onMSGestureChange(evt); });
+        });
+    }
 
 }
 @NgModule({

--- a/projects/igniteui-angular/src/lib/grid/grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grid/grid.component.ts
@@ -2205,6 +2205,8 @@ export class IgxGridComponent implements OnInit, OnDestroy, AfterContentInit, Af
             this.document.defaultView.removeEventListener('resize', this.resizeHandler);
             this.verticalScrollContainer.getVerticalScroll().removeEventListener('scroll', this.verticalScrollHandler);
             this.parentVirtDir.getHorizontalScroll().removeEventListener('scroll', this.horizontalScrollHandler);
+            const vertScrDC = this.verticalScrollContainer.dc.instance._viewContainer.element.nativeElement;
+            vertScrDC.removeEventListener('scroll', (evt) => { this.scrollHandler(evt); });
         });
         this.destroy$.next(true);
         this.destroy$.complete();


### PR DESCRIPTION
#2607

Resolving the following checkboxes:

- igx-chips-area has 5 subscriptions in ngDoCheck which we should unsubscribe from (onMoveStart, onMoveEnd, onDragEnter, onKeyDown and onSelection).
- igxDrag subscriptions in ngOnInit. 
- igxFor - this.vh.instance.elementRef.nativeElement and this.hvh.instance.elementRef.nativeElement have scroll event listeners not removed.
- igxScrollInertia - a lot of not removed event listeners in ngOnInit
- igx-grid - vertScrDC has scroll event listener.

Note that the following were already resolved:
- igx-grid-cell - row.virtDirRow.onChunkLoad
- igx-grid - virtualContainer.onChunkLoad


