### PR TITLE
Fix - Selection - Selection header properly checks against filteredData - 6.1.x

### DIFF
--- a/projects/igniteui-angular/src/lib/grid/grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grid/grid.component.ts
@@ -3659,7 +3659,7 @@ export class IgxGridComponent implements OnInit, OnDestroy, AfterContentInit, Af
             if (this.headerCheckbox) {
                 this.headerCheckbox.indeterminate = !this.allRowsSelected && !this.selection.are_none_selected(this.id);
                 if (!this.headerCheckbox.indeterminate) {
-                    this.headerCheckbox.checked = this.selection.are_all_selected(this.id, data);
+                    this.headerCheckbox.checked = this.allRowsSelected;
                 }
             }
             this.cdr.markForCheck();

--- a/projects/igniteui-angular/src/lib/grid/grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grid/grid.component.ts
@@ -3654,11 +3654,12 @@ export class IgxGridComponent implements OnInit, OnDestroy, AfterContentInit, Af
      */
     public checkHeaderCheckboxStatus(headerStatus?: boolean) {
         if (headerStatus === undefined) {
-            this.allRowsSelected = this.selection.are_all_selected(this.id, this.data);
+            const data = this.filteredData && this.filteredData.length ?  this.filteredData : this.data;
+            this.allRowsSelected = this.selection.are_all_selected(this.id, data);
             if (this.headerCheckbox) {
                 this.headerCheckbox.indeterminate = !this.allRowsSelected && !this.selection.are_none_selected(this.id);
                 if (!this.headerCheckbox.indeterminate) {
-                    this.headerCheckbox.checked = this.selection.are_all_selected(this.id, this.data);
+                    this.headerCheckbox.checked = this.selection.are_all_selected(this.id, data);
                 }
             }
             this.cdr.markForCheck();


### PR DESCRIPTION
#2793
`checkHeaderCheckboxStatus` properly checks if all rows are selected using `filteredData` instead of `data` when filtering is in place