### PR TITLE
CellID is reference

### DIFF
--- a/projects/igniteui-angular/src/lib/grid/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grid/cell.component.ts
@@ -21,7 +21,7 @@ import { IgxColumnComponent } from './column.component';
 import { Subject, animationFrameScheduler as rAF, fromEvent, combineLatest } from 'rxjs';
 import { IgxGridGroupByRowComponent } from './groupby-row.component';
 
-export interface CellID {
+export interface ICellID {
     rowID: any;
     columnID: number;
     rowIndex: number;
@@ -247,7 +247,7 @@ export class IgxGridCellComponent implements OnInit, OnDestroy, AfterViewInit {
      * ```
      * @memberof IgxGridCellComponent
      */
-    public get cellID(): CellID {
+    public get cellID(): ICellID {
         const primaryKey = this.grid.primaryKey;
         this._cellID.rowID = primaryKey ? this.row.rowData[primaryKey] : this.row.rowData;
         this._cellID.columnID = this.columnIndex;
@@ -553,7 +553,7 @@ export class IgxGridCellComponent implements OnInit, OnDestroy, AfterViewInit {
             takeUntil(this.destroy$),
             sampleTime(0, rAF)
         );
-    private _cellID: CellID = { rowID: null, columnID: null, rowIndex: null };
+    private _cellID: ICellID = { rowID: null, columnID: null, rowIndex: null };
     private cellSelectionID: string;
     private prevCellSelectionID: string;
     private previousCellEditMode = false;

--- a/projects/igniteui-angular/src/lib/grid/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grid/cell.component.ts
@@ -21,6 +21,12 @@ import { IgxColumnComponent } from './column.component';
 import { Subject, animationFrameScheduler as rAF, fromEvent, combineLatest } from 'rxjs';
 import { IgxGridGroupByRowComponent } from './groupby-row.component';
 
+export interface CellID {
+    rowID: any;
+    columnID: number;
+    rowIndex: number;
+}
+
 /**
  * Providing reference to `IgxGridCellComponent`:
  * ```typescript
@@ -241,10 +247,12 @@ export class IgxGridCellComponent implements OnInit, OnDestroy, AfterViewInit {
      * ```
      * @memberof IgxGridCellComponent
      */
-    public get cellID() {
+    public get cellID(): CellID {
         const primaryKey = this.grid.primaryKey;
-        const rowID = primaryKey ? this.row.rowData[primaryKey] : this.row.rowData;
-        return { rowID, columnID: this.columnIndex, rowIndex: this.rowIndex };
+        this._cellID.rowID = primaryKey ? this.row.rowData[primaryKey] : this.row.rowData;
+        this._cellID.columnID = this.columnIndex;
+        this._cellID.rowIndex = this.rowIndex;
+        return this._cellID;
     }
 
     /**
@@ -545,6 +553,7 @@ export class IgxGridCellComponent implements OnInit, OnDestroy, AfterViewInit {
             takeUntil(this.destroy$),
             sampleTime(0, rAF)
         );
+    private _cellID: CellID = { rowID: null, columnID: null, rowIndex: null };
     private cellSelectionID: string;
     private prevCellSelectionID: string;
     private previousCellEditMode = false;

--- a/projects/igniteui-angular/src/lib/grid/cell.spec.ts
+++ b/projects/igniteui-angular/src/lib/grid/cell.spec.ts
@@ -1056,6 +1056,19 @@ describe('IgxGrid - Cell component', () => {
             done();
         });
     });
+
+    it('Select and deselect cell using selection service', () => {
+        const fix = TestBed.createComponent(DefaultGridComponent);
+        fix.detectChanges();
+
+        const grid = fix.componentInstance.instance;
+        const cell = grid.getCellByColumn(0, 'index');
+        const cellSelectionID = grid.id + '-cell';
+        grid.selection.select_item(cellSelectionID, cell.cellID);
+        expect(grid.selection.size(cellSelectionID)).toBe(1);
+        grid.selection.deselect_item(cellSelectionID, cell.cellID);
+        expect(grid.selection.size(cellSelectionID)).toBe(0);
+    });
 });
 
 @Component({


### PR DESCRIPTION
Closes #2636

Additional information related to this pull request:
When requested, cellID is now reference, instead of new object. This also means that selection will work, when using cellID as identifier.