### PR TITLE
Fix - Grid - Dirty state is applied when value of cell is changed to false

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -461,7 +461,7 @@ export class IgxGridCellComponent implements OnInit, AfterViewInit {
         if (this.grid.rowEditable) {
             const rowCurrentState = this.grid.transactions.getAggregatedValue(this.row.rowID, false);
             if (rowCurrentState) {
-                return rowCurrentState && rowCurrentState[this.column.field];
+                return rowCurrentState[this.column.field] !== undefined && rowCurrentState[this.column.field] !== null;
             }
         } else {
             const rowTransaction: State = this.grid.transactions.getState(this.row.rowID);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -2869,6 +2869,27 @@ describe('IgxGrid Component Tests', () => {
                 fixture.detectChanges();
                 expect(cell.value).toBe('Changed product');
             }));
+
+            it('Should properly mark cell/row as dirty if new value evaluates to `false`', fakeAsync(() => {
+                const fixture = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
+                fixture.detectChanges();
+
+                const grid = fixture.componentInstance.grid;
+                const targetRow = grid.getRowByIndex(0);
+                let targetRowElement = targetRow.element.nativeElement;
+                let targetCellElement = targetRow.cells.toArray()[1].nativeElement;
+                expect(targetRowElement.classList).not.toContain('igx-grid__tr--edited', 'row contains edited class w/o edits');
+                expect(targetCellElement.classList).not.toContain('igx-grid__td--edited', 'cell contains edited class w/o edits');
+
+                targetRow.cells.toArray()[1].update('');
+                tick();
+                fixture.detectChanges();
+
+                targetRowElement = targetRow.element.nativeElement;
+                targetCellElement = targetRow.cells.toArray()[1].nativeElement;
+                expect(targetRowElement.classList).toContain('igx-grid__tr--edited', 'row does not contain edited class w/ edits');
+                expect(targetCellElement.classList).toContain('igx-grid__td--edited', 'cell does not contain edited class w/ edits');
+            }));
         });
 
         describe('Row Editing - Grouping',  () => {


### PR DESCRIPTION
Closes #2940

Cell dirty state was checking if the row exists in the transaction log and if the value of the cell is present, but the check returned `false` if the value of the cell evaluates to `false` (e.g. `false`, `0`, `''`)

