### PR TITLE
feat(igxFocus): allow igxFocus to work with custom editors #2456

### DIFF
--- a/projects/igniteui-angular/src/lib/checkbox/checkbox.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/checkbox/checkbox.component.spec.ts
@@ -204,6 +204,18 @@ describe('IgxCheckbox', () => {
         expect(testInstance.subscribed).toBe(false);
         expect(testInstance.clickCounter).toEqual(2);
     });
+
+    describe('EditorProvider', () => {
+        it('Should return correct edit element', () => {
+            const fixture = TestBed.createComponent(CheckboxSimpleComponent);
+            fixture.detectChanges();
+
+            const instance = fixture.componentInstance.cb;
+            const editElement = fixture.debugElement.query(By.css('.igx-checkbox__input')).nativeElement;
+
+            expect(instance.getEditElement()).toBe(editElement);
+        });
+    });
 });
 
 @Component({ template: `<igx-checkbox>Init</igx-checkbox>` })

--- a/projects/igniteui-angular/src/lib/checkbox/checkbox.component.ts
+++ b/projects/igniteui-angular/src/lib/checkbox/checkbox.component.ts
@@ -8,11 +8,13 @@ import {
     NgModule,
     Output,
     Provider,
-    ViewChild
+    ViewChild,
+    ElementRef
 } from '@angular/core';
 import { CheckboxRequiredValidator, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { IgxRippleModule } from '../directives/ripple/ripple.directive';
 import { isIE } from '../core/utils';
+import { EditorProvider } from '../core/edit-provider';
 
 export enum LabelPosition {
     BEFORE = 'before',
@@ -46,7 +48,7 @@ let nextId = 0;
     preserveWhitespaces: false,
     templateUrl: 'checkbox.component.html'
 })
