### PR TITLE
CellID is reference 

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -17,14 +17,8 @@ import { GridBaseAPIService } from './api.service';
 import { IgxColumnComponent } from './column.component';
 import { isNavigationKey, valToPxlsUsingRange } from '../core/utils';
 import { State } from '../services/index';
-import { IgxGridBaseComponent, IGridEditEventArgs } from './grid-base.component';
+import { IgxGridBaseComponent, IGridEditEventArgs, ICellID } from './grid-base.component';
 import { first } from 'rxjs/operators';
-
-export interface CellID {
-    rowID: any;
-    columnID: number;
-    rowIndex: number;
-}
 
 /**
  * Providing reference to `IgxGridCellComponent`:
@@ -248,7 +242,7 @@ export class IgxGridCellComponent implements OnInit, AfterViewInit {
      * ```
      * @memberof IgxGridCellComponent
      */
-    public get cellID(): CellID {
+    public get cellID(): ICellID {
         const primaryKey = this.grid.primaryKey;
         this._cellID.rowID = primaryKey ? this.row.rowData[primaryKey] : this.row.rowData;
         this._cellID.columnID = this.columnIndex;
@@ -494,7 +488,7 @@ export class IgxGridCellComponent implements OnInit, AfterViewInit {
     public editValue;
     public focused = false;
     protected isSelected = false;
-    private _cellID: CellID = { rowID: null, columnID: null, rowIndex: null };
+    private _cellID: ICellID = { rowID: null, columnID: null, rowIndex: null };
     private cellSelectionID: string;
     private prevCellSelectionID: string;
     private previousCellEditMode = false;

--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -19,6 +19,13 @@ import { isNavigationKey, valToPxlsUsingRange } from '../core/utils';
 import { State } from '../services/index';
 import { IgxGridBaseComponent, IGridEditEventArgs } from './grid-base.component';
 import { first } from 'rxjs/operators';
+
+export interface CellID {
+    rowID: any;
+    columnID: number;
+    rowIndex: number;
+}
+
 /**
  * Providing reference to `IgxGridCellComponent`:
  * ```typescript
@@ -241,10 +248,12 @@ export class IgxGridCellComponent implements OnInit, AfterViewInit {
      * ```
      * @memberof IgxGridCellComponent
      */
-    public get cellID() {
+    public get cellID(): CellID {
         const primaryKey = this.grid.primaryKey;
-        const rowID = primaryKey ? this.row.rowData[primaryKey] : this.row.rowData;
-        return { rowID, columnID: this.columnIndex, rowIndex: this.rowIndex };
+        this._cellID.rowID = primaryKey ? this.row.rowData[primaryKey] : this.row.rowData;
+        this._cellID.columnID = this.columnIndex;
+        this._cellID.rowIndex = this.rowIndex;
+        return this._cellID;
     }
 
     /**
@@ -485,6 +494,7 @@ export class IgxGridCellComponent implements OnInit, AfterViewInit {
     public editValue;
     public focused = false;
     protected isSelected = false;
+    private _cellID: CellID = { rowID: null, columnID: null, rowIndex: null };
     private cellSelectionID: string;
     private prevCellSelectionID: string;
     private previousCellEditMode = false;

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -74,6 +74,11 @@ const MINIMUM_COLUMN_WIDTH = 136;
 
 export const IgxGridTransaction = new InjectionToken<string>('IgxGridTransaction');
 
+export interface ICellID {
+    rowID: any;
+    columnID: any;
+    rowIndex: number;
+}
 export interface IGridCellEventArgs {
     cell: IgxGridCellComponent;
     event: Event;
@@ -81,11 +86,7 @@ export interface IGridCellEventArgs {
 
 export interface IGridEditEventArgs extends CancelableEventArgs {
     rowID: any;
-    cellID?: {
-        rowID: any,
-        columnID: any,
-        rowIndex: number
-    };
+    cellID?: ICellID;
     oldValue: any;
     newValue?: any;
     event?: Event;

--- a/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
@@ -1194,6 +1194,19 @@ describe('IgxGrid - Cell component', () => {
         expect(columns[4].editable).toBeFalsy();
         expect(columns[5].editable).toBeFalsy();
     }));
+
+    it('Select and deselect cell using selection service', () => {
+        const fix = TestBed.createComponent(DefaultGridComponent);
+        fix.detectChanges();
+
+        const grid = fix.componentInstance.instance;
+        const cell = grid.getCellByColumn(0, 'index');
+        const cellSelectionID = grid.id + '-cell';
+        grid.selection.select_item(cellSelectionID, cell.cellID);
+        expect(grid.selection.size(cellSelectionID)).toBe(1);
+        grid.selection.deselect_item(cellSelectionID, cell.cellID);
+        expect(grid.selection.size(cellSelectionID)).toBe(0);
+    });
 });
 
 @Component({


### PR DESCRIPTION
Closes #2636  

Additional information related to this pull request:
When requested, `cellID` is now reference, instead of new object. This also means that selection will work, when using `cellID` as identifier.

