### PR TITLE
#2994 Add migration for Sass theme props migration

### DIFF
--- a/projects/igniteui-angular/migrations/common/schema/index.ts
+++ b/projects/igniteui-angular/migrations/common/schema/index.ts
@@ -1,7 +1,18 @@
 // generate schema:
 // npx typescript-json-schema migrations/common/schema/index.ts SelectorChanges -o migrations/common/schema/selector.schema.json --required
 
-// tslint:disable:interface-name
+export interface ThemePropertyChanges {
+    /** An array of changes to theme function properties */
+    changes: ThemePropertyChange[];
+}
+export interface ThemePropertyChange extends ChangeAction {
+    /** Name of the theme property */
+    name: string;
+    /** Theming function this parameter belongs to */
+    owner: string;
+}
+
+
 export interface SelectorChanges {
     /** An array of changes to component/directive selectors */
     changes: SelectorChange[];
@@ -35,9 +46,9 @@ export interface ClassChange {
 }
 
 export interface ChangeAction {
-    /** Replace original selector with new one */
+    /** Replace original selector/property with new one */
     replaceWith?: string;
-    /** Remove directive/component */
+    /** Remove directive/component/property */
     remove?: boolean;
 }
 

--- a/projects/igniteui-angular/migrations/common/schema/theme-props.schema.json
+++ b/projects/igniteui-angular/migrations/common/schema/theme-props.schema.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "ThemePropertyChange": {
+            "properties": {
+                "name": {
+                    "description": "Name of the theme property",
+                    "type": "string"
+                },
+                "owner": {
+                    "description": "Theming function this parameter belongs to",
+                    "type": "string"
+                },
+                "remove": {
+                    "description": "Remove directive/component/property",
+                    "type": "boolean"
+                },
+                "replaceWith": {
+                    "description": "Replace original selector/property with new one",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name",
+                "owner"
+            ],
+            "type": "object"
+        }
+    },
+    "properties": {
+        "changes": {
+            "description": "An array of changes to theme function properties",
+            "items": {
+                "$ref": "#/definitions/ThemePropertyChange"
+            },
+            "type": "array"
+        }
+    },
+    "required": [
+        "changes"
+    ],
+    "type": "object"
+}
+

--- a/projects/igniteui-angular/migrations/migration-collection.json
+++ b/projects/igniteui-angular/migrations/migration-collection.json
@@ -25,6 +25,11 @@
             "version": "6.2.0",
             "description": "Updates Ignite UI for Angular from v6.1.x to v6.2.0",
             "factory": "./update-6_2"
+        },
+        "migration-06": {
+            "version": "6.2.1",
+            "description": "Updates Ignite UI for Angular from v6.2.0 to v6.2.1",
+            "factory": "./update-6_2_1"
         }
     }
 }

--- a/projects/igniteui-angular/migrations/update-6_2_1/changes/theme-props.json
+++ b/projects/igniteui-angular/migrations/update-6_2_1/changes/theme-props.json
@@ -1,15 +1,32 @@
 {
     "$schema": "../../common/schema/theme-props.schema.json",
     "changes": [
-        {
-            "name": "$chip-background",
-            "replaceWith": "$background",
-            "owner": "igx-chip-theme"
-        },
-        {
-            "name": "$chip-hover-background",
-            "replaceWith": "$hover-background",
-            "owner": "igx-chip-theme"
-        }
+        { "name": "$chip-background", "replaceWith": "$background", "owner": "igx-chip-theme" },
+        { "name": "$chip-hover-background", "replaceWith": "$hover-background", "owner": "igx-chip-theme" },
+        { "name": "$text-hover-color", "replaceWith": "$hover-text-color", "owner": "igx-chip-theme" },
+        { "name": "$order-icon-color", "remove": true, "owner": "igx-chip-theme" },
+        { "name": "$order-icon-hover-color", "remove": true, "owner": "igx-chip-theme" },
+        { "name": "$dir-icon-color", "remove": true, "owner": "igx-chip-theme" },
+        { "name": "$remove-icon-color", "remove": true, "owner": "igx-chip-theme" },
+        { "name": "$remove-icon-hover-color", "remove": true, "owner": "igx-chip-theme" },
+        { "name": "$chip-focus-border-color", "replaceWith": "$focus-border-color", "owner": "igx-chip-theme" },
+        { "name": "$selected-chip-background", "replaceWith": "$selected-background", "owner": "igx-chip-theme" },
+        { "name": "$selected-chip-text-color", "replaceWith": "$selected-text-color", "owner": "igx-chip-theme" },
+        { "name": "$selected-chip-icon-color", "remove": true, "owner": "igx-chip-theme" },
+        { "name": "$selected-chip-hover-background", "replaceWith": "$hover-selected-background", "owner": "igx-chip-theme" },
+        { "name": "$selected-chip-focus-background", "replaceWith": "$focus-selected-background", "owner": "igx-chip-theme" },
+        { "name": "$selected-chip-text-hover-color", "replaceWith": "$hover-selected-text-color", "owner": "igx-chip-theme" },
+        { "name": "$selected-chip-icon-hover-color", "remove": true, "owner": "igx-chip-theme" },
+        { "name": "$selected-remove-icon-color", "remove": true, "owner": "igx-chip-theme" },
+        { "name": "$selected-chip-icon-focus-color", "remove": true, "owner": "igx-chip-theme" },
+        { "name": "$selected-remove-icon-hover-color", "remove": true, "owner": "igx-chip-theme" },
+        { "name": "$selected-chip-text-focus-color", "replaceWith": "$focus-selected-text-color", "owner": "igx-chip-theme" },
+        { "name": "$selected-chip-focus-border-color", "replaceWith": "$focus-selected-border-color", "owner": "igx-chip-theme" },
+        { "name": "$selected-chip-hover-border-color", "replaceWith": "$hover-selected-border-color", "owner": "igx-chip-theme" },
+
+        { "name": "$row-content-focus-background", "remove": true, "owner": "igx-grid-theme" },
+        { "name": "$row-indentation-background", "remove": true, "owner": "igx-grid-theme" },
+        { "name": "$grouping-indicator-hover-background", "remove": true, "owner": "igx-grid-theme" },
+        { "name": "$grouping-indicator-focus-background", "remove": true, "owner": "igx-grid-theme" }
     ]
 }

