### PR TITLE
Add support for first-class functions for older versions of Sass

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/base/utilities/_functions.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/base/utilities/_functions.scss
@@ -401,5 +401,9 @@
         @return map-get($themes, $theme);
     }
 
-    @return call(get-function(#{$theme}-theme));
+    @if (function-exists('get-function')) {
+        @return call(get-function(#{$theme}-theme));
+      } @else {
+        @return call((#{$theme}-theme));
+    }
 }

--- a/projects/igniteui-angular/src/lib/core/styles/base/utilities/_functions.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/base/utilities/_functions.scss
@@ -403,7 +403,7 @@
 
     @if (function-exists('get-function')) {
         @return call(get-function(#{$theme}-theme));
-      } @else {
+    } @else {
         @return call((#{$theme}-theme));
     }
 }


### PR DESCRIPTION
Closes #2814.

You can find additional information in the issue.

