### PR TITLE
Fix - Transaction - Dates are properly compared when adding transaction

### DIFF
--- a/projects/igniteui-angular/src/lib/core/utils.ts
+++ b/projects/igniteui-angular/src/lib/core/utils.ts
@@ -88,6 +88,20 @@ export function isDate(value: any) {
 }
 
 /**
+ * Cehcks if the two passed arguments are equal
+ * Currently supports date objects
+ * @param obj1
+ * @param obj2
+ * @returns: `boolean`
+ */
+export function isEqual(obj1, obj2): boolean {
+    if (isDate(obj1) && isDate(obj2)) {
+        return obj1.getTime() === obj2.getTime();
+    }
+    return obj1 === obj2;
+}
+
+/**
  *@hidden
  */
 export const enum KEYCODES {

--- a/projects/igniteui-angular/src/lib/grids/api.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/api.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { Subject } from 'rxjs';
-import { cloneArray } from '../core/utils';
+import { cloneArray, isEqual } from '../core/utils';
 import { DataUtil } from '../data-operations/data-util';
 import { IFilteringExpression, FilteringLogic } from '../data-operations/filtering-expression.interface';
 import { IGroupByExpandState } from '../data-operations/groupby-expand-state.interface';
@@ -285,8 +285,7 @@ export class GridBaseAPIService <T extends IgxGridBaseComponent> {
             }
 
             //  if edit (new) value is same as old value do nothing here
-            if (oldValue !== undefined && oldValue === args.newValue) { return; }
-
+            if (oldValue !== undefined && isEqual(oldValue, args.newValue)) { return; }
             const transaction: Transaction = { id: rowID, type: TransactionType.UPDATE, newValue: { [column.field]: args.newValue } };
             if (grid.transactions.enabled) {
                 grid.transactions.add(transaction, rowData);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -23,7 +23,7 @@ import {
 import { IgxStringFilteringOperand } from '../../data-operations/filtering-condition';
 import { SortingDirection } from '../../data-operations/sorting-expression.interface';
 import { IgxGridCellComponent } from '../cell.component';
-import { TransactionType } from '../../services';
+import { TransactionType, Transaction } from '../../services';
 import { configureTestSuite } from '../../test-utils/configure-suite';
 
 const DEBOUNCETIME = 30;
@@ -2688,6 +2688,71 @@ describe('IgxGrid Component Tests', () => {
                 tick();
                 fixture.detectChanges();
                 expect(cell.value).toBe('Updated value');
+            }));
+
+            it(`Should not log a transaction when a cell's value does not change`, fakeAsync(() => {
+                const fixture = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
+                fixture.detectChanges();
+
+                const grid = fixture.componentInstance.grid;
+                const cell = grid.getCellByColumn(0, 'ProductName');
+                const initialState = grid.transactions.aggregatedState(false);
+                expect(cell.value).toBe('Chai');
+
+                // Set to same value
+                cell.update('Chai');
+                tick();
+                fixture.detectChanges();
+                expect(cell.value).toBe('Chai');
+                expect(grid.transactions.aggregatedState(false)).toEqual(initialState);
+
+                // Change value and check if it's logged
+                cell.update('Updated value');
+                tick();
+                fixture.detectChanges();
+                expect(cell.value).toBe('Updated value');
+                const expectedTransaction: Transaction = {
+                    id: 1,
+                    newValue: {ProductName: 'Updated value'},
+                    type: TransactionType.UPDATE
+                };
+                expect(grid.transactions.aggregatedState(false)).toEqual([expectedTransaction]);
+            }));
+
+            it(`Should not log a transaction when a cell's value does not change - Date`, fakeAsync(() => {
+                const fixture = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
+                fixture.detectChanges();
+
+                const grid = fixture.componentInstance.grid;
+                const cellStock = grid.getCellByColumn(0, 'UnitsInStock');
+                const cellDate = grid.getCellByColumn(0, 'OrderDate');
+                const initialCellValue = cellDate.value;
+                const initialState = grid.transactions.aggregatedState(false);
+
+                // Enter edit mode
+                cellDate.onKeydownEnterEditMode({ stopPropagation: () => {}, preventDefault: () => {}});
+                tick();
+                fixture.detectChanges();
+                // Perform Shift + Tab to UnitsInStock
+                cellDate.nativeElement.dispatchEvent(new KeyboardEvent('keydown', {key: 'tab', shiftKey: true, code: 'tab'}));
+                tick();
+                fixture.detectChanges();
+                // Exit edit mode
+                grid.endRowEdit(true);
+                tick();
+                fixture.detectChanges();
+                expect(grid.transactions.aggregatedState(false)).toEqual(initialState);
+
+                const newValue = new Date('01/01/2000');
+                cellDate.update(newValue);
+                tick();
+                fixture.detectChanges();
+                const expectedTransaction: Transaction = {
+                    id: 1,
+                    newValue: {OrderDate: newValue},
+                    type: TransactionType.UPDATE
+                };
+                expect(grid.transactions.aggregatedState(false)).toEqual([expectedTransaction]);
             }));
 
             it('Should allow to change of a cell in added row in grid with transactions', fakeAsync(() => {


### PR DESCRIPTION
Closes #2848.  

When checking if a transaction needs to be added, instead of using `===`, the grid api will check using `isEqual` (new in `utils`) - Currently works only for `Date` objects, checking `date.getTime()` instead of just `===` (and thus avoiding to add new transaction when none are needed)