-export class IgxCheckboxComponent implements ControlValueAccessor {
+export class IgxCheckboxComponent implements ControlValueAccessor, EditorProvider {
     /**
      *@hidden
      */
@@ -58,7 +60,7 @@ export class IgxCheckboxComponent implements ControlValueAccessor {
      * ```
      * @memberof IgxSwitchComponent
      */
-    @ViewChild('checkbox') public nativeCheckbox;
+    @ViewChild('checkbox') public nativeCheckbox: ElementRef;
     /**
      * Returns reference to the native label element.
      * ```typescript
@@ -367,6 +369,11 @@ export class IgxCheckboxComponent implements ControlValueAccessor {
      *@hidden
      */
     public registerOnTouched(fn: () => void) { this._onTouchedCallback = fn; }
+
+    /** @hidden */
+    getEditElement() {
+        return this.nativeCheckbox.nativeElement;
+    }
 }
 
 export const IGX_CHECKBOX_REQUIRED_VALIDATOR: Provider = {

--- a/projects/igniteui-angular/src/lib/core/edit-provider.ts
+++ b/projects/igniteui-angular/src/lib/core/edit-provider.ts
@@ -1,4 +1,7 @@
-/** Used for editor control components */
+/**
+ * Used for editor control components
+ * @hidden
+ */
 export interface EditorProvider {
     /** Return the focusable native element */
     getEditElement();

--- a/projects/igniteui-angular/src/lib/core/edit-provider.ts
+++ b/projects/igniteui-angular/src/lib/core/edit-provider.ts
@@ -1,0 +1,5 @@
+/** Used for editor control components */
+export interface EditorProvider {
+    /** Return the focusable native element */
+    getEditElement();
+}

--- a/projects/igniteui-angular/src/lib/date-picker/date-picker.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/date-picker/date-picker.component.spec.ts
@@ -331,6 +331,18 @@ describe('IgxDatePicker', () => {
         expect(datePicker.value.getSeconds()).toBe(date.getSeconds());
         expect(datePicker.value.getMilliseconds()).toBe(date.getMilliseconds());
     });
+
+    describe('EditorProvider', () => {
+        it('Should return correct edit element', () => {
+            const fixture = TestBed.createComponent(IgxDatePickerTestComponent);
+            fixture.detectChanges();
+
+            const instance = fixture.componentInstance.datePicker;
+            const editElement = fixture.debugElement.query(By.css('.igx-date-picker__input-date')).nativeElement;
+
+            expect(instance.getEditElement()).toBe(editElement);
+        });
+    });
 });
 
 @Component({

--- a/projects/igniteui-angular/src/lib/date-picker/date-picker.component.ts
+++ b/projects/igniteui-angular/src/lib/date-picker/date-picker.component.ts
@@ -35,6 +35,7 @@ import { IgxOverlayOutletDirective } from '../directives/toggle/toggle.directive
 import { OverlaySettings } from '../services';
 import { DeprecateClass } from '../core/deprecateDecorators';
 import { DateRangeDescriptor } from '../core/dates/dateRange';
+import { EditorProvider } from '../core/edit-provider';
 
 @Directive({
     selector: '[igxDatePickerTemplate]'
@@ -77,8 +78,7 @@ let NEXT_ID = 0;
     templateUrl: 'date-picker.component.html'
 })
 @DeprecateClass('\'igx-datePicker\' selector is deprecated. Use \'igx-date-picker\' selector instead.')
-export class IgxDatePickerComponent implements ControlValueAccessor, OnInit, OnDestroy {
-
+export class IgxDatePickerComponent implements ControlValueAccessor, EditorProvider, OnInit, OnDestroy {
     /**
      *An @Input property that sets the value of `id` attribute. If not provided it will be automatically generated.
      *```html
@@ -444,7 +444,7 @@ export class IgxDatePickerComponent implements ControlValueAccessor, OnInit, OnD
 
     private _specialDates: DateRangeDescriptor[] = null;
 
-    @ViewChild(IgxInputDirective) private input: IgxInputDirective;
+    @ViewChild(IgxInputDirective) protected input: IgxInputDirective;
 
     constructor(private resolver: ComponentFactoryResolver) { }
 
@@ -474,6 +474,11 @@ export class IgxDatePickerComponent implements ControlValueAccessor, OnInit, OnD
      *@hidden
      */
     public registerOnTouched(fn: () => void) { this._onTouchedCallback = fn; }
+
+    /** @hidden */
+    getEditElement() {
+        return this.input.nativeElement;
+    }
 
     /**
      *@hidden

--- a/projects/igniteui-angular/src/lib/directives/focus/focus.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/focus/focus.directive.spec.ts
@@ -21,6 +21,7 @@ describe('igxFocus', () => {
             declarations: [
                 IgxFocusDirective,
                 SetFocusComponent,
+                NoFocusComponent,
                 TriggerFocusOnClickComponent,
                 CheckboxPickerComponent
             ],
@@ -28,61 +29,39 @@ describe('igxFocus', () => {
         }).compileComponents();
     }));
 
-    it('The second element should be focused', () => {
+    it('The second element should be focused', fakeAsync(() => {
         const fix = TestBed.createComponent(SetFocusComponent);
         fix.detectChanges();
 
         const secondElem: HTMLElement = fix.debugElement.queryAll(By.all())[1].nativeElement;
 
-        fix.whenStable().then(() => {
-            fix.detectChanges();
-            expect(document.activeElement.isSameNode(secondElem)).toBe(true);
-        });
-    });
+        tick(16);
+        fix.detectChanges();
+        expect(document.activeElement).toBe(secondElem);
+    }));
 
-    it('Should select the last input element when click the button', () => {
+    it('Should select the last input element when click the button', fakeAsync(() => {
         const fix = TestBed.createComponent(TriggerFocusOnClickComponent);
         fix.detectChanges();
 
         const button: DebugElement = fix.debugElement.query(By.css('button'));
-        const divs = fix.debugElement.queryAll(By.all());
+        const divs = fix.debugElement.queryAll(By.css('div'));
         const lastDiv = divs[divs.length - 1 ].nativeElement;
 
         button.triggerEventHandler('click', null);
+        tick(16);
+        expect(document.activeElement).toBe(lastDiv);
+    }));
 
+    it('Should not focus when the focus state is set to false', fakeAsync(() => {
+        const fix = TestBed.createComponent(NoFocusComponent);
         fix.detectChanges();
+        tick(16);
+        const input = fix.debugElement.queryAll(By.css('input'))[0].nativeElement;
 
-        fix.whenStable().then(() => {
-            expect(document.activeElement.isSameNode(lastDiv));
-        });
-    });
-
-    it('Should not focus when the focus state is set to false', () => {
-        const template =
-        `
-            <input type="text" value="First" />
-            <input type="text" [igxFocus]="false" value="Fifth" />
-            <input type="text" value="Seventh" />
-        `;
-        TestBed.overrideComponent(SetFocusComponent, {
-            set: {
-                template
-            }
-        });
-
-        TestBed.compileComponents().then(() => {
-            const fix = TestBed.createComponent(SetFocusComponent);
-            fix.detectChanges();
-
-            const secondInput = fix.debugElement.queryAll(By.all())[1].nativeElement;
-
-            expect(document.activeElement.isSameNode(secondInput)).toBe(false);
-            expect(document.activeElement.isSameNode(document.body)).toBe(true);
-
-        }).catch((reason) => {
-            return Promise.reject(reason);
-        });
-    });
+        expect(document.activeElement).not.toBe(input);
+        expect(document.activeElement).toBe(document.body);
+    }));
 
     it('Should return EditorProvider element to focus', fakeAsync(() => {
         const elem = { nativeElement: document.createElement('button') };
@@ -123,11 +102,16 @@ describe('igxFocus', () => {
 class SetFocusComponent { }
 
 @Component({
+    template: `<input type="text" [igxFocus]="false" value="First" />`
+})
+class NoFocusComponent { }
+
+@Component({
     template:
     `
     <div>First</div>
     <div>Second</div>
-    <div [igxFocus]>Third</div>
+    <div tabindex="0" [igxFocus]>Third</div>
     <button (click)="focus()">Focus the third one</button>
     `
 })

--- a/projects/igniteui-angular/src/lib/directives/focus/focus.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/focus/focus.directive.ts
@@ -1,4 +1,6 @@
-import { Directive, ElementRef, Input, NgModule } from '@angular/core';
+import { Directive, ElementRef, Input, NgModule, Optional, Inject, Self } from '@angular/core';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { EditorProvider } from '../../core/edit-provider';
 
 @Directive({
     exportAs: 'igxFocus',
@@ -43,10 +45,13 @@ export class IgxFocusDirective {
      * @memberof IgxFocusDirective
      */
     get nativeElement() {
+        if (this.comp && this.comp[0] && this.comp[0].getEditElement) {
+            return (this.comp[0] as EditorProvider).getEditElement();
+        }
         return this.element.nativeElement;
     }
 
-    constructor(private element: ElementRef) { }
+    constructor(private element: ElementRef, @Inject(NG_VALUE_ACCESSOR) @Self() @Optional() private comp?: any[]) { }
     /**
      * Triggers the igxFocus state.
      * ```typescript

--- a/projects/igniteui-angular/src/lib/grids/cell.component.html
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.html
@@ -15,14 +15,14 @@
     </ng-container>
     <ng-container *ngIf="column.dataType === 'number'">
         <igx-input-group>
-            <input igxInput [(ngModel)]="gridAPI.get_cell_inEditMode(gridID).cell.editValue" [igxFocus]="focused"  type="number">
+            <input igxInput [(ngModel)]="gridAPI.get_cell_inEditMode(gridID).cell.editValue" [igxFocus]="focused" type="number">
         </igx-input-group>
     </ng-container>
     <ng-container *ngIf="column.dataType === 'boolean'">
-        <igx-checkbox [(ngModel)]="gridAPI.get_cell_inEditMode(gridID).cell.editValue" [checked]="gridAPI.get_cell_inEditMode(gridID).cell.editValue" [disableRipple]="true"></igx-checkbox>
+        <igx-checkbox [(ngModel)]="gridAPI.get_cell_inEditMode(gridID).cell.editValue" [checked]="gridAPI.get_cell_inEditMode(gridID).cell.editValue" [igxFocus]="focused" [disableRipple]="true"></igx-checkbox>
     </ng-container>
     <ng-container *ngIf="column.dataType === 'date'">
-        <igx-datePicker [(ngModel)]="gridAPI.get_cell_inEditMode(gridID).cell.editValue" [labelVisibility]="false"></igx-datePicker>
+        <igx-datePicker [(ngModel)]="gridAPI.get_cell_inEditMode(gridID).cell.editValue" [igxFocus]="focused" [labelVisibility]="false"></igx-datePicker>
     </ng-container>
 </ng-template>
 <ng-container *ngTemplateOutlet="template; context: context">

--- a/projects/igniteui-angular/src/lib/radio/radio.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/radio/radio.component.spec.ts
@@ -178,6 +178,18 @@ describe('IgxRadio', () => {
         expect(radioInstance.required).toBe(true);
         expect(nativeRadio.required).toBe(true);
     });
+
+    describe('EditorProvider', () => {
+        it('Should return correct edit element', () => {
+            const fixture = TestBed.createComponent(InitRadioComponent);
+            fixture.detectChanges();
+
+            const radioInstance = fixture.componentInstance.radio;
+            const editElement = fixture.debugElement.query(By.css('.igx-radio__input')).nativeElement;
+
+            expect(radioInstance.getEditElement()).toBe(editElement);
+        });
+    });
 });
 
 @Component({ template: `<igx-radio #radio>Radio</igx-radio>` })

--- a/projects/igniteui-angular/src/lib/radio/radio.component.ts
+++ b/projects/igniteui-angular/src/lib/radio/radio.component.ts
@@ -4,10 +4,12 @@ import {
     HostBinding,
     Input,
     Output,
-    ViewChild
+    ViewChild,
+    ElementRef
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { isIE } from '../core/utils';
+import { EditorProvider } from '../core/edit-provider';
 
 export interface IChangeRadioEventArgs {
     value: any;
@@ -40,7 +42,7 @@ const noop = () => { };
     templateUrl: 'radio.component.html'
 })
 
-export class IgxRadioComponent implements ControlValueAccessor {
+export class IgxRadioComponent implements ControlValueAccessor, EditorProvider {
     /**
      * Returns reference to native radio element.
      * ```typescript
@@ -48,7 +50,7 @@ export class IgxRadioComponent implements ControlValueAccessor {
      * ```
      * @memberof IgxSwitchComponent
      */
-    @ViewChild('radio') public nativeRadio;
+    @ViewChild('radio') public nativeRadio: ElementRef;
     /**
      * Returns reference to native label element.
      * ```typescript
@@ -308,6 +310,10 @@ export class IgxRadioComponent implements ControlValueAccessor {
     public writeValue(value: any) {
         this._value = value;
         this.checked = (this._value === this.value);
+    }
+    /** @hidden */
+    getEditElement() {
+        return this.nativeRadio.nativeElement;
     }
     /**
      *@hidden

--- a/projects/igniteui-angular/src/lib/slider/slider.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/slider/slider.component.spec.ts
@@ -627,6 +627,29 @@ describe('IgxSlider', () => {
         expect((slider.value as IRangeSliderValue).lower).toBe(5);
         expect((slider.value as IRangeSliderValue).upper).toBe(7);
     });
+
+    describe('EditorProvider', () => {
+        it('Should return correct edit element (single)', () => {
+            const fixture = TestBed.createComponent(SliderInitializeTestComponent);
+            fixture.detectChanges();
+
+            const instance = fixture.componentInstance.slider;
+            const editElement = fixture.debugElement.query(By.css('.igx-slider__thumb-to')).nativeElement;
+
+            expect(instance.getEditElement()).toBe(editElement);
+        });
+
+        it('Should return correct edit element (range)', () => {
+            const fixture = TestBed.createComponent(SliderInitializeTestComponent);
+            const instance = fixture.componentInstance.slider;
+            instance.type = SliderType.RANGE;
+            fixture.detectChanges();
+
+            const editElement = fixture.debugElement.query(By.css('.igx-slider__thumb-from')).nativeElement;
+
+            expect(instance.getEditElement()).toBe(editElement);
+        });
+    });
 });
 @Component({
     selector: 'igx-slider-test-component',

--- a/projects/igniteui-angular/src/lib/slider/slider.component.ts
+++ b/projects/igniteui-angular/src/lib/slider/slider.component.ts
@@ -5,6 +5,7 @@ import {
     ViewChild
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { EditorProvider } from '../core/edit-provider';
 
 export enum SliderType {
     /**
@@ -57,7 +58,7 @@ let NEXT_ID = 0;
     selector: 'igx-slider',
     templateUrl: 'slider.component.html'
 })
-export class IgxSliderComponent implements ControlValueAccessor, OnInit, AfterViewInit {
+export class IgxSliderComponent implements ControlValueAccessor, EditorProvider, OnInit, AfterViewInit {
 
     /**
      * An @Input property that sets the value of the `id` attribute.
@@ -540,6 +541,11 @@ export class IgxSliderComponent implements ControlValueAccessor, OnInit, AfterVi
      */
     public registerOnTouched(fn: any): void {
         this._onTouchedCallback = fn;
+    }
+
+    /** @hidden */
+    getEditElement() {
+        return this.isRange ? this.thumbFrom.nativeElement : this.thumbTo.nativeElement;
     }
 
     /**

--- a/projects/igniteui-angular/src/lib/switch/switch.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/switch/switch.component.spec.ts
@@ -178,6 +178,18 @@ describe('IgxSwitch', () => {
         expect(testInstance.subscribed).toBe(false);
         expect(testInstance.clickCounter).toEqual(2);
     });
+
+    describe('EditorProvider', () => {
+        it('Should return correct edit element', () => {
+            const fixture = TestBed.createComponent(SwitchSimpleComponent);
+            fixture.detectChanges();
+
+            const instance = fixture.componentInstance.switch;
+            const editElement = fixture.debugElement.query(By.css('.igx-switch__input')).nativeElement;
+
+            expect(instance.getEditElement()).toBe(editElement);
+        });
+    });
 });
 
 @Component({ template: `<igx-switch>Init</igx-switch>` })

--- a/projects/igniteui-angular/src/lib/switch/switch.component.ts
+++ b/projects/igniteui-angular/src/lib/switch/switch.component.ts
@@ -8,11 +8,13 @@ import {
     NgModule,
     Output,
     Provider,
-    ViewChild
+    ViewChild,
+    ElementRef
 } from '@angular/core';
 import { CheckboxRequiredValidator, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { IgxRippleModule } from '../directives/ripple/ripple.directive';
 import { isIE } from '../core/utils';
+import { EditorProvider } from '../core/edit-provider';
 
 export enum SwitchLabelPosition {
     BEFORE = 'before',
@@ -44,7 +46,7 @@ let nextId = 0;
     selector: 'igx-switch',
     templateUrl: 'switch.component.html'
 })
-export class IgxSwitchComponent implements ControlValueAccessor {
+export class IgxSwitchComponent implements ControlValueAccessor, EditorProvider {
     /**
      *@hidden
      */
@@ -56,7 +58,7 @@ export class IgxSwitchComponent implements ControlValueAccessor {
      * ```
      * @memberof IgxSwitchComponent
      */
-    @ViewChild('checkbox') public nativeCheckbox;
+    @ViewChild('checkbox') public nativeCheckbox: ElementRef;
     /**
      * Returns reference to the native label element.
      * ```typescript
@@ -322,6 +324,11 @@ export class IgxSwitchComponent implements ControlValueAccessor {
         this._value = value;
         this.checked = !!this._value;
     }
+    /** @hidden */
+    getEditElement() {
+        return this.nativeCheckbox.nativeElement;
+    }
+
     /**
      *@hidden
      */

--- a/projects/igniteui-angular/src/lib/time-picker/time-picker.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/time-picker/time-picker.component.spec.ts
@@ -941,6 +941,18 @@ describe('IgxTimePicker', () => {
         const selectAMPM = AMPMColumn.children[3];
         expect(selectAMPM.nativeElement.innerText).toBe('AM');
     }));
+
+    describe('EditorProvider', () => {
+        it('Should return correct edit element', () => {
+            const fixture = TestBed.createComponent(IgxTimePickerTestComponent);
+            fixture.detectChanges();
+
+            const instance = fixture.componentInstance.timePicker;
+            const editElement = fixture.debugElement.query(By.css('input[igxInput]')).nativeElement;
+
+            expect(instance.getEditElement()).toBe(editElement);
+        });
+    });
 });
 
 @Component({

--- a/projects/igniteui-angular/src/lib/time-picker/time-picker.component.ts
+++ b/projects/igniteui-angular/src/lib/time-picker/time-picker.component.ts
@@ -32,6 +32,7 @@ import {
     IgxTimePickerTemplateDirective
 } from './time-picker.directives';
 import { Subscription } from 'rxjs';
+import { EditorProvider } from '../core/edit-provider';
 
 let NEXT_ID = 0;
 export class TimePickerHammerConfig extends HammerGestureConfig {
@@ -67,7 +68,7 @@ export interface IgxTimePickerValidationFailedEventArgs {
     styles: [':host {display: block;}'],
     templateUrl: 'time-picker.component.html'
 })
-export class IgxTimePickerComponent implements ControlValueAccessor, OnInit, OnDestroy, DoCheck, AfterViewInit {
+export class IgxTimePickerComponent implements ControlValueAccessor, EditorProvider, OnInit, OnDestroy, DoCheck, AfterViewInit {
 
     private _value: Date;
 
@@ -522,6 +523,11 @@ export class IgxTimePickerComponent implements ControlValueAccessor, OnInit, OnD
      * @hidden
      */
     public registerOnTouched(fn: () => void) { this._onTouchedCallback = fn; }
+
+    /** @hidden */
+    getEditElement() {
+        return this._input.nativeElement;
+    }
 
     private _onTouchedCallback: () => void = () => { };
 


### PR DESCRIPTION
Closes # .  

Additional information related to this pull request:
Taking advantage of the fact that all composite editors are all provided as `NG_VALUE_ACCESSOR` (needed a common token) and making them optional DI for the `igxFocus` so the directive can receive potential host component and focus its inner field instead.
