### PR TITLE
fix(grid): #2507 prevent scrolling on arrow keys

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -15,10 +15,11 @@ import { IgxSelectionAPIService } from '../core/selection';
 import { IgxTextHighlightDirective } from '../directives/text-highlight/text-highlight.directive';
 import { GridBaseAPIService } from './api.service';
 import { IgxColumnComponent } from './column.component';
-import { isNavigationKey, valToPxlsUsingRange } from '../core/utils';
+import { isNavigationKey, valToPxlsUsingRange, KEYS } from '../core/utils';
 import { State } from '../services/index';
 import { IgxGridBaseComponent, IGridEditEventArgs } from './grid-base.component';
 import { first } from 'rxjs/operators';
+import { DataType } from '../data-operations/data-util';
 /**
  * Providing reference to `IgxGridCellComponent`:
  * ```typescript
@@ -698,6 +699,12 @@ export class IgxGridCellComponent implements OnInit, AfterViewInit {
         }
 
         if (this.inEditMode && isNavigationKey(key)) {
+            let editCell = this.gridAPI.get_cell_inEditMode(this.gridID);
+            let column = this.gridAPI.get(this.gridID).columns[editCell.cellID.columnID];
+            
+            if((column.dataType ===  DataType.Boolean && (key !== KEYS.SPACE && key !== KEYS.SPACE_IE)) || column.dataType === DataType.Date) {
+                event.preventDefault();
+            }
             return;
         }
 


### PR DESCRIPTION
Closes #2507 

Added event.preventDefault for date and boolean cells(columns) in editMode, to stop the page scrolling with arrow up/down.
