### PR TITLE
Feat - Transaction - Add canRedo / canUndo properties

### DIFF
--- a/projects/igniteui-angular/src/lib/services/transaction/base-transaction.ts
+++ b/projects/igniteui-angular/src/lib/services/transaction/base-transaction.ts
@@ -7,6 +7,12 @@ export class IgxBaseTransactionService implements TransactionService {
     protected _isPending = false;
     protected _pendingTransactions: Transaction[] = [];
     protected _pendingStates: Map<any, State> = new Map();
+    public canUndo = false;
+    public canRedo = false;
+    public get enabled(): boolean {
+        return this._isPending;
+    }
+
     public onStateUpdate = new EventEmitter<void>();
 
     public add(transaction: Transaction, recordRef?: any): void {
@@ -33,10 +39,6 @@ export class IgxBaseTransactionService implements TransactionService {
 
     public getState(id: any): State {
         return this._pendingStates.get(id);
-    }
-
-    public get enabled(): boolean {
-        return this._isPending;
     }
 
     public getAggregatedValue(id: any, mergeChanges: boolean): any {

--- a/projects/igniteui-angular/src/lib/services/transaction/base-transaction.ts
+++ b/projects/igniteui-angular/src/lib/services/transaction/base-transaction.ts
@@ -7,8 +7,12 @@ export class IgxBaseTransactionService implements TransactionService {
     protected _isPending = false;
     protected _pendingTransactions: Transaction[] = [];
     protected _pendingStates: Map<any, State> = new Map();
-    public canUndo = false;
-    public canRedo = false;
+    public get canRedo(): boolean {
+        return false;
+    }
+    public get canUndo(): boolean {
+        return false;
+    }
     public get enabled(): boolean {
         return this._isPending;
     }

--- a/projects/igniteui-angular/src/lib/services/transaction/igx-transaction.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/transaction/igx-transaction.spec.ts
@@ -452,6 +452,36 @@ describe('IgxTransaction', () => {
             trans.clear();
         });
 
+        it('Should properly confirm the length of the undo/redo stacks', () => {
+            const originalData = SampleTestData.generateProductData(11);
+            const transaction = new IgxTransactionService();
+            expect(transaction).toBeDefined();
+
+            // Stacks are clear by default
+            expect(transaction.canRedo).toBeFalsy();
+            expect(transaction.canUndo).toBeFalsy();
+            let addItem: Transaction = { id: 1, type: TransactionType.UPDATE, newValue: { Category: 'Something' } };
+            transaction.add(addItem);
+            expect(transaction.canRedo).toBeFalsy();
+            expect(transaction.canUndo).toBeTruthy();
+            addItem = { id: 2, type: TransactionType.UPDATE, newValue: { Category: 'Something 2' } };
+            transaction.add(addItem);
+            expect(transaction.canRedo).toBeFalsy();
+            expect(transaction.canUndo).toBeTruthy();
+            transaction.undo();
+            expect(transaction.canRedo).toBeTruthy();
+            expect(transaction.canUndo).toBeTruthy();
+            transaction.undo();
+            expect(transaction.canRedo).toBeTruthy();
+            expect(transaction.canUndo).toBeFalsy();
+            transaction.redo();
+            expect(transaction.canRedo).toBeTruthy();
+            expect(transaction.canUndo).toBeTruthy();
+            transaction.redo();
+            expect(transaction.canRedo).toBeFalsy();
+            expect(transaction.canUndo).toBeTruthy();
+        });
+
         it('Should update data when data is list of objects', () => {
             const originalData = SampleTestData.generateProductData(50);
             const trans = new IgxTransactionService();

--- a/projects/igniteui-angular/src/lib/services/transaction/igx-transaction.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/transaction/igx-transaction.spec.ts
@@ -460,11 +460,11 @@ describe('IgxTransaction', () => {
             // Stacks are clear by default
             expect(transaction.canRedo).toBeFalsy();
             expect(transaction.canUndo).toBeFalsy();
-            let addItem: Transaction = { id: 1, type: TransactionType.UPDATE, newValue: { Category: 'Something' } };
+            let addItem: Transaction = { id: 1, type: TransactionType.ADD, newValue: { Category: 'Something' } };
             transaction.add(addItem);
             expect(transaction.canRedo).toBeFalsy();
             expect(transaction.canUndo).toBeTruthy();
-            addItem = { id: 2, type: TransactionType.UPDATE, newValue: { Category: 'Something 2' } };
+            addItem = { id: 2, type: TransactionType.ADD, newValue: { Category: 'Something 2' } };
             transaction.add(addItem);
             expect(transaction.canRedo).toBeFalsy();
             expect(transaction.canUndo).toBeTruthy();

--- a/projects/igniteui-angular/src/lib/services/transaction/igx-transaction.ts
+++ b/projects/igniteui-angular/src/lib/services/transaction/igx-transaction.ts
@@ -9,6 +9,15 @@ export class IgxTransactionService extends IgxBaseTransactionService {
     private _redoStack: { transaction: Transaction, recordRef: any }[] = [];
     private _undoStack: { transaction: Transaction, recordRef: any }[] = [];
     private _states: Map<any, State> = new Map();
+
+    get canUndo(): boolean {
+        return this._undoStack.length > 0;
+    }
+
+    get canRedo(): boolean {
+        return this._redoStack.length > 0;
+    }
+
     public onStateUpdate = new EventEmitter<void>();
 
     public add(transaction: Transaction, recordRef?: any): void {
@@ -36,7 +45,7 @@ export class IgxTransactionService extends IgxBaseTransactionService {
     public aggregatedState(mergeChanges: boolean): Transaction[] {
         const result: Transaction[] = [];
         this._states.forEach((state: State, key: any) => {
-            const value = mergeChanges ? this.getAggregatedValue(key, mergeChanges) : state.value;
+            const value = mergeChanges ? this.mergeValues(state.recordRef, state.value) : state.value;
             result.push({ id: key, newValue: value, type: state.type });
         });
         return result;

--- a/projects/igniteui-angular/src/lib/services/transaction/transaction.ts
+++ b/projects/igniteui-angular/src/lib/services/transaction/transaction.ts
@@ -30,6 +30,16 @@ export interface TransactionService {
     onStateUpdate?: EventEmitter<void>;
 
     /**
+     * @returns if there are any transactions in the Undo stack
+     */
+    canUndo: boolean;
+
+    /**
+     * @returns if there are any transactions in the Redo stack
+     */
+    canRedo: boolean;
+
+    /**
      * Adds provided  transaction with recordRef if any
      * @param transaction Transaction to be added
      * @param recordRef Reference to the value of the record in the data source related to the changed item
@@ -53,7 +63,7 @@ export interface TransactionService {
     redo(): void;
 
     /**
-     * Returns aggregated state of all transactions including pending ones
+     * Returns aggregated changes from all transactions
      * @param mergeChanges If set to true will merge each state's value over relate recordRef
      * and will record resulting value in the related transaction
      * @returns Collection of aggregated transactions for each changed record


### PR DESCRIPTION
Closes #2869.  

Adding `canRedo` and `canUndo` properties to transaction interface