--- a/projects/igniteui-angular/migrations/update-6_2_1/changes/theme-props.json
+++ b/projects/igniteui-angular/migrations/update-6_2_1/changes/theme-props.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "../../common/schema/theme-props.schema.json",
+    "changes": [
+        {
+            "name": "$chip-background",
+            "replaceWith": "$background",
+            "owner": "igx-chip-theme"
+        },
+        {
+            "name": "$chip-hover-background",
+            "replaceWith": "$hover-background",
+            "owner": "igx-chip-theme"
+        }
+    ]
+}

--- a/projects/igniteui-angular/migrations/update-6_2_1/index.spec.ts
+++ b/projects/igniteui-angular/migrations/update-6_2_1/index.spec.ts
@@ -34,7 +34,10 @@ describe('Update 6.2.1', () => {
 `$dark-chip-theme: igx-chip-theme(
     $roundness: 4px,
     $chip-background: #180505,
-    $chip-hover-background: white
+    $chip-hover-background: white,
+    $remove-icon-color: red,
+    $dir-icon-color: yellow,
+    $selected-chip-hover-background: gray
 );`
         );
         const tree = schematicRunner.runSchematic('migration-06', {}, appTree);
@@ -43,7 +46,8 @@ describe('Update 6.2.1', () => {
 `$dark-chip-theme: igx-chip-theme(
     $roundness: 4px,
     $background: #180505,
-    $hover-background: white
+    $hover-background: white,
+    $hover-selected-background: gray
 );`
             );
         done();

--- a/projects/igniteui-angular/migrations/update-6_2_1/index.spec.ts
+++ b/projects/igniteui-angular/migrations/update-6_2_1/index.spec.ts
@@ -1,0 +1,51 @@
+import * as path from 'path';
+
+// tslint:disable:no-implicit-dependencies
+import { virtualFs } from '@angular-devkit/core';
+import { EmptyTree } from '@angular-devkit/schematics';
+// tslint:disable-next-line:no-submodule-imports
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+
+describe('Update 6.2.1', () => {
+    let appTree: UnitTestTree;
+    const schematicRunner = new SchematicTestRunner('ig-migrate', path.join(__dirname, '../migration-collection.json'));
+    const configJson = {
+        defaultProject: 'testProj',
+        projects: {
+            testProj: {
+                sourceRoot: '/testSrc'
+            }
+        },
+        schematics: {
+            '@schematics/angular:component': {
+                prefix: 'appPrefix'
+            }
+        }
+      };
+
+    beforeEach(() => {
+        appTree = new UnitTestTree(new EmptyTree());
+        appTree.create('/angular.json', JSON.stringify(configJson));
+    });
+
+    it('should update Sass files', done => {
+        appTree.create(
+            '/testSrc/appPrefix/style.scss',
+`$dark-chip-theme: igx-chip-theme(
+    $roundness: 4px,
+    $chip-background: #180505,
+    $chip-hover-background: white
+);`
+        );
+        const tree = schematicRunner.runSchematic('migration-06', {}, appTree);
+        expect(tree.readContent('/testSrc/appPrefix/style.scss'))
+            .toEqual(
+`$dark-chip-theme: igx-chip-theme(
+    $roundness: 4px,
+    $background: #180505,
+    $hover-background: white
+);`
+            );
+        done();
+    });
+});

--- a/projects/igniteui-angular/migrations/update-6_2_1/index.ts
+++ b/projects/igniteui-angular/migrations/update-6_2_1/index.ts
@@ -1,0 +1,19 @@
+import {
+    chain,
+    Rule,
+    SchematicContext,
+    SchematicsException,
+    Tree
+} from '@angular-devkit/schematics';
+import { UpdateChanges } from '../common/UpdateChanges';
+
+const version = '6.2.1';
+
+export default function(): Rule {
+    return (host: Tree, context: SchematicContext) => {
+        context.logger.info(`Applying migration for Ignite UI for Angular to version ${version}`);
+
+        const update = new UpdateChanges(__dirname, host, context);
+        update.applyChanges();
+    };
+}


### PR DESCRIPTION
New option to migrate Sass function properties.
Closes #2994.

Additional information related to this pull request:
Can be configured with `theme-props.json`, can replace or remove props.
Added the two props I saw on the chip. Will be updating with more configuration once a full list of changes is compiled.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [x] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 