### PR TITLE
Fix - Selection - Selection header properly checks against filteredData

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -3659,12 +3659,13 @@ export abstract class IgxGridBaseComponent implements OnInit, OnDestroy, AfterCo
      */
     public checkHeaderCheckboxStatus(headerStatus?: boolean) {
         if (headerStatus === undefined) {
-            this.allRowsSelected = this.selection.are_all_selected(this.id, this.dataLength);
+            const dataLength = this.filteredData ? this.filteredData.length : this.dataLength;
+            this.allRowsSelected = this.selection.are_all_selected(this.id, dataLength);
             if (this.headerCheckbox) {
                 this.headerCheckbox.indeterminate = !this.allRowsSelected && !this.selection.are_none_selected(this.id);
                 if (!this.headerCheckbox.indeterminate) {
                     this.headerCheckbox.checked =
-                        this.selection.are_all_selected(this.id, this.dataLength);
+                        this.selection.are_all_selected(this.id, dataLength);
                 }
             }
             this.cdr.markForCheck();


### PR DESCRIPTION
Closes #2793.  

`checkHeaderCheckboxStatus` proprely checks if all rows are selected using `filteredData.length` instead of `dataLength` when filtering is in place

