### PR TITLE
 #2411 add default z-index to overlay wrapper

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/overlay/_overlay-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/overlay/_overlay-theme.scss
@@ -42,6 +42,7 @@
         background-color: transparent;
         transition: background-color .25s $ease-in-out-quad;
         pointer-events: none;
+        z-index: 10;
     }
 
     %overlay-wrapper--modal {


### PR DESCRIPTION
This should allow overlay wrappers directly under body to show above most common layout blocks.
Specifically related to #2411 scenario with date picker; also #2307.

**Additional information related to this pull request:**
We moved the filtering dialogs to the grid outlet for the first issue, however that doesn't work with the modal overlays (see #2745) and those remain under the document body. That brings them outside the stacking contexts of the container around the grid and the grid itself and so a picker would show under the grid sample.

Reproducible in the dev demos if you remove the perspective from the `.content` and also adding a sample from @npaunov:
[igx-test-sample.zip](https://github.com/IgniteUI/igniteui-angular/files/2510216/igx-test-sample.zip)


