### PR TITLE
igxGrid - refactor header and filter cell components

### DIFF
--- a/projects/igniteui-angular/src/lib/core/utils.ts
+++ b/projects/igniteui-angular/src/lib/core/utils.ts
@@ -163,10 +163,10 @@ export const enum KEYS {
 * let range = document.createRange();
 * let column = this.grid.columnList.filter(c => c.field === 'ID')[0];
 *
-* let size = valToPxlsUsingRange(range, column.cells[0].nativeElement);
+* let size = getNodeSizeViaRange(range, column.cells[0].nativeElement);
 * ```
  */
-export function valToPxlsUsingRange(range: Range, node: any): number {
+export function getNodeSizeViaRange(range: Range, node: any): number {
     let overflow = null;
     if (isIE() || isEdge()) {
         overflow = node.style.overflow;
@@ -194,7 +194,7 @@ export function valToPxlsUsingRange(range: Range, node: any): number {
 * let size = valToPxlsUsingCanvas(ctx, column.cells[0].nativeElement);
 * ```
  */
-export function valToPxlsUsingCanvas(canvas2dCtx: any, node: any): number {
+export function getNodeSizeViaCanvas(canvas2dCtx: any, node: any): number {
     const s = this.grid.document.defaultView.getComputedStyle(node);
 
     // need to set the font to get correct width
@@ -228,6 +228,22 @@ export function isFirefox(): boolean {
 export function isNavigationKey(key: string): boolean {
     return ['down', 'up', 'left', 'right', 'arrowdown', 'arrowup', 'arrowleft', 'arrowright',
         'home', 'end', 'space', 'spacebar', ' '].indexOf(key) !== -1;
+}
+
+/**
+ *@hidden
+ */
+export function flatten(arr: any[]) {
+    let result = [];
+
+    arr.forEach(el => {
+        result.push(el);
+        if (el.children) {
+            const children = Array.isArray(el.children) ? el.children : el.children.toArray();
+            result = result.concat(flatten(children));
+        }
+    });
+    return result;
 }
 
 export interface CancelableEventArgs {

--- a/projects/igniteui-angular/src/lib/directives/dragdrop/dragdrop.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/dragdrop/dragdrop.directive.ts
@@ -572,11 +572,14 @@ export class IgxDragDirective implements OnInit, OnDestroy {
 
     /**
      * @hidden
-     * Create dragGhost element - copy of the base element. Bind all needed events.
+     * Create dragGhost element - if a Node object is provided it creates a clone of that node,
+     * otherwise it clones the host element.
+     * Bind all needed events.
      * @param event Pointer event required when the dragGhost is being initialized.
+     * @param node The Node object to be cloned.
      */
-    protected createDragGhost(event) {
-        this._dragGhost = this.element.nativeElement.cloneNode(true);
+    protected createDragGhost(event, node: any = null) {
+        this._dragGhost = node ? node.cloneNode(true) : this.element.nativeElement.cloneNode(true);
         this._dragGhost.style.transitionDuration = '0.0s';
         this._dragGhost.style.position = 'absolute';
         this._dragGhost.style.top = this._dragStartY + 'px';

--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -15,7 +15,7 @@ import { IgxSelectionAPIService } from '../core/selection';
 import { IgxTextHighlightDirective } from '../directives/text-highlight/text-highlight.directive';
 import { GridBaseAPIService } from './api.service';
 import { IgxColumnComponent } from './column.component';
-import { isNavigationKey, valToPxlsUsingRange, KEYS } from '../core/utils';
+import { isNavigationKey, getNodeSizeViaRange, KEYS } from '../core/utils';
 import { State } from '../services/index';
 import { IgxGridBaseComponent, IGridEditEventArgs } from './grid-base.component';
 import { first } from 'rxjs/operators';
@@ -380,6 +380,7 @@ export class IgxGridCellComponent implements OnInit, AfterViewInit {
      * @memberof IgxGridCellComponent
      */
     @HostBinding('style.min-width')
+    @HostBinding('style.max-width')
     @HostBinding('style.flex-basis')
     get width() {
         const hasVerticalScroll = !this.grid.verticalScrollContainer.dc.instance.notVirtual;
@@ -902,7 +903,7 @@ export class IgxGridCellComponent implements OnInit, AfterViewInit {
      */
     public calculateSizeToFit(range: any): number {
         return Math.max(...Array.from(this.nativeElement.children)
-                   .map((child) => valToPxlsUsingRange(range, child)));
+                   .map((child) => getNodeSizeViaRange(range, child)));
     }
 
     private isToggleKey(key) {

--- a/projects/igniteui-angular/src/lib/grids/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/column.component.ts
@@ -21,15 +21,17 @@ import {
     IgxCellHeaderTemplateDirective,
     IgxCellTemplateDirective
 } from './grid.common';
-import {
-    IgxBooleanFilteringOperand, IgxNumberFilteringOperand, IgxDateFilteringOperand,
-    IgxStringFilteringOperand,
-    IgxGridBaseComponent,
-    FilteringExpressionsTree
-} from '../../public_api';
 import { IgxGridHeaderComponent } from './grid-header.component';
-import { valToPxlsUsingRange } from '../core/utils';
 import { DefaultSortingStrategy, ISortingStrategy } from '../data-operations/sorting-strategy';
+import { getNodeSizeViaRange, flatten } from '../core/utils';
+import {
+    IgxBooleanFilteringOperand,
+    IgxNumberFilteringOperand,
+    IgxDateFilteringOperand,
+    IgxStringFilteringOperand } from '../data-operations/filtering-condition';
+import { IgxGridBaseComponent } from './grid-base.component';
+import { FilteringExpressionsTree } from '../data-operations/filtering-expressions-tree';
+import { IgxGridFilteringCellComponent } from './filtering/grid-filtering-cell.component';
 
 /**
  * **Ignite UI for Angular Column** -
@@ -304,6 +306,11 @@ export class IgxColumnComponent implements AfterContentInit {
      */
     @Input()
     public headerClasses = '';
+        /**
+     *@hidden
+     */
+    @Input()
+    public headerGroupClasses = '';
     /**
      * Sets a conditional class selector of the column cells.
      * Accepts an object literal, containing key-value pairs,
@@ -1064,9 +1071,19 @@ export class IgxColumnComponent implements AfterContentInit {
      * @memberof IgxColumnComponent
      */
     get headerCell(): IgxGridHeaderComponent {
-        if (this.grid.headerList.length > 0) {
-            return flatten(this.grid.headerList.toArray()).find((h) => h.column === this);
-        }
+        return this.grid.headerCellList.find((header) => header.column === this);
+    }
+
+    /**
+     * Returns a reference to the filter cell of the column.
+     * ```typescript
+     * let column = this.grid.columnList.filter(c => c.field === 'ID')[0];
+     * let filterell = column.filterell;
+     * ```
+     * @memberof IgxColumnComponent
+     */
+    get filterCell(): IgxGridFilteringCellComponent {
+        return this.grid.filterCellList.find((filterCell) => filterCell.column === this);
     }
 
     /**
@@ -1109,7 +1126,7 @@ export class IgxColumnComponent implements AfterContentInit {
             if (this.cells[0].nativeElement.children.length > 0) {
                 this.cells.forEach((cell) => cellsContentWidths.push(cell.calculateSizeToFit(range)));
             } else {
-                cellsContentWidths = this.cells.map((cell) => valToPxlsUsingRange(range, cell.nativeElement));
+                cellsContentWidths = this.cells.map((cell) => getNodeSizeViaRange(range, cell.nativeElement));
             }
 
             const index = cellsContentWidths.indexOf(Math.max(...cellsContentWidths));
@@ -1122,16 +1139,15 @@ export class IgxColumnComponent implements AfterContentInit {
 
         if (this.headerCell) {
             let headerCell;
-            const titleIndex = this.grid.hasMovableColumns ? 1 : 0;
-            if (this.headerTemplate && this.headerCell.elementRef.nativeElement.children[titleIndex].children.length > 0) {
-                headerCell =  Math.max(...Array.from(this.headerCell.elementRef.nativeElement.children[titleIndex].children)
-                    .map((child) => valToPxlsUsingRange(range, child)));
+            if (this.headerTemplate && this.headerCell.elementRef.nativeElement.children[0].children.length > 0) {
+                headerCell =  Math.max(...Array.from(this.headerCell.elementRef.nativeElement.children[0].children)
+                    .map((child) => getNodeSizeViaRange(range, child)));
             } else {
-                headerCell = valToPxlsUsingRange(range, this.headerCell.elementRef.nativeElement.children[titleIndex]);
+                headerCell = getNodeSizeViaRange(range, this.headerCell.elementRef.nativeElement.children[0]);
             }
 
-            if (this.sortable || (this.grid.allowFiltering && this.filterable)) {
-                headerCell += this.headerCell.elementRef.nativeElement.children[titleIndex + 1].getBoundingClientRect().width;
+            if (this.sortable) {
+                headerCell += this.headerCell.elementRef.nativeElement.children[1].getBoundingClientRect().width;
             }
 
             const headerStyle = this.grid.document.defaultView.getComputedStyle(this.headerCell.elementRef.nativeElement);
@@ -1350,25 +1366,10 @@ export class IgxColumnGroupComponent extends IgxColumnComponent implements After
             if (typeof val.width === 'string' && val.width.indexOf('%') !== -1) {
                 isChildrenWidthInPercent = true;
             }
-
             return acc + parseInt(val.width, 10);
         }, 0)}`;
         return isChildrenWidthInPercent ? width + '%' : width;
     }
 
     set width(val) { }
-}
-
-
-
-function flatten(arr: any[]) {
-    let result = [];
-
-    arr.forEach(el => {
-        result.push(el);
-        if (el.children) {
-            result = result.concat(flatten(el.children.toArray()));
-        }
-    });
-    return result;
 }

--- a/projects/igniteui-angular/src/lib/grids/filtering/grid-filtering-cell.component.html
+++ b/projects/igniteui-angular/src/lib/grids/filtering/grid-filtering-cell.component.html
@@ -9,8 +9,9 @@
 
 <ng-template #defaultFilter>
     <igx-chips-area #chipsArea class="igx-filtering-chips">
-        <ng-container *ngFor="let item of visibleExpressionsList; let last = last;" >
+        <ng-container *ngFor="let item of expressionsList; let last = last; let index = index;" >
             <igx-chip
+                *ngIf="isChipVisible(index)"
                 [removable]="true"
                 [displayDensity]="'cosy'"
                 (click)="onChipClicked(item.expression)"
@@ -24,7 +25,7 @@
                     {{filteringService.getChipLabel(item.expression)}}
                 </span>
             </igx-chip>
-            <span class="igx-filtering-chips__connector" *ngIf="!last">{{filteringService.getOperatorAsString(item.afterOperator)}}</span>
+            <span class="igx-filtering-chips__connector" *ngIf="!last && isChipVisible(index + 1)">{{filteringService.getOperatorAsString(item.afterOperator)}}</span>
         </ng-container>
         <div #moreIcon [ngClass]="filteringIndicatorClass()" (click)="onChipClicked()" (keydown)="onChipKeyDown($event)" tabindex="0">
             <igx-icon>filter_list</igx-icon>

--- a/projects/igniteui-angular/src/lib/grids/filtering/grid-filtering-cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/filtering/grid-filtering-cell.component.ts
@@ -8,14 +8,15 @@ import {
     AfterViewInit,
     ElementRef,
     HostListener,
-    OnInit
+    OnInit,
+    ChangeDetectionStrategy,
+    DoCheck
 } from '@angular/core';
 import { IgxColumnComponent } from '../column.component';
 import { IFilteringExpression } from '../../data-operations/filtering-expression.interface';
-import { FilteringExpressionsTree } from '../../data-operations/filtering-expressions-tree';
 import { IBaseChipEventArgs, IgxChipsAreaComponent, IgxChipComponent } from '../../chips';
 import { IgxFilteringService, ExpressionUI } from './grid-filtering.service';
-import { KEYS, cloneArray } from '../../core/utils';
+import { KEYS } from '../../core/utils';
 import { IgxGridNavigationService } from '../grid-navigation.service';
 import { IgxGridGroupByRowComponent } from '../grid';
 
@@ -23,18 +24,17 @@ import { IgxGridGroupByRowComponent } from '../grid';
  * @hidden
  */
 @Component({
+    changeDetection: ChangeDetectionStrategy.OnPush,
     preserveWhitespaces: false,
     selector: 'igx-grid-filtering-cell',
     templateUrl: './grid-filtering-cell.component.html'
 })
-export class IgxGridFilteringCellComponent implements AfterViewInit, OnInit {
+export class IgxGridFilteringCellComponent implements AfterViewInit, OnInit, DoCheck {
 
-    private rootExpressionsTree: FilteringExpressionsTree;
-    private expressionsList: ExpressionUI[];
     private baseClass = 'igx-grid__filtering-cell-indicator';
     private currentTemplate = null;
 
-    public visibleExpressionsList: ExpressionUI[];
+    public expressionsList: ExpressionUI[];
     public moreFiltersCount = 0;
 
     @Input()
@@ -61,36 +61,8 @@ export class IgxGridFilteringCellComponent implements AfterViewInit, OnInit {
     @ViewChild('complexChip', { read: IgxChipComponent })
     protected complexChip: IgxChipComponent;
 
-    @HostBinding('style.min-width')
-    @HostBinding('style.max-width')
-    @HostBinding('style.flex-basis')
-    get width() {
-        // HACK - think of a better solution
-        const colWidth = this.column.width;
-        const isPercentageWidth = colWidth && typeof colWidth === 'string' && colWidth.indexOf('%') !== -1;
-
-        if (isPercentageWidth) {
-            const firstContentCell = this.column.cells[0];
-            if (firstContentCell) {
-                return firstContentCell.nativeElement.getBoundingClientRect().width + 'px';
-            }
-        } else {
-            return this.column.width;
-        }
-    }
-
     @HostBinding('class.igx-grid__filtering-cell')
     public cssClass = 'igx-grid__filtering-cell';
-
-    @HostBinding('class.igx-grid__th--pinned-last')
-    get isLastPinned() {
-        const pinnedCols = this.filteringService.grid.pinnedColumns;
-        if (pinnedCols.length === 0) {
-            return false;
-        } else {
-            return pinnedCols.indexOf(this.column) === pinnedCols.length - 1;
-        }
-    }
 
     constructor(public cdr: ChangeDetectorRef, public filteringService: IgxFilteringService, public navService: IgxGridNavigationService) {
         this.filteringService.subscribeToEvents();
@@ -101,6 +73,10 @@ export class IgxGridFilteringCellComponent implements AfterViewInit, OnInit {
     }
 
     ngAfterViewInit(): void {
+        this.updateFilterCellArea();
+    }
+
+    public ngDoCheck() {
         this.updateFilterCellArea();
     }
 
@@ -117,6 +93,7 @@ export class IgxGridFilteringCellComponent implements AfterViewInit, OnInit {
                 eventArgs.stopPropagation();
                 return;
             }
+
             if (this.column.visibleIndex === this.filteringService.grid.columnList.length - 1) {
                 if (!this.filteringService.grid.filteredData || this.filteringService.grid.filteredData.length > 0) {
                     if (this.filteringService.grid.rowList.filter(row => row instanceof IgxGridGroupByRowComponent).length > 0) {
@@ -137,16 +114,23 @@ export class IgxGridFilteringCellComponent implements AfterViewInit, OnInit {
     @HostListener('keydown.shift.tab', ['$event'])
     public onShiftTabKeyDown(eventArgs) {
         if (this.isFirstElementFocused()) {
-            const prevIndex = this.column.visibleIndex - 1 - this.filteringService.grid.pinnedColumns.length;
-
             if (this.column.visibleIndex > 0 && !this.navService.isColumnLeftFullyVisible(this.column.visibleIndex - 1)) {
                 eventArgs.preventDefault();
+                const prevIndex = this.column.visibleIndex - 1 - this.filteringService.grid.pinnedColumns.length;
                 this.ScrollToChip(prevIndex, false);
             } else if (this.column.visibleIndex === 0) {
                 eventArgs.preventDefault();
             }
         }
         eventArgs.stopPropagation();
+    }
+
+    /**
+     * Returns whether a chip with a given index is visible or not.
+     */
+    public isChipVisible(index: number) {
+        const expression = this.expressionsList[index];
+        return !!(expression && expression.isVisible);
     }
 
     /**
@@ -261,13 +245,7 @@ export class IgxGridFilteringCellComponent implements AfterViewInit, OnInit {
         this.filteringService.removeExpression(this.column.field, indexToRemove);
 
         this.updateVisibleFilters();
-        this.filter();
-    }
-
-    private filter(): void {
-        this.rootExpressionsTree = this.filteringService.createSimpleFilteringTree(this.column.field);
-
-        this.filteringService.filter(this.column.field, this.rootExpressionsTree);
+        this.filteringService.filter(this.column.field);
     }
 
     private isMoreIconHidden(): boolean {
@@ -275,21 +253,20 @@ export class IgxGridFilteringCellComponent implements AfterViewInit, OnInit {
     }
 
     private updateVisibleFilters() {
-        this.visibleExpressionsList = cloneArray(this.expressionsList);
-
-        // TODO: revise the usage of this.cdr.detectChanges() here
-        this.cdr.detectChanges();
+        this.expressionsList.forEach((ex) => ex.isVisible = true);
 
         if (this.moreIcon) {
             this.filteringService.columnToMoreIconHidden.set(this.column.field, true);
         }
+        this.cdr.detectChanges();
+
         if (this.chipsArea && this.expressionsList.length > 1) {
             const areaWidth = this.chipsArea.element.nativeElement.offsetWidth;
             let viewWidth = 0;
             const chipsAreaElements = this.chipsArea.element.nativeElement.children;
             let visibleChipsCount = 0;
             const moreIconWidth = this.moreIcon.nativeElement.offsetWidth -
-            parseInt(document.defaultView.getComputedStyle(this.moreIcon.nativeElement)['margin-left'], 10);
+                parseInt(document.defaultView.getComputedStyle(this.moreIcon.nativeElement)['margin-left'], 10);
 
             for (let index = 0; index < chipsAreaElements.length - 1; index++) {
                 if (viewWidth + chipsAreaElements[index].offsetWidth < areaWidth) {
@@ -308,9 +285,12 @@ export class IgxGridFilteringCellComponent implements AfterViewInit, OnInit {
                     }
                     this.moreFiltersCount = this.expressionsList.length - visibleChipsCount;
                     this.filteringService.columnToMoreIconHidden.set(this.column.field, false);
-                    this.visibleExpressionsList.splice(visibleChipsCount);
                     break;
                 }
+            }
+
+            for (let i = visibleChipsCount; i < this.expressionsList.length; i++) {
+                this.expressionsList[i].isVisible = false;
             }
             this.cdr.detectChanges();
         }

--- a/projects/igniteui-angular/src/lib/grids/filtering/grid-filtering-row.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/filtering/grid-filtering-row.component.ts
@@ -5,12 +5,12 @@ import {
     Input,
     TemplateRef,
     ViewChild,
-    OnDestroy,
     ViewChildren,
     QueryList,
     ElementRef,
     HostBinding,
-    HostListener
+    HostListener,
+    ChangeDetectionStrategy
 } from '@angular/core';
 import { Subject } from 'rxjs';
 import { DataType } from '../../data-operations/data-util';
@@ -20,7 +20,6 @@ import { IFilteringOperation } from '../../data-operations/filtering-condition';
 import { FilteringLogic, IFilteringExpression } from '../../data-operations/filtering-expression.interface';
 import { HorizontalAlignment, VerticalAlignment, OverlaySettings } from '../../services/overlay/utilities';
 import { ConnectedPositioningStrategy } from '../../services/overlay/position/connected-positioning-strategy';
-import { FilteringExpressionsTree } from '../../data-operations/filtering-expressions-tree';
 import { IChipSelectEventArgs, IBaseChipEventArgs, IgxChipsAreaComponent, IgxChipComponent } from '../../chips';
 import { ExpressionUI } from './grid-filtering.service';
 import { IgxDropDownItemComponent } from '../../drop-down/drop-down-item.component';
@@ -32,11 +31,12 @@ import { AbsoluteScrollStrategy } from '../../services/overlay/scroll';
  * @hidden
  */
 @Component({
+    changeDetection: ChangeDetectionStrategy.OnPush,
     preserveWhitespaces: false,
     selector: 'igx-grid-filtering-row',
     templateUrl: './grid-filtering-row.component.html'
 })
-export class IgxGridFilteringRowComponent implements AfterViewInit, OnDestroy {
+export class IgxGridFilteringRowComponent implements AfterViewInit {
 
     private _positionSettings = {
         horizontalStartPoint: HorizontalAlignment.Left,
@@ -57,11 +57,8 @@ export class IgxGridFilteringRowComponent implements AfterViewInit, OnDestroy {
         positionStrategy: new ConnectedPositioningStrategy(this._positionSettings)
     };
 
-    private rootExpressionsTree: FilteringExpressionsTree;
     private chipsAreaWidth: number;
     private chipAreaScrollOffset = 0;
-    private conditionChanged = new Subject();
-    private unaryConditionChanged = new Subject();
     private _column = null;
 
     public showArrows: boolean;
@@ -141,10 +138,7 @@ export class IgxGridFilteringRowComponent implements AfterViewInit, OnDestroy {
     @HostBinding('class.igx-grid__filtering-row')
     public cssClass = 'igx-grid__filtering-row';
 
-    constructor(public filteringService: IgxFilteringService, public element: ElementRef, public cdr: ChangeDetectorRef) {
-        this.unaryConditionChanged.subscribe(() => this.unaryConditionChangedCallback());
-        this.conditionChanged.subscribe(() => this.conditionChangedCallback());
-    }
+    constructor(public filteringService: IgxFilteringService, public element: ElementRef, public cdr: ChangeDetectorRef) {}
 
     ngAfterViewInit() {
         this._conditionsOverlaySettings.outlet = this.column.grid.outletDirective;
@@ -156,11 +150,6 @@ export class IgxGridFilteringRowComponent implements AfterViewInit, OnDestroy {
         }
 
         this.input.nativeElement.focus();
-    }
-
-    ngOnDestroy() {
-        this.conditionChanged.unsubscribe();
-        this.unaryConditionChanged.unsubscribe();
     }
 
     @HostListener('keydown.shift.tab', ['$event'])
@@ -378,8 +367,8 @@ export class IgxGridFilteringRowComponent implements AfterViewInit, OnDestroy {
             });
         }
 
-        this.filteringService.updateFilteringCell(this.column.field);
-        this.filteringService.focusFilterCellChip(this.column.field, true);
+        this.filteringService.updateFilteringCell(this.column);
+        this.filteringService.focusFilterCellChip(this.column, true);
 
         this.filteringService.isFilterRowVisible = false;
         this.filteringService.filteredColumn = null;
@@ -422,9 +411,11 @@ export class IgxGridFilteringRowComponent implements AfterViewInit, OnDestroy {
         const value = (eventArgs.newSelection as IgxDropDownItemComponent).value;
         this.expression.condition = this.getCondition(value);
         if (this.expression.condition.isUnary) {
-            this.unaryConditionChanged.next(value);
+            // update grid's filtering on the next cycle to ensure the drop-down is closed
+            // if the drop-down is not closed this event handler will be invoked multiple times
+            requestAnimationFrame(() => this.unaryConditionChangedCallback());
         } else {
-            this.conditionChanged.next(value);
+            requestAnimationFrame(() => this.conditionChangedCallback());
         }
 
         if (this.input) {
@@ -491,7 +482,10 @@ export class IgxGridFilteringRowComponent implements AfterViewInit, OnDestroy {
         if (eventArgs.oldSelection) {
             expression.afterOperator = (eventArgs.newSelection as IgxDropDownItemComponent).value;
             this.expressionsList[this.expressionsList.indexOf(expression) + 1].beforeOperator = expression.afterOperator;
-            this.filter();
+
+            // update grid's filtering on the next cycle to ensure the drop-down is closed
+            // if the drop-down is not closed this event handler will be invoked multiple times
+            requestAnimationFrame(() => this.filter());
         }
     }
 
@@ -667,8 +661,6 @@ export class IgxGridFilteringRowComponent implements AfterViewInit, OnDestroy {
     }
 
     private filter() {
-        this.rootExpressionsTree = this.filteringService.createSimpleFilteringTree(this.column.field);
-
-        this.filteringService.filter(this.column.field, this.rootExpressionsTree);
+        this.filteringService.filter(this.column.field);
     }
 }

--- a/projects/igniteui-angular/src/lib/grids/filtering/grid-filtering.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/filtering/grid-filtering.service.ts
@@ -10,6 +10,7 @@ import { takeUntil } from 'rxjs/operators';
 import { IForOfState } from '../../directives/for-of/for_of.directive';
 import { IgxGridFilterConditionPipe } from '../grid-common.pipes';
 import { TitleCasePipe, DatePipe } from '@angular/common';
+import { IgxColumnComponent } from '../grid';
 
 const FILTERING_ICONS_FONT_SET = 'filtering-icons';
 
@@ -21,6 +22,7 @@ export class ExpressionUI {
     public beforeOperator: FilteringLogic;
     public afterOperator: FilteringLogic;
     public isSelected = false;
+    public isVisible = true;
 }
 
 /**
@@ -41,9 +43,9 @@ export class IgxFilteringService implements OnDestroy {
 
     public gridId: string;
     public isFilterRowVisible = false;
-    public filteredColumn = null;
+    public filteredColumn: IgxColumnComponent = null;
     public selectedExpression: IFilteringExpression = null;
-    public columnToFocus = null;
+    public columnToFocus: IgxColumnComponent = null;
     public shouldFocusNext = false;
     public columnToMoreIconHidden = new Map<string, boolean>();
 
@@ -66,7 +68,7 @@ export class IgxFilteringService implements OnDestroy {
             this.areEventsSubscribed = true;
 
             this.grid.onColumnResized.pipe(takeUntil(this.destroy$)).subscribe((eventArgs: IColumnResizeEventArgs) => {
-                this.updateFilteringCell(eventArgs.column.field);
+                this.updateFilteringCell(eventArgs.column);
             });
 
             this.grid.parentVirtDir.onChunkLoad.pipe(takeUntil(this.destroy$)).subscribe((eventArgs: IForOfState) => {
@@ -77,7 +79,7 @@ export class IgxFilteringService implements OnDestroy {
                     });
                 }
                 if (this.columnToFocus) {
-                    this.focusFilterCellChip(this.columnToFocus.field, false);
+                    this.focusFilterCellChip(this.columnToFocus, false);
                     this.columnToFocus = null;
                 }
             });
@@ -93,9 +95,10 @@ export class IgxFilteringService implements OnDestroy {
     /**
      * Execute filtering on the grid.
      */
-    public filter(field: string, expressionsTree: FilteringExpressionsTree): void {
+    public filter(field: string): void {
         this.isFiltering = true;
 
+        const expressionsTree = this.createSimpleFilteringTree(field);
         this.grid.filter(field, null, expressionsTree);
 
         // Wait for the change detection to update filtered data through the pipes and then emit the event.
@@ -169,7 +172,7 @@ export class IgxFilteringService implements OnDestroy {
                     this.columnsWithComplexFilter.add(key);
                 }
 
-                this.updateFilteringCell(key);
+                this.updateFilteringCell(column);
             });
         }
     }
@@ -272,8 +275,8 @@ export class IgxFilteringService implements OnDestroy {
     /**
      * Updates the content of a filterCell.
      */
-    public updateFilteringCell(columnId: string) {
-        const filterCell = this.grid.filterCellList.find(cell => cell.column.field === columnId);
+    public updateFilteringCell(column: IgxColumnComponent) {
+        const filterCell = column.filterCell;
         if (filterCell) {
             filterCell.updateFilterCellArea();
         }
@@ -282,8 +285,8 @@ export class IgxFilteringService implements OnDestroy {
     /**
      * Focus a chip in a filterCell.
      */
-    public focusFilterCellChip(columnId: string, focusFirst: boolean) {
-        const filterCell = this.grid.filterCellList.find(cell => cell.column.field === columnId);
+    public focusFilterCellChip(column: IgxColumnComponent, focusFirst: boolean) {
+        const filterCell = column.filterCell;
         if (filterCell) {
             filterCell.focusChip(focusFirst);
         }

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -28,7 +28,7 @@ import {
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { IgxSelectionAPIService } from '../core/selection';
-import { cloneArray, isNavigationKey, mergeObjects, CancelableEventArgs } from '../core/utils';
+import { cloneArray, isNavigationKey, mergeObjects, CancelableEventArgs, flatten } from '../core/utils';
 import { DataType, DataUtil } from '../data-operations/data-util';
 import { FilteringLogic, IFilteringExpression } from '../data-operations/filtering-expression.interface';
 import { IGroupByRecord } from '../data-operations/groupby-record.interface';
@@ -61,6 +61,7 @@ import { IDisplayDensityOptions, DisplayDensityToken, DisplayDensityBase } from 
 import { IgxGridRowComponent } from './grid';
 import { IgxFilteringService } from './filtering/grid-filtering.service';
 import { IgxGridFilteringCellComponent } from './filtering/grid-filtering-cell.component';
+import { IgxGridHeaderGroupComponent } from './grid-header-group.component';
 
 const MINIMUM_COLUMN_WIDTH = 136;
 
@@ -242,7 +243,7 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
 
             this.filteringService.refreshExpressions();
             this.clearSummaryCache();
-            this.cdr.markForCheck();
+            this.markForCheck();
         }
     }
 
@@ -1153,14 +1154,41 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
     /**
      * @hidden
      */
-    @ViewChildren(IgxGridHeaderComponent, { read: IgxGridHeaderComponent })
-    public headerList: QueryList<IgxGridHeaderComponent>;
+    @ViewChildren(IgxGridHeaderGroupComponent, { read: IgxGridHeaderGroupComponent })
+    public headerGroups: QueryList<IgxGridHeaderGroupComponent>;
 
     /**
-     * @hidden
+     * A list of all `IgxGridHeaderGroupComponent`.
+     * ```typescript
+     * const headerGroupsList = this.grid.headerGroupsList;
+     * ```
+	 * @memberof IgxGridBaseComponent
      */
-    @ViewChildren(IgxGridFilteringCellComponent, { read: IgxGridFilteringCellComponent })
-    public filterCellList: QueryList<IgxGridFilteringCellComponent>;
+    get headerGroupsList(): IgxGridHeaderGroupComponent[] {
+        return this.headerGroups ? flatten(this.headerGroups.toArray()) : [];
+    }
+
+    /**
+     * A list of all `IgxGridHeaderComponent`.
+     * ```typescript
+     * const headers = this.grid.headerCellList;
+     * ```
+	 * @memberof IgxGridBaseComponent
+     */
+    get headerCellList(): IgxGridHeaderComponent[] {
+        return this.headerGroupsList.map((headerGroup) => headerGroup.headerCell).filter((headerCell) => headerCell);
+    }
+
+    /**
+     * A list of all `IgxGridFilteringCellComponent`.
+     * ```typescript
+     * const filterCells = this.grid.filterCellList;
+     * ```
+	 * @memberof IgxGridBaseComponent
+     */
+    get filterCellList(): IgxGridFilteringCellComponent[] {
+        return this.headerGroupsList.map((headerGroup) => headerGroup.filterCell).filter((filterCell) => filterCell);
+    }
 
     @ViewChildren('row')
     private _rowList: QueryList<IgxGridRowComponent>;
@@ -1881,14 +1909,6 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
      * @hidden
      */
     public draggedColumn: IgxColumnComponent;
-    /**
-     * @hidden
-     */
-    public isColumnResizing: boolean;
-    /**
-     * @hidden
-     */
-    public isColumnMoving: boolean;
 
     /**
      * @hidden
@@ -2262,6 +2282,17 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
                 this.tfoot.nativeElement.clientHeight;
         }
         return this.theadRow.nativeElement.clientHeight + this.tbody.nativeElement.clientHeight;
+    }
+
+    /**
+     * @hidden
+     */
+    get headerCheckboxWidth() {
+        if (this.headerCheckboxContainer) {
+            return this.headerCheckboxContainer.nativeElement.clientWidth;
+        }
+
+        return 0;
     }
 
     /**
@@ -2733,6 +2764,11 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
         if (this.rowList) {
             this.rowList.forEach((row) => row.cdr.markForCheck());
         }
+
+        if (this.filterCellList) {
+            this.filterCellList.forEach((c) => c.cdr.markForCheck());
+        }
+
         this.cdr.detectChanges();
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid-column-resizing.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-column-resizing.service.ts
@@ -1,0 +1,160 @@
+import { Injectable } from '@angular/core';
+import { isFirefox } from '../core/utils';
+import { IgxColumnComponent } from './column.component';
+
+/** @hidden */
+@Injectable()
+export class IgxColumnResizingService {
+
+    private pinnedMaxWidth: string;
+
+    /**
+     *@hidden
+     */
+    public startResizePos: number;
+    /**
+     * Indicates that a column is currently being resized.
+     */
+    public isColumnResizing: boolean;
+    /**
+     *@hidden
+     */
+    public resizeCursor: string = null;
+    /**
+     *@hidden
+     */
+    public showResizer = false;
+    /**
+     *@hidden
+     */
+    public resizerHeight: number;
+    /**
+     *@hidden
+     */
+    public resizeEndTimeout = isFirefox() ? 200 : 0;
+    /**
+     * The column being resized.
+     */
+    public column: IgxColumnComponent;
+
+
+    /**
+     * Returns the minimal possible width to which the column can be resized.
+     */
+    get restrictResizeMin(): number {
+        const actualMinWidth = parseFloat(this.column.minWidth);
+        const defaultMinWidth = parseFloat(this.column.defaultMinWidth);
+
+        let minWidth = Number.isNaN(actualMinWidth) || actualMinWidth < defaultMinWidth ? defaultMinWidth : actualMinWidth;
+        minWidth = minWidth < parseFloat(this.column.width) ? minWidth : parseFloat(this.column.width);
+
+        return minWidth - this.column.headerCell.elementRef.nativeElement.getBoundingClientRect().width;
+    }
+
+    /**
+     * Returns the maximal possible width to which the column can be resized.
+     */
+    get restrictResizeMax(): number {
+        const actualWidth = this.column.headerCell.elementRef.nativeElement.getBoundingClientRect().width;
+
+        if (this.column.pinned) {
+            const pinnedMaxWidth = this.pinnedMaxWidth =
+                this.column.grid.calcPinnedContainerMaxWidth - this.column.grid.getPinnedWidth(true) + actualWidth;
+
+            if (this.column.maxWidth && parseFloat(this.column.maxWidth) < pinnedMaxWidth) {
+                this.pinnedMaxWidth = this.column.maxWidth;
+
+                return parseFloat(this.column.maxWidth) - actualWidth;
+            } else {
+                return pinnedMaxWidth - actualWidth;
+            }
+        } else {
+            if (this.column.maxWidth) {
+                return parseFloat(this.column.maxWidth) - actualWidth;
+            } else {
+                return Number.MAX_SAFE_INTEGER;
+            }
+        }
+    }
+
+    /**
+     * Autosizes the column to the longest currently visible cell value, including the header cell.
+     * If the column has a predifined maxWidth and the autosized column width will become bigger than it,
+     * then the column is sized to its maxWidth.
+     * If the column is pinned and the autosized column width will cause the pinned area to become bigger
+     * than the maximum allowed pinned area width (80% of the total grid width), autosizing will be deismissed.
+     */
+    public autosizeColumnOnDblClick() {
+        if (this.column.resizable) {
+            const currentColWidth = this.column.headerCell.elementRef.nativeElement.getBoundingClientRect().width;
+
+            const size = this.column.getLargestCellWidth();
+
+            if (this.column.pinned) {
+                const newPinnedWidth = this.column.grid.getPinnedWidth(true) - currentColWidth + parseFloat(size);
+
+                if (newPinnedWidth <= this.column.grid.calcPinnedContainerMaxWidth) {
+                    this.column.width = size;
+                }
+            } else if (this.column.maxWidth && (parseFloat(size) > parseFloat(this.column.maxWidth))) {
+                this.column.width = parseFloat(this.column.maxWidth) + 'px';
+            } else if (parseFloat(size) < parseFloat(this.column.defaultMinWidth)) {
+                this.column.width = this.column.defaultMinWidth + 'px';
+            } else {
+                this.column.width = size;
+            }
+
+            this.column.grid.markForCheck();
+            this.column.grid.reflow();
+            this.column.grid.onColumnResized.emit({
+                column: this.column,
+                prevWidth: currentColWidth.toString(),
+                newWidth: this.column.width
+            });
+        }
+    }
+
+    /**
+     * Resizes the column regaridng to the column minWidth and maxWidth.
+     */
+    public resizeColumn(event: MouseEvent) {
+        this.isColumnResizing = false;
+
+        this.showResizer = false;
+        const diff = event.clientX - this.startResizePos;
+
+        if (this.column.resizable) {
+            let currentColWidth = parseFloat(this.column.width);
+
+            const actualMinWidth = parseFloat(this.column.minWidth);
+            const defaultMinWidth = parseFloat(this.column.defaultMinWidth);
+
+            let colMinWidth = Number.isNaN(actualMinWidth) || actualMinWidth < defaultMinWidth ? defaultMinWidth : actualMinWidth;
+            const colMaxWidth = this.column.pinned ? parseFloat(this.pinnedMaxWidth) : parseFloat(this.column.maxWidth);
+
+            const actualWidth = this.column.headerCell.elementRef.nativeElement.getBoundingClientRect().width;
+
+            currentColWidth = Number.isNaN(currentColWidth) || (currentColWidth < actualWidth) ? actualWidth : currentColWidth;
+            colMinWidth = colMinWidth < currentColWidth ? colMinWidth : currentColWidth;
+
+            if (currentColWidth + diff < colMinWidth) {
+                this.column.width = colMinWidth + 'px';
+            } else if (colMaxWidth && (currentColWidth + diff > colMaxWidth)) {
+                this.column.width = colMaxWidth + 'px';
+            } else {
+                this.column.width = (currentColWidth + diff) + 'px';
+            }
+
+            this.column.grid.markForCheck();
+            this.column.grid.reflow();
+
+            if (currentColWidth !== parseFloat(this.column.width)) {
+                this.column.grid.onColumnResized.emit({
+                    column: this.column,
+                    prevWidth: currentColWidth.toString(),
+                    newWidth: this.column.width
+                });
+            }
+        }
+    }
+}

--- a/projects/igniteui-angular/src/lib/grids/grid-common.module.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-common.module.ts
@@ -55,6 +55,8 @@ import {
     IgxRowEditTabStopDirective
 } from './grid.rowEdit.directive';
 import { IgxGridNavigationService } from './grid-navigation.service';
+import { IgxGridHeaderGroupComponent } from './grid-header-group.component';
+import { IgxColumnResizingService } from './grid-column-resizing.service';
 
 @NgModule({
     declarations: [
@@ -81,8 +83,8 @@ import { IgxGridNavigationService } from './grid-navigation.service';
         IgxGridFilteringRowComponent,
         IgxDatePipeComponent,
         IgxDecimalPipeComponent,
-        IgxRowComponent
-
+        IgxRowComponent,
+        IgxGridHeaderGroupComponent
     ],
     entryComponents: [
         IgxColumnComponent,
@@ -132,6 +134,7 @@ import { IgxGridNavigationService } from './grid-navigation.service';
         IgxColumnPinningModule,
         IgxGridFilteringCellComponent,
         IgxGridFilteringRowComponent,
+        IgxGridHeaderGroupComponent
     ],
     imports: [
         CommonModule,
@@ -160,6 +163,7 @@ import { IgxGridNavigationService } from './grid-navigation.service';
         IgxSelectionAPIService,
         IgxColumnMovingService,
         IgxGridNavigationService,
+        IgxColumnResizingService,
         { provide: IgxGridTransaction, useClass: IgxBaseTransactionService }
     ]
 })

--- a/projects/igniteui-angular/src/lib/grids/grid-header-group.component.html
+++ b/projects/igniteui-angular/src/lib/grids/grid-header-group.component.html
@@ -1,0 +1,42 @@
+<ng-container *ngIf="column.columnGroup">
+    <span *ngIf="grid.hasMovableColumns" class="igx-grid__th-drop-indicator-left"></span>
+    <div class="igx-grid__thead-title"
+        [ngClass]="{'igx-grid__th--pinned-last': hasLastPinnedChildColumn}">{{ column.header }}</div>
+    <div class="igx-grid__thead-group">
+        <ng-container *ngFor="let child of column.children">
+            <igx-grid-header-group *ngIf="!child.hidden" class="igx-grid__thead-subgroup"
+                                [column]="child"
+                                [gridID]="child.gridID"
+                                [igxColumnMovingDrag]="child"
+                                [attr.droppable]="true"
+                                [igxColumnMovingDrop]="child"
+                                [style.min-width.px]="child.width"
+                                [style.flex-basis.px]="child.width">
+            </igx-grid-header-group>
+        </ng-container>
+    </div>
+    <span *ngIf="grid.hasMovableColumns" class="igx-grid__th-drop-indicator-right"></span>
+</ng-container>
+
+<ng-container *ngIf="!column.columnGroup">
+    <span *ngIf="grid.hasMovableColumns" class="igx-grid__th-drop-indicator-left"></span>
+    <igx-grid-header [gridID]="column.gridID" [column]="column"></igx-grid-header>
+    <igx-grid-filtering-cell *ngIf="grid.allowFiltering" [column]="column" [attr.draggable]="false"></igx-grid-filtering-cell>
+    <span *ngIf="!column.columnGroup" class="igx-grid__th-resize-handle"
+            [attr.draggable]="false"
+            [style.cursor]="colResizingService.resizeCursor"
+            (mouseover)="onResizeAreaMouseOver()"
+            (mousedown)="onResizeAreaMouseDown($event)"
+            (dblclick)="autosizeColumnOnDblClick($event)">
+        <div *ngIf="colResizingService.showResizer && colResizingService.column === column"
+            class="igx-grid__th-resize-line"
+            [style.height.px]="colResizingService.resizerHeight"
+            igxResizer
+            [restrictHResizeMax]="colResizingService.restrictResizeMax"
+            [restrictHResizeMin]="colResizingService.restrictResizeMin"
+            [resizeEndTimeout]="colResizingService.resizeEndTimeout"
+            (resizeEnd)="colResizingService.resizeColumn($event)">
+        </div>
+    </span>
+    <span *ngIf="grid.hasMovableColumns" class="igx-grid__th-drop-indicator-right"></span>
+</ng-container>

--- a/projects/igniteui-angular/src/lib/grids/grid-header-group.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-header-group.component.ts
@@ -1,0 +1,213 @@
+import {
+    Component,
+    HostBinding,
+    Input,
+    ViewChild,
+    QueryList,
+    ViewChildren,
+    forwardRef,
+    ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    DoCheck
+} from '@angular/core';
+import { IgxColumnComponent } from './column.component';
+import { IgxFilteringService } from './filtering/grid-filtering.service';
+import { GridBaseAPIService } from './api.service';
+import { IgxGridBaseComponent } from './grid-base.component';
+import { IgxColumnResizingService } from './grid-column-resizing.service';
+import { IgxGridHeaderComponent } from './grid-header.component';
+import { IgxGridFilteringCellComponent } from './filtering/grid-filtering-cell.component';
+
+const Z_INDEX = 9999;
+
+/**
+ * @hidden
+ */
+@Component({
+    changeDetection: ChangeDetectionStrategy.OnPush,
+    preserveWhitespaces: false,
+    selector: 'igx-grid-header-group',
+    templateUrl: './grid-header-group.component.html'
+})
+export class IgxGridHeaderGroupComponent implements DoCheck {
+
+    /**
+     * Gets the column of the header group.
+     * @memberof IgxGridHeaderGroupComponent
+     */
+    @Input()
+    public column: IgxColumnComponent;
+
+    /**
+     * Gets the `id` of the grid in which the header group is stored.
+     * @memberof IgxGridHeaderGroupComponent
+     */
+    @Input()
+    public gridID: string;
+
+    /**
+     * @hidden
+     */
+    @ViewChild(IgxGridHeaderComponent)
+    public headerCell: IgxGridHeaderComponent;
+
+    /**
+     * @hidden
+     */
+    @ViewChild(IgxGridFilteringCellComponent)
+    public filterCell: IgxGridFilteringCellComponent;
+
+    /**
+     * @hidden
+     */
+    @ViewChildren(forwardRef(() => IgxGridHeaderGroupComponent), { read: IgxGridHeaderGroupComponent })
+    public children: QueryList<IgxGridHeaderGroupComponent>;
+
+    /**
+     * Gets the width of the header group.
+     * @memberof IgxGridHeaderGroupComponent
+     */
+    @HostBinding('style.min-width')
+    @HostBinding('style.flex-basis')
+    get width() {
+        return this.column.width;
+    }
+
+    /**
+     * Gets the style classes of the header group.
+     * @memberof IgxGridHeaderGroupComponent
+     */
+    @HostBinding('class')
+    get styleClasses(): string {
+        const defaultClasses = [
+            'igx-grid__thead-item',
+            this.column.headerGroupClasses
+        ];
+
+        const classList = {
+            'igx-grid__th--pinned': this.isPinned,
+            'igx-grid__th--pinned-last': this.isLastPinned,
+            'igx-grid__drag-col-header': this.isHeaderDragged,
+            'igx-grid__th--filtering': this.isFiltered
+        };
+
+        Object.entries(classList).forEach(([className, value]) => {
+            if (value) {
+                defaultClasses.push(className);
+            }
+        });
+        return defaultClasses.join(' ');
+    }
+
+    /**
+     * @hidden
+     */
+    @HostBinding('style.z-index')
+    get zIndex() {
+        if (!this.column.pinned) {
+            return null;
+        }
+        return Z_INDEX - this.grid.pinnedColumns.indexOf(this.column);
+    }
+
+    /**
+     * Gets the grid of the header group.
+     * @memberof IgxGridHeaderGroupComponent
+     */
+    get grid(): any {
+        return this.gridAPI.get(this.gridID);
+    }
+
+    /**
+     * Gets whether the header group belongs to a column that is filtered.
+     * @memberof IgxGridHeaderGroupComponent
+     */
+    get isFiltered(): boolean {
+        return this.filteringService.filteredColumn === this.column;
+    }
+
+    /**
+     * Gets whether the header group is stored in the last column in the pinned area.
+     * @memberof IgxGridHeaderGroupComponent
+     */
+    get isLastPinned(): boolean {
+        const pinnedCols = this.grid.pinnedColumns;
+
+        if (pinnedCols.length === 0) {
+            return false;
+        }
+
+        return pinnedCols.indexOf(this.column) === pinnedCols.length - 1;
+    }
+
+    /**
+     * Gets whether the header group is stored in a pinned column.
+     * @memberof IgxGridHeaderGroupComponent
+     */
+    get isPinned(): boolean {
+        return this.column.pinned;
+    }
+
+    /**
+     * Gets whether the header group belongs to a column that is moved.
+     * @memberof IgxGridHeaderGroupComponent
+     */
+    get isHeaderDragged(): boolean {
+        return this.grid.draggedColumn ===  this.column;
+    }
+
+    /**
+     * @hidden
+     */
+    get hasLastPinnedChildColumn(): boolean {
+        const pinnedCols = this.grid.pinnedColumns;
+        if (this.column.allChildren) {
+            return this.column.allChildren.some((child) => {
+                return pinnedCols.length > 0 && pinnedCols.indexOf(child) === pinnedCols.length - 1;
+            });
+        }
+    }
+
+    public ngDoCheck() {
+        this.cdr.markForCheck();
+    }
+
+    constructor(private cdr: ChangeDetectorRef,
+                public gridAPI: GridBaseAPIService<IgxGridBaseComponent>,
+                public colResizingService: IgxColumnResizingService,
+                public filteringService: IgxFilteringService) { }
+
+    /**
+     * @hidden
+     */
+    public onResizeAreaMouseOver() {
+        if (this.column.resizable) {
+            this.colResizingService.resizeCursor = 'col-resize';
+        }
+    }
+
+    /**
+     * @hidden
+     */
+    public onResizeAreaMouseDown(event) {
+        if (event.button === 0 && this.column.resizable) {
+            this.colResizingService.column = this.column;
+            this.colResizingService.showResizer = true;
+            this.colResizingService.isColumnResizing = true;
+            this.colResizingService.resizerHeight = this.column.grid.calcResizerHeight;
+            this.colResizingService.startResizePos = event.clientX;
+        } else {
+            this.colResizingService.resizeCursor = null;
+        }
+    }
+
+    /**
+     * @hidden
+     */
+    public autosizeColumnOnDblClick(event) {
+        if (event.button === 0 && this.column.resizable) {
+            this.colResizingService.column = this.column;
+            this.colResizingService.autosizeColumnOnDblClick();
+         }
+    }
+}

--- a/projects/igniteui-angular/src/lib/grids/grid-header.component.html
+++ b/projects/igniteui-angular/src/lib/grids/grid-header.component.html
@@ -2,49 +2,11 @@
     {{ column.header || column.field }}
 </ng-template>
 
-<ng-container *ngIf="column.columnGroup">
-    <span *ngIf="grid.hasMovableColumns" class="igx-grid__th-drop-indicator-left"></span>
-    <div class="igx-grid__thead-title" [style.width.px]="column.width">{{ column.header }}</div>
-    <div class="igx-grid__thead-group">
-        <ng-container *ngFor="let child of column.children">
-            <div class="igx-grid__thead-subgroup">
-                <igx-grid-header [igxColumnMovingDrag]="child" [attr.droppable]="true" [igxColumnMovingDrop]="child" *ngIf="!child.hidden" [gridID]="column.gridID" [column]="child"
-                    [style.min-width.px]="child.width" [style.flex-basis.px]='child.width' [style.max-width.px]='child.width'></igx-grid-header>
-                <igx-grid-filtering-cell [attr.draggable]="false" *ngIf="grid.allowFiltering && !child.children && !child.hidden" [column]="child"
-                    [style.min-width.px]="child.width" [style.flex-basis.px]='child.width' [style.max-width.px]='child.width'></igx-grid-filtering-cell>
-            </div>
-        </ng-container>
-    </div>
-    <span *ngIf="grid.hasMovableColumns" class="igx-grid__th-drop-indicator-right"></span>
-</ng-container>
-
-<ng-container *ngIf="!column.columnGroup">
-    <span *ngIf="grid.hasMovableColumns" class="igx-grid__th-drop-indicator-left">
-    </span>
-    <span class="igx-grid__th-title">
-        <ng-container *ngTemplateOutlet="column.headerTemplate ? column.headerTemplate : defaultColumn; context: { $implicit: column }">
-        </ng-container>
-    </span>
-    <div class="igx-grid__th-icons" *ngIf="!column.columnGroup">
-        <igx-icon class="sort-icon" *ngIf="column.sortable">{{sortingIcon}}</igx-icon>
-        <!-- <igx-grid-filter [column]="column" *ngIf="column.filterable"></igx-grid-filter> -->
-    </div>
-
-    <span *ngIf="!column.columnGroup" [attr.draggable]="false" [style.cursor]="resizeCursor" #resizeArea
-        class="igx-grid__th-resize-handle">
-
-        <div *ngIf="showResizer" igxResizer
-            class="igx-grid__th-resize-line"
-            [style.height.px]="resizerHeight"
-            [restrictHResizeMax]="restrictResizeMax"
-            [restrictHResizeMin]="restrictResizeMin"
-            [resizeEndTimeout]="resizeEndTimeout"
-            (resizeEnd)="onResize($event)">
-        </div>
-
-    </span>
-
-    <span *ngIf="grid.hasMovableColumns" class="igx-grid__th-drop-indicator-right">
-    </span>
-</ng-container>
+<span class="igx-grid__th-title">
+    <ng-container *ngTemplateOutlet="column.headerTemplate ? column.headerTemplate : defaultColumn; context: { $implicit: column }">
+    </ng-container>
+</span>
+<div class="igx-grid__th-icons" *ngIf="!column.columnGroup">
+    <igx-icon class="sort-icon" *ngIf="column.sortable">{{sortingIcon}}</igx-icon>
+</div>
 

--- a/projects/igniteui-angular/src/lib/grids/grid-header.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-header.component.ts
@@ -1,5 +1,4 @@
 import {
-    AfterViewInit,
     ChangeDetectionStrategy,
     ChangeDetectorRef,
     Component,
@@ -9,22 +8,15 @@ import {
     HostListener,
     Input,
     NgZone,
-    OnInit,
-    ViewChild,
-    QueryList,
-    ViewChildren,
-    OnDestroy
+    OnInit
 } from '@angular/core';
 import { DataType } from '../data-operations/data-util';
 import { SortingDirection } from '../data-operations/sorting-expression.interface';
-import { RestrictDrag } from '../directives/dragdrop/dragdrop.directive';
 import { GridBaseAPIService } from './api.service';
 import { IgxColumnComponent } from './column.component';
-import { IgxColumnMovingService } from './grid.common';
-import { isFirefox } from '../core/utils';
 import { IgxGridBaseComponent } from './grid-base.component';
 import { IgxFilteringService } from './filtering/grid-filtering.service';
-import { IgxGridComponent } from './grid';
+import { IgxColumnResizingService } from './grid-column-resizing.service';
 
 /**
  * @hidden
@@ -35,7 +27,7 @@ import { IgxGridComponent } from './grid';
     selector: 'igx-grid-header',
     templateUrl: './grid-header.component.html'
 })
-export class IgxGridHeaderComponent implements OnInit, DoCheck, AfterViewInit, OnDestroy {
+export class IgxGridHeaderComponent implements OnInit, DoCheck {
 
     @Input()
     public column: IgxColumnComponent;
@@ -55,10 +47,7 @@ export class IgxGridHeaderComponent implements OnInit, DoCheck, AfterViewInit, O
             'asc': this.ascending,
             'desc': this.descending,
             'igx-grid__th--number': this.column.dataType === DataType.Number,
-            'igx-grid__th--sorted': this.sorted,
-            'igx-grid__drag-col-header': this.dragged,
-            'igx-grid__th--pinned-last': this.isLastPinned,
-            'igx-grid__th--filtering': this.filteringService.filteredColumn === this.column
+            'igx-grid__th--sorted': this.sorted
         };
 
         Object.entries(classList).forEach(([klass, value]) => {
@@ -67,25 +56,6 @@ export class IgxGridHeaderComponent implements OnInit, DoCheck, AfterViewInit, O
             }
         });
         return defaultClasses.join(' ');
-    }
-
-
-    @HostBinding('style.min-width')
-    @HostBinding('style.max-width')
-    @HostBinding('style.flex-basis')
-    get width() {
-        // HACK - think of a better solution
-        const colWidth = this.column.width;
-        const isPercentageWidth = colWidth && typeof colWidth === 'string' && colWidth.indexOf('%') !== -1;
-
-        if (isPercentageWidth) {
-            const firstContentCell = this.column.cells[0];
-            if (firstContentCell) {
-                return firstContentCell.nativeElement.getBoundingClientRect().width + 'px';
-            }
-        } else {
-            return this.column.width;
-        }
     }
 
     @HostBinding('style.height.px')
@@ -121,14 +91,6 @@ export class IgxGridHeaderComponent implements OnInit, DoCheck, AfterViewInit, O
         return this.column === this.column.grid.draggedColumn;
     }
 
-    @HostBinding('style.z-index')
-    get zIndex() {
-        if (!this.column.pinned) {
-            return null;
-        }
-        return 9999 - this.grid.pinnedColumns.indexOf(this.column);
-    }
-
     @HostBinding('attr.role')
     public hostRole = 'columnheader';
 
@@ -140,29 +102,14 @@ export class IgxGridHeaderComponent implements OnInit, DoCheck, AfterViewInit, O
         return `${this.gridID}_${this.column.field}`;
     }
 
-    @ViewChild('resizeArea')
-    public resizeArea: ElementRef;
-
-    @ViewChildren(IgxGridHeaderComponent, { read: IgxGridHeaderComponent })
-    public children: QueryList<IgxGridHeaderComponent>;
-
-    public resizeCursor = null;
-    public showResizer = false;
-    public resizerHeight;
-    public dragDirection: RestrictDrag = RestrictDrag.HORIZONTALLY;
-    public resizeEndTimeout = isFirefox() ? 200 : 0;
-
     protected sortDirection = SortingDirection.None;
-
-    private _startResizePos;
-    private _pinnedMaxWidth;
 
     constructor(
         public gridAPI: GridBaseAPIService<IgxGridBaseComponent>,
+        public colResizingService: IgxColumnResizingService,
         public cdr: ChangeDetectorRef,
         public elementRef: ElementRef,
         public zone: NgZone,
-        private cms: IgxColumnMovingService,
         public filteringService: IgxFilteringService
     ) { }
 
@@ -176,29 +123,9 @@ export class IgxGridHeaderComponent implements OnInit, DoCheck, AfterViewInit, O
         this.cdr.markForCheck();
     }
 
-    ngAfterViewInit() {
-        if (!this.column.columnGroup) {
-            this.zone.runOutsideAngular(() => {
-                this.resizeArea.nativeElement.addEventListener('mouseover', this.onResizeAreaMouseOver.bind(this));
-                this.resizeArea.nativeElement.addEventListener('mousedown', this.onResizeAreaMouseDown.bind(this));
-                this.resizeArea.nativeElement.addEventListener('dblclick', this.onResizeAreaDblClick.bind(this));
-            });
-        }
-    }
-
-    ngOnDestroy() {
-        if (!this.column.columnGroup) {
-            this.zone.runOutsideAngular(() => {
-                this.resizeArea.nativeElement.removeEventListener('mouseover', this.onResizeAreaMouseOver);
-                this.resizeArea.nativeElement.removeEventListener('mousedown', this.onResizeAreaMouseDown);
-                this.resizeArea.nativeElement.removeEventListener('dblclick', this.onResizeAreaDblClick);
-            });
-        }
-    }
-
     @HostListener('click', ['$event'])
     public onClick(event) {
-        if (!this.column.grid.isColumnResizing) {
+        if (!this.colResizingService.isColumnResizing) {
             event.stopPropagation();
             if (this.grid.filteringService.isFilterRowVisible) {
                 if (this.column.filterable && !this.column.columnGroup &&
@@ -224,140 +151,12 @@ export class IgxGridHeaderComponent implements OnInit, DoCheck, AfterViewInit, O
         }
     }
 
-    get restrictResizeMin(): number {
-        const actualMinWidth = parseFloat(this.column.minWidth);
-        const defaultMinWidth = parseFloat(this.column.defaultMinWidth);
-
-        let minWidth = Number.isNaN(actualMinWidth) || actualMinWidth < defaultMinWidth ? defaultMinWidth : actualMinWidth;
-        minWidth = minWidth < parseFloat(this.column.width) ? minWidth : parseFloat(this.column.width);
-
-        return minWidth - this.elementRef.nativeElement.getBoundingClientRect().width;
-    }
-
-    get restrictResizeMax(): number {
-        const actualWidth = this.elementRef.nativeElement.getBoundingClientRect().width;
-
-        if (this.column.pinned) {
-            const pinnedMaxWidth = this._pinnedMaxWidth =
-                this.grid.calcPinnedContainerMaxWidth - this.grid.getPinnedWidth(true) + actualWidth;
-
-            if (this.column.maxWidth && parseFloat(this.column.maxWidth) < pinnedMaxWidth) {
-                this._pinnedMaxWidth = this.column.maxWidth;
-
-                return parseFloat(this.column.maxWidth) - actualWidth;
-            } else {
-                return pinnedMaxWidth - actualWidth;
-            }
-        } else {
-            if (this.column.maxWidth) {
-                return parseFloat(this.column.maxWidth) - actualWidth;
-            } else {
-                return Number.MAX_SAFE_INTEGER;
-            }
-        }
-    }
-
     get grid(): any {
         return this.gridAPI.get(this.gridID);
-    }
-
-    get isPinned() {
-        return this.column.pinned;
-    }
-
-    get isLastPinned() {
-        const pinnedCols = this.grid.pinnedColumns;
-        if (pinnedCols.length === 0) {
-            return false;
-        } else {
-            return pinnedCols.indexOf(this.column) === pinnedCols.length - 1;
-        }
     }
 
     protected getSortDirection() {
         const expr = this.gridAPI.get(this.gridID).sortingExpressions.find((x) => x.fieldName === this.column.field);
         this.sortDirection = expr ? expr.dir : SortingDirection.None;
-    }
-
-    private onResizeAreaMouseOver() {
-        if (this.column.resizable) {
-            this.resizeCursor = 'col-resize';
-            this.cdr.detectChanges();
-        }
-    }
-
-    private onResizeAreaMouseDown(event) {
-        if (event.button === 0 && this.column.resizable) {
-            this.showResizer = true;
-            this.column.grid.isColumnResizing = true;
-            this.resizerHeight = this.grid.calcResizerHeight;
-            this._startResizePos = event.clientX;
-        } else {
-            this.resizeCursor = null;
-        }
-        this.cdr.detectChanges();
-    }
-
-    private onResizeAreaDblClick() {
-        if (this.column.resizable) {
-            const currentColWidth = this.elementRef.nativeElement.getBoundingClientRect().width;
-
-            const size = this.column.getLargestCellWidth();
-
-            if (this.column.pinned) {
-                const newPinnedWidth = this.grid.getPinnedWidth(true) - currentColWidth + parseFloat(size);
-
-                if (newPinnedWidth <= this.grid.calcPinnedContainerMaxWidth) {
-                    this.column.width = size;
-                }
-            } else if (this.column.maxWidth && (parseFloat(size) > parseFloat(this.column.maxWidth))) {
-                this.column.width = parseFloat(this.column.maxWidth) + 'px';
-            } else if (parseFloat(size) < parseFloat(this.column.defaultMinWidth)) {
-                this.column.width = this.column.defaultMinWidth + 'px';
-            } else {
-                this.column.width = size;
-            }
-
-            this.grid.markForCheck();
-            this.grid.reflow();
-            this.grid.onColumnResized.emit({ column: this.column, prevWidth: currentColWidth.toString(), newWidth: this.column.width });
-        }
-    }
-
-    public onResize(event) {
-        this.column.grid.isColumnResizing = false;
-
-        this.showResizer = false;
-        const diff = event.clientX - this._startResizePos;
-
-        if (this.column.resizable) {
-            let currentColWidth = parseFloat(this.column.width);
-
-            const actualMinWidth = parseFloat(this.column.minWidth);
-            const defaultMinWidth = parseFloat(this.column.defaultMinWidth);
-
-            let colMinWidth = Number.isNaN(actualMinWidth) || actualMinWidth < defaultMinWidth ? defaultMinWidth : actualMinWidth;
-            const colMaxWidth = this.column.pinned ? parseFloat(this._pinnedMaxWidth) : parseFloat(this.column.maxWidth);
-
-            const actualWidth = this.elementRef.nativeElement.getBoundingClientRect().width;
-
-            currentColWidth = Number.isNaN(currentColWidth) || (currentColWidth < actualWidth) ? actualWidth : currentColWidth;
-            colMinWidth = colMinWidth < currentColWidth ? colMinWidth : currentColWidth;
-
-            if (currentColWidth + diff < colMinWidth) {
-                this.column.width = colMinWidth + 'px';
-            } else if (colMaxWidth && (currentColWidth + diff > colMaxWidth)) {
-                this.column.width = colMaxWidth + 'px';
-            } else {
-                this.column.width = (currentColWidth + diff) + 'px';
-            }
-
-            this.grid.markForCheck();
-            this.grid.reflow();
-
-            if (currentColWidth !== parseFloat(this.column.width)) {
-                this.grid.onColumnResized.emit({ column: this.column, prevWidth: currentColWidth.toString(), newWidth: this.column.width });
-            }
-        }
     }
 }

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -419,7 +419,8 @@ export class IgxGridNavigationService {
         this.grid.rowList.find(row => row instanceof  IgxGridRowComponent).cells.first._clearCellSelection();
         const visColLength = this.grid.unpinnedColumns.length;
         if (this.isColumnFullyVisible(visColLength - 1)) {
-            this.grid.filteringService.focusFilterCellChip(this.grid.filterCellList.last.column.field, false);
+            const lastFilterCellIndex = this.grid.filterCellList.length - 1;
+            this.grid.filteringService.focusFilterCellChip(this.grid.filterCellList[lastFilterCellIndex].column, false);
         } else {
             this.grid.filteringService.columnToFocus = this.grid.unpinnedColumns[visColLength - 1];
             this.grid.filteringService.shouldFocusNext = false;

--- a/projects/igniteui-angular/src/lib/grids/grid.common.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid.common.ts
@@ -123,6 +123,7 @@ export class IgxColumnResizerDirective implements OnInit, OnDestroy {
         event.preventDefault();
     }
 }
+
 /**
  * @hidden
  */
@@ -176,6 +177,8 @@ export class IgxColumnMovingService {
     private _column: IgxColumnComponent;
 
     public cancelDrop: boolean;
+    public isColumnMoving: boolean;
+
     public selection: {
         column: IgxColumnComponent,
         rowID: any
@@ -256,7 +259,6 @@ export class IgxColumnMovingDragDirective extends IgxDragDirective {
     }
 
     public onPointerDown(event) {
-
         if (!this.draggable || event.target.getAttribute('draggable') === 'false') {
             return;
         }
@@ -270,7 +272,7 @@ export class IgxColumnMovingDragDirective extends IgxDragDirective {
 
         super.onPointerDown(event);
 
-        this.column.grid.isColumnMoving = true;
+        this.cms.isColumnMoving = true;
         this.column.grid.cdr.detectChanges();
 
         const currSelection = this.column.grid.selection.first_item(this.column.gridID + '-cell');
@@ -296,7 +298,7 @@ export class IgxColumnMovingDragDirective extends IgxDragDirective {
             this.column.grid.cdr.detectChanges();
         }
 
-        if (this.column.grid.isColumnMoving) {
+        if (this.cms.isColumnMoving) {
             const args = {
                 source: this.column,
                 cancel: false
@@ -314,14 +316,16 @@ export class IgxColumnMovingDragDirective extends IgxDragDirective {
         this.zone.run(() => {
             super.onPointerUp(event);
 
-            this.column.grid.isColumnMoving = false;
+            this.cms.isColumnMoving = false;
             this.column.grid.draggedColumn = null;
             this.column.grid.cdr.detectChanges();
         });
     }
 
     protected createDragGhost(event) {
-        super.createDragGhost(event);
+        const index = this.column.grid.hasMovableColumns ? 1 : 0;
+
+        super.createDragGhost(event, this.element.nativeElement.children[index]);
 
         let pageX, pageY;
         if (this.pointerEventsEnabled || !this.touchEventsEnabled) {
@@ -347,19 +351,15 @@ export class IgxColumnMovingDragDirective extends IgxDragDirective {
         if (!this.column.columnGroup) {
             this.renderer.addClass(icon, this._dragGhostImgIconClass);
 
-            this._dragGhost.removeChild(this._dragGhost.children[2]);
-            this._dragGhost.insertBefore(icon, this._dragGhost.children[1]);
+            this._dragGhost.insertBefore(icon, this._dragGhost.firstElementChild);
 
             this.left = this._dragStartX = pageX - ((this._dragGhost.getBoundingClientRect().width / 3) * 2);
             this.top = this._dragStartY = pageY - ((this._dragGhost.getBoundingClientRect().height / 3) * 2);
         } else {
-            this._dragGhost.removeChild(this._dragGhost.children[2]);
-            this._dragGhost.removeChild(this._dragGhost.firstElementChild);
-            this._dragGhost.removeChild(this._dragGhost.lastElementChild);
-            this._dragGhost.insertBefore(icon, this._dragGhost.firstElementChild);
+            this._dragGhost.insertBefore(icon, this._dragGhost.childNodes[0]);
 
             this.renderer.addClass(icon, this._dragGhostImgIconGroupClass);
-            this._dragGhost.children[1].style.paddingLeft = '0px';
+            this._dragGhost.children[0].style.paddingLeft = '0px';
 
             this.left = this._dragStartX = pageX - ((this._dragGhost.getBoundingClientRect().width / 3) * 2);
             this.top = this._dragStartY = pageY - ((this._dragGhost.getBoundingClientRect().height / 3) * 2);
@@ -389,7 +389,7 @@ export class IgxColumnMovingDropDirective extends IgxDropDirective implements On
     }
 
     get isDropTarget(): boolean {
-        return this._column && this._column.grid.hasMovableColumns;
+        return this._column && this._column.grid.hasMovableColumns && this.cms.column.movable;
     }
 
     get horizontalScroll(): any {
@@ -425,7 +425,8 @@ export class IgxColumnMovingDropDirective extends IgxDropDirective implements On
                 this.renderer.removeClass(this._dropIndicator, this._dropIndicatorClass);
             }
 
-            const pos = this.elementRef.nativeElement.getBoundingClientRect().left + parseFloat(this.column.width) / 2;
+            const clientRect = this.elementRef.nativeElement.getBoundingClientRect();
+            const pos = clientRect.left + clientRect.width / 2;
 
             if (event.detail.pageX < pos) {
                 this._dropPos = DropPosition.BeforeDropTarget;
@@ -530,11 +531,9 @@ export class IgxColumnMovingDropDirective extends IgxDropDirective implements On
             this.column.grid.moveColumn(this.cms.column, this.column, this._dropPos);
 
             if (this.cms.selection && this.cms.selection.column) {
-                const colID = this.column.grid.columnList.toArray().indexOf(this.cms.selection.column);
-
                 this.column.grid.selection.set(this.column.gridID + '-cell', new Set([{
                     rowID: this.cms.selection.rowID,
-                    columnID: colID
+                    columnID: this.column.grid.columnList.toArray().indexOf(this.cms.selection.column)
                 }]));
 
                 const cell = this.column.grid.getCellByKey(this.cms.selection.rowID, this.cms.selection.column.field);
@@ -542,8 +541,6 @@ export class IgxColumnMovingDropDirective extends IgxDropDirective implements On
                 if (cell) {
                     cell.nativeElement.focus();
                 }
-
-                this.cms.selection = null;
             }
 
             this.column.grid.draggedColumn = null;

--- a/projects/igniteui-angular/src/lib/grids/grid/column-group.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/column-group.spec.ts
@@ -68,7 +68,8 @@ describe('IgxGrid - multi-column headers', () => {
         addressGroup.hidden = true;
         tick();
 
-        expect(document.querySelectorAll('igx-grid-header').length).toEqual(6);
+        expect(document.querySelectorAll('igx-grid-header').length).toEqual(4);
+        expect(document.querySelectorAll('igx-grid-header-group').length).toEqual(6);
     }));
 
     it('column hiding - child level', fakeAsync(() => {
@@ -81,7 +82,7 @@ describe('IgxGrid - multi-column headers', () => {
         addressGroup.children.first.hidden = true;
         tick();
 
-        expect(document.querySelectorAll('igx-grid-header').length).toEqual(5);
+        expect(document.querySelectorAll('igx-grid-header-group').length).toEqual(5);
         expect(addressGroup.children.first.hidden).toBe(true);
         expect(addressGroup.children.first.children.toArray().every(c => c.hidden === true)).toEqual(true);
     }));
@@ -102,7 +103,7 @@ describe('IgxGrid - multi-column headers', () => {
         // Hide column in goup
         grid.getColumnByName('CompanyName').hidden = true;
         tick();
-        expect(document.querySelectorAll('igx-grid-header').length).toEqual(16);
+        expect(document.querySelectorAll('igx-grid-header-group').length).toEqual(16);
         expect(fixture.debugElement.queryAll(By.css(GRID_COL_THEAD_CLASS)).length).toEqual(9);
 
         grid.getColumnByName('Address').hidden = true;
@@ -586,7 +587,7 @@ describe('IgxGrid - multi-column headers', () => {
             testColumnGroupHeaderRendering(secondGroup,
                 secondGroupChildrenCount * secondSubGroupChildrenCount * columnWidthPx,
                 gridHeadersDepth * grid.defaultRowHeight, componentInstance.secondGroupTitle,
-                'secondSubGroup', secondGroupChildrenCount);
+                'secondSubGroup', 0);
 
             const secondSubGroups = secondGroup.queryAll(By.css('.secondSubGroup'));
             testColumnGroupHeaderRendering(secondSubGroups[0],
@@ -1850,21 +1851,21 @@ export class StegosaurusGridComponent implements AfterViewInit {
 @Component({
     template: `
         <igx-grid #grid [data]="data" [height]="gridHeight" [columnWidth]="columnWidth">
-            <igx-column-group headerClasses="firstGroup" [header]="firstGroupTitle">
+            <igx-column-group headerGroupClasses="firstGroup" [header]="firstGroupTitle">
                 <igx-column headerClasses="firstGroupColumn" field="ID" *ngFor="let item of hunderdItems;"></igx-column>
             </igx-column-group>
-            <igx-column-group headerClasses="secondGroup" [header]="secondGroupTitle">
-                <igx-column-group headerClasses="secondSubGroup" [header]="secondSubGroupTitle">
+            <igx-column-group headerGroupClasses="secondGroup" [header]="secondGroupTitle">
+                <igx-column-group headerGroupClasses="secondSubGroup" [header]="secondSubGroupTitle">
                     <igx-column headerClasses="secondSubGroupColumn" field="ID" *ngFor="let item of fiftyItems;"></igx-column>
                 </igx-column-group>
-                <igx-column-group headerClasses="secondSubGroup" [header]="secondSubGroupTitle">
+                <igx-column-group headerGroupClasses="secondSubGroup" [header]="secondSubGroupTitle">
                     <igx-column  headerClasses="secondSubGroupColumn" field="ID" *ngFor="let item of fiftyItems;"></igx-column>
                 </igx-column-group>
             </igx-column-group>
             <igx-column headerClasses="lonelyId" [header]="idHeaderTitle" field="ID"></igx-column>
             <igx-column-group header="General Information">
                 <igx-column headerClasses="companyName" [header]="companyNameTitle" field="CompanyName"></igx-column>
-                <igx-column-group headerClasses="personDetails" [header]="personDetailsTitle">
+                <igx-column-group headerGroupClasses="personDetails" [header]="personDetailsTitle">
                     <igx-column headerClasses="personDetailsColumn" field="ContactName"></igx-column>
                     <igx-column headerClasses="personDetailsColumn" field="ContactTitle"></igx-column>
                 </igx-column-group>
@@ -1907,7 +1908,7 @@ export class BlueWhaleGridComponent {
 @Component({
     template: `
         <igx-grid #grid [data]="data" height="600px" columnWidth="100px">
-            <igx-column-group headerClasses="emptyColGroup" #emptyColGroup header="First Group">
+            <igx-column-group headerGroupClasses="emptyColGroup" #emptyColGroup header="First Group">
             </igx-column-group>
         </igx-grid>
     `
@@ -1925,13 +1926,13 @@ export class EmptyColGridComponent {
 @Component({
     template: `
         <igx-grid #grid [data]="data" height="600px" [columnWidth]="columnWidth">
-            <igx-column-group headerClasses="addressColGroup" [header]="addressColGroupTitle">
+            <igx-column-group headerGroupClasses="addressColGroup" [header]="addressColGroupTitle">
                 <igx-column headerClasses="addressCol" field="Address" [header]="addressColTitle"></igx-column>
             </igx-column-group>
-            <igx-column-group headerClasses="phoneColGroup" [header]="phoneColGroupTitle">
+            <igx-column-group headerGroupClasses="phoneColGroup" [header]="phoneColGroupTitle">
                 <igx-column headerClasses="phoneCol" field="Phone" [header]="phoneColTitle" [width]="phoneColWidth"></igx-column>
             </igx-column-group>
-            <igx-column-group headerClasses="faxColGroup" [header]="faxColGroupTitle">
+            <igx-column-group headerGroupClasses="faxColGroup" [header]="faxColGroupTitle">
                 <igx-column headerClasses="faxCol" field="Fax" [header]="faxColTitle" [width]="faxColWidth"></igx-column>
             </igx-column-group>
         </igx-grid>
@@ -1960,13 +1961,13 @@ export class OneColPerGroupGridComponent {
 @Component({
     template: `
         <igx-grid #grid [data]="data" height="600px" [columnWidth]="columnWidth">
-            <igx-column-group headerClasses="masterColGroup" [header]="masterColGroupTitle">
-                <igx-column-group headerClasses="firstSlaveColGroup slaveColGroup" [header]="firstSlaveColGroupTitle">
+            <igx-column-group headerGroupClasses="masterColGroup" [header]="masterColGroupTitle">
+                <igx-column-group headerGroupClasses="firstSlaveColGroup slaveColGroup" [header]="firstSlaveColGroupTitle">
                     <igx-column headerClasses="addressCol firstSlaveChild" field="Address" [header]="addressColTitle"></igx-column>
                     <igx-column headerClasses="phoneCol firstSlaveChild" field="Phone" [header]="phoneColTitle" [width]="phoneColWidth">
                     </igx-column>
                 </igx-column-group>
-                <igx-column-group headerClasses="secondSlaveColGroup slaveColGroup" [header]="secondSlaveColGroupTitle">
+                <igx-column-group headerGroupClasses="secondSlaveColGroup slaveColGroup" [header]="secondSlaveColGroupTitle">
                     <igx-column headerClasses="faxCol secondSlaveChild" field="Fax" [header]="faxColTitle" [width]="faxColWidth">
                     </igx-column>
                     <igx-column headerClasses="cityCol secondSlaveChild" field="City" [header]="cityColTitle" [width]="cityColWidth">
@@ -2054,8 +2055,9 @@ function getColGroup(grid: IgxGridComponent, headerName: string): IgxColumnGroup
 // tests column and column group header rendering
 function testColumnGroupHeaderRendering(column: DebugElement, width: number, height: number,
     title: string, descendentColumnCssClass?: string, descendentColumnCount?: number) {
-    expect(column.nativeElement.parentElement.offsetHeight).toBe(height);
-    expect(column.nativeElement.parentElement.offsetWidth).toBe(width);
+
+    expect(column.nativeElement.offsetHeight).toBe(height);
+    expect(column.nativeElement.offsetWidth).toBe(width);
 
     const colHeaderTitle = column.children
         .filter(c => c.nativeElement.classList.contains(GRID_COL_GROUP_THEAD_TITLE_CLASS))[0];
@@ -2103,7 +2105,7 @@ function testColumnsVisibleIndexes(columns: IgxColumnComponent[]) {
 }
 
 function testGroupsAndColumns(groups: number, columns: number) {
-    expect(document.querySelectorAll('igx-grid-header').length).toEqual(groups);
+    expect(document.querySelectorAll('igx-grid-header-group').length).toEqual(groups);
     expect(document.querySelectorAll(GRID_COL_THEAD_CLASS).length).toEqual(columns);
 }
 
@@ -2176,7 +2178,7 @@ class NestedColGroupsTests {
         const masterColGroup = fixture.debugElement.query(By.css('.masterColGroup'));
         const masterColGroupWidth = firstSlaveColGroupWidth + secondSlaveColGroupWidth;
         const masterSlaveColGroupDepth = 3;
-        const masterColGroupChildrenCount = 2;
+        const masterColGroupChildrenCount = 0;
 
         testColumnGroupHeaderRendering(masterColGroup, masterColGroupWidth,
             masterSlaveColGroupDepth * grid.defaultRowHeight, ci.masterColGroupTitle,

--- a/projects/igniteui-angular/src/lib/grids/grid/column-moving.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/column-moving.spec.ts
@@ -24,7 +24,7 @@ describe('IgxGrid - Column Moving', () => {
     configureTestSuite();
     const CELL_CSS_CLASS = '.igx-grid__td';
     const COLUMN_HEADER_CLASS = '.igx-grid__th';
-    const COLUMN_GROUP_HEADER_CLASS = '.igx-grid__th--fw';
+    const COLUMN_GROUP_HEADER_CLASS = '.igx-grid__thead-title';
 
     let fixture, grid: IgxGridComponent;
 
@@ -141,8 +141,7 @@ describe('IgxGrid - Column Moving', () => {
             expect(columnsList[2].field).toEqual('LastName');
         }));
 
-        xit('Should not break filtering, sorting and resizing when column moving is enabled.', (async() => {
-            pending('This scenario need to be reworked with new Filtering row');
+        it('Should not break sorting and resizing when column moving is enabled.', (async() => {
             fixture.componentInstance.isFilterable = true;
             fixture.componentInstance.isResizable = true;
             fixture.componentInstance.isSortable = true;
@@ -171,13 +170,12 @@ describe('IgxGrid - Column Moving', () => {
 
 
             // step 2 - verify resizing is not broken
-            const resizeHandle = headers[0].nativeElement.children[3];
-
-            UIInteractions.simulateMouseEvent('mousedown', resizeHandle, 200, 0);
+            const resizeHandle = headers[0].parent.nativeElement.children[2];
+            UIInteractions.simulateMouseEvent('mousedown', resizeHandle, 200, 80);
             await wait();
             fixture.detectChanges();
 
-            const resizer = headers[0].nativeElement.children[3].children[0];
+            const resizer = headers[0].parent.nativeElement.children[2].children[0];
             expect(resizer).toBeDefined();
             UIInteractions.simulateMouseEvent('mousemove', resizer, 300, 5);
             await wait();
@@ -194,18 +192,6 @@ describe('IgxGrid - Column Moving', () => {
             fixture.detectChanges();
 
             expect(grid.getCellByColumn(0, 'ID').value).toEqual(6);
-
-
-            // step 4 - verify filtering is not broken
-            const filterUIContainer = fixture.debugElement.query(By.css('igx-grid-filter'));
-            const filterIcon = filterUIContainer.query(By.css('igx-icon'));
-
-            filterIcon.nativeElement.click();
-            await wait();
-            fixture.detectChanges();
-
-            const dialog = filterUIContainer.query(By.directive(IgxToggleDirective));
-            expect(dialog.nativeElement.classList).toContain('igx-toggle');
         }));
 
         it('Should not break vertical or horizontal scrolling after columns are reordered.', (async() => {
@@ -243,44 +229,6 @@ describe('IgxGrid - Column Moving', () => {
             fixture.detectChanges();
 
             expect(grid.columnList.toArray()[2].cells[3].value).toBeTruthy('BRown');
-        }));
-
-        xit('Should close filter dialog, if opened, when column moving starts.', (async() => {
-            pending('This scenario need to be reworked with new Filtering row');
-            fixture.componentInstance.isFilterable = true;
-            fixture.detectChanges();
-
-            const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
-
-            headers[0].triggerEventHandler('click', new Event('click'));
-            fixture.detectChanges();
-
-            const filterUIContainer = fixture.debugElement.query(By.css('igx-grid-filter'));
-            const filterIcon = filterUIContainer.query(By.css('igx-icon'));
-
-            // step 1 - open the filtering dialog
-            filterIcon.nativeElement.click();
-            await wait();
-            fixture.detectChanges();
-
-            let dialog = filterUIContainer.query(By.directive(IgxToggleDirective));
-            expect(dialog.nativeElement.classList.contains('igx-toggle')).toBeTruthy();
-
-            // step 2 - move a column
-            const header = headers[0].nativeElement;
-            UIInteractions.simulatePointerEvent('pointerdown', header, 100, 65);
-            await wait();
-            UIInteractions.simulatePointerEvent('pointermove', header, 106, 71);
-            await wait();
-            UIInteractions.simulatePointerEvent('pointermove', header, 300, 71);
-            await wait();
-            UIInteractions.simulatePointerEvent('pointerup', header, 300, 71);
-            await wait();
-            fixture.detectChanges();
-
-            // step 3 - verify the filtering dialog is closed
-            dialog = filterUIContainer.query(By.directive(IgxToggleDirective));
-            expect(dialog.nativeElement.classList.contains('igx-toggle--hidden')).toBeTruthy();
         }));
 
         it('Should fire onColumnMovingStart, onColumnMoving and onColumnMovingEnd with correct values of event arguments.', (async() => {
@@ -509,6 +457,7 @@ describe('IgxGrid - Column Moving', () => {
             cell = fixture.debugElement.queryAll(By.css(CELL_CSS_CLASS))[1];
             UIInteractions.triggerKeyDownEvtUponElem('arrowright', cell.nativeElement, true);
             await wait(50);
+            fixture.detectChanges();
 
             expect(grid.getCellByColumn(0, 'LastName').selected).toBeTruthy();
         }));
@@ -542,6 +491,7 @@ describe('IgxGrid - Column Moving', () => {
             cell = fixture.debugElement.queryAll(By.css(CELL_CSS_CLASS))[0];
             UIInteractions.triggerKeyDownEvtUponElem('arrowright', cell.nativeElement, true);
             await wait(50);
+            fixture.detectChanges();
 
             expect(grid.getCellByColumn(0, 'LastName').selected).toBeTruthy();
         }));
@@ -1002,7 +952,7 @@ describe('IgxGrid - Column Moving', () => {
         it('MCH - should reorder only columns on the same level (top level simple column).', (async() => {
 
             // step 1 - try reordering simple column level 0 and simple column level 1
-            const header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[0].nativeElement;
+            const header = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS))[0].nativeElement;
             UIInteractions.simulatePointerEvent('pointerdown', header, 50, 75);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 50, 81);
@@ -1051,7 +1001,7 @@ describe('IgxGrid - Column Moving', () => {
         it('MCH - should reorder only columns on the same level (top level group column).', (async() => {
 
             // step 1 - try reordering group column level 0 and simple column level 1
-            let header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[1].nativeElement;
+            let header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[0].nativeElement;
             UIInteractions.simulatePointerEvent('pointerdown', header, 250, 25);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 250, 31);
@@ -1073,9 +1023,9 @@ describe('IgxGrid - Column Moving', () => {
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 250, 31);
             await wait(50);
-            UIInteractions.simulatePointerEvent('pointermove', header, 560, 81);
-            await wait();
-            UIInteractions.simulatePointerEvent('pointerup', header, 560, 81);
+            UIInteractions.simulatePointerEvent('pointermove', header, 570, 81);
+            await wait(50);
+            UIInteractions.simulatePointerEvent('pointerup', header, 570, 81);
             await wait();
             fixture.detectChanges();
 
@@ -1085,14 +1035,14 @@ describe('IgxGrid - Column Moving', () => {
             expect(columnsList[2].field).toEqual('CompanyName');
 
             // step 3 - try reordering group column level 0 and group column level 0
-            header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[7].nativeElement;
-            UIInteractions.simulatePointerEvent('pointerdown', header, 800, 25);
+            header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[2].nativeElement;
+            UIInteractions.simulatePointerEvent('pointerdown', header, 700, 25);
             await wait();
-            UIInteractions.simulatePointerEvent('pointermove', header, 800, 31);
+            UIInteractions.simulatePointerEvent('pointermove', header, 700, 31);
             await wait(50);
-            UIInteractions.simulatePointerEvent('pointermove', header, 350, 31);
+            UIInteractions.simulatePointerEvent('pointermove', header, 200, 31);
             await wait();
-            UIInteractions.simulatePointerEvent('pointerup', header, 350, 31);
+            UIInteractions.simulatePointerEvent('pointerup', header, 200, 31);
             await wait();
             fixture.detectChanges();
 
@@ -1106,7 +1056,7 @@ describe('IgxGrid - Column Moving', () => {
         it('MCH - should reorder only columns on the same level (sub level simple column).', (async() => {
 
             // step 1 - try reordering simple column level 1 and simple column level 0
-            const header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[2].nativeElement;
+            const header = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS))[1].nativeElement;
             UIInteractions.simulatePointerEvent('pointerdown', header, 150, 100);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 150, 106);
@@ -1174,7 +1124,8 @@ describe('IgxGrid - Column Moving', () => {
         it('MCH - should reorder only columns on the same level (sub level group column).', (async() => {
 
             // step 1 - try reordering group column level 1 and simple column level 0
-            const header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[3].nativeElement;
+            const header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[1].nativeElement;
+
             UIInteractions.simulatePointerEvent('pointerdown', header, 300, 75);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 300, 81);
@@ -1226,7 +1177,7 @@ describe('IgxGrid - Column Moving', () => {
         it('MCH - should reorder only columns on the same level, with same parent.', (async() => {
 
             // step 1 - try reordering simple column level 1 and simple column level 1 (different parent)
-            let header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[2].nativeElement;
+            let header = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS))[1].nativeElement;
             UIInteractions.simulatePointerEvent('pointerdown', header, 150, 75);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 150, 81);
@@ -1242,7 +1193,7 @@ describe('IgxGrid - Column Moving', () => {
             expect(columnsList[5].field).toEqual('Country');
 
             // step 2 - try reordering simple column level 2 and simple column level 2 (same parent)
-            header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[5].nativeElement;
+            header = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS))[3].nativeElement;
             UIInteractions.simulatePointerEvent('pointerdown', header, 400, 125);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 400, 131);
@@ -1258,14 +1209,14 @@ describe('IgxGrid - Column Moving', () => {
             expect(columnsList[3].field).toEqual('ContactName');
 
             // step 3 - try reordering simple column level 0 and simple column level 0 (no parent)
-            header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[0].nativeElement;
+            header = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS))[0].nativeElement;
             UIInteractions.simulatePointerEvent('pointerdown', header, 50, 75);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 50, 81);
             await wait(50);
-            UIInteractions.simulatePointerEvent('pointermove', header, 560, 81);
+            UIInteractions.simulatePointerEvent('pointermove', header, 580, 81);
             await wait();
-            UIInteractions.simulatePointerEvent('pointerup', header, 560, 81);
+            UIInteractions.simulatePointerEvent('pointerup', header, 580, 81);
             await wait();
             fixture.detectChanges();
 
@@ -1284,14 +1235,14 @@ describe('IgxGrid - Column Moving', () => {
             fixture.detectChanges();
 
             // step 2 - reorder the parent column and verify selection is preserved
-            const header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[1].nativeElement;
+            const header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[0].nativeElement;
             UIInteractions.simulatePointerEvent('pointerdown', header, 300, 25);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 300, 31);
             await wait(50);
-            UIInteractions.simulatePointerEvent('pointermove', header, 560, 50);
+            UIInteractions.simulatePointerEvent('pointermove', header, 580, 50);
             await wait();
-            UIInteractions.simulatePointerEvent('pointerup', header, 560, 50);
+            UIInteractions.simulatePointerEvent('pointerup', header, 580, 50);
             await wait();
             fixture.detectChanges();
 
@@ -1312,7 +1263,7 @@ describe('IgxGrid - Column Moving', () => {
             fixture.detectChanges();
 
             // step 2 - try pinning a sub level simple column
-            let header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[2].nativeElement;
+            let header = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS))[1].nativeElement;
             UIInteractions.simulatePointerEvent('pointerdown', header, 150, 75);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 150, 81);
@@ -1327,7 +1278,7 @@ describe('IgxGrid - Column Moving', () => {
             expect(columnsList[1].field).toEqual('CompanyName');
 
             // step 3 - try pinning a top level group column
-            header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[1].nativeElement;
+            header = fixture.debugElement.queryAll(By.css(COLUMN_GROUP_HEADER_CLASS))[0].nativeElement;
             UIInteractions.simulatePointerEvent('pointerdown', header, 150, 25);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 150, 31);

--- a/projects/igniteui-angular/src/lib/grids/grid/column-resizing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/column-resizing.spec.ts
@@ -1,5 +1,5 @@
 import { Component, DebugElement, OnInit, ViewChild } from '@angular/core';
-import { async, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { async, fakeAsync, TestBed, tick, flush } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -18,6 +18,7 @@ import { configureTestSuite } from '../../test-utils/configure-suite';
 describe('IgxGrid - Deferred Column Resizing', () => {
     configureTestSuite();
     const COLUMN_HEADER_CLASS = '.igx-grid__th';
+    const COLUMN_HEADER_GROUP_CLASS = '.igx-grid__thead-item';
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -50,22 +51,17 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         expect(grid.columns[0].resizable).toBeTruthy();
         expect(grid.columns[2].resizable).toBeFalsy();
 
-        const headerResArea = headers[0].nativeElement.children[2];
-        UIInteractions.simulateMouseEvent('mouseover', headerResArea, 100, 5);
-        UIInteractions.simulateMouseEvent('mousedown', headerResArea, 100, 5);
-        UIInteractions.simulateMouseEvent('mousedup', headerResArea, 100, 5);
-        tick(100);
-        fixture.detectChanges();
-        UIInteractions.simulateMouseEvent('mousedown', headerResArea, 100, 5);
-        tick(100);
+        const headerResArea = headers[0].parent.children[1].nativeElement;
+        UIInteractions.simulateMouseEvent('mousedown', headerResArea, 100, 15);
+        tick();
         fixture.detectChanges();
 
-        let resizer = headers[0].nativeElement.children[2].children[0];
+        let resizer = headers[0].parent.children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
-        UIInteractions.simulateMouseEvent('mousemove', resizer, 250, 5);
-        tick(100);
+        UIInteractions.simulateMouseEvent('mousemove', resizer, 250, 15);
+        tick();
 
-        UIInteractions.simulateMouseEvent('mouseup', resizer, 250, 5);
+        UIInteractions.simulateMouseEvent('mouseup', resizer, 250, 15);
         tick();
         fixture.detectChanges();
 
@@ -75,7 +71,7 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         tick();
         fixture.detectChanges();
 
-        resizer = headers[0].nativeElement.children[2].children[0];
+        resizer = headers[0].parent.children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 40, 5);
         tick();
@@ -105,12 +101,12 @@ describe('IgxGrid - Deferred Column Resizing', () => {
 
         expect(grid.columns[0].width).toEqual('100px');
 
-        const headerResArea = headers[0].nativeElement.children[2];
+        const headerResArea = headers[0].parent.children[1].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 100, 0);
         tick();
         fixture.detectChanges();
 
-        const resizer = headers[0].nativeElement.children[2].children[0];
+        const resizer = headers[0].parent.children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 700, 5);
         tick();
@@ -134,18 +130,18 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         expect(grid.columns[1].maxWidth).toEqual('250px');
         expect(grid.columns[1].resizable).toBeTruthy();
 
-        const headerResArea = headers[1].nativeElement.children[2];
+        const headerResArea = headers[1].parent.children[1].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 200, 0);
         tick();
         fixture.detectChanges();
 
-        let resizer = headers[1].nativeElement.children[2].children[0];
+        let resizer = headers[1].parent.children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 370, 5);
         tick();
 
         UIInteractions.simulateMouseEvent('mouseup', resizer, 370, 5);
-        tick(100);
+        tick();
         fixture.detectChanges();
 
         expect(grid.columns[1].width).toEqual('250px');
@@ -154,7 +150,7 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         tick();
         fixture.detectChanges();
 
-        resizer = headers[1].nativeElement.children[2].children[0];
+        resizer = headers[1].parent.children[1].children[0].nativeElement;
         UIInteractions.simulateMouseEvent('mousemove', resizer, 100, 5);
         tick();
 
@@ -176,12 +172,12 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         expect(grid.columns[2].sortable).toBeTruthy();
         expect(grid.columns[2].cells[0].value).toEqual(254);
 
-        const headerResArea = headers[2].nativeElement.children[2];
+        const headerResArea = headers[2].parent.children[1].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 450, 0);
         tick();
         fixture.detectChanges();
 
-        const resizer = headers[2].nativeElement.children[1].children[0];
+        const resizer = headers[2].parent.children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 550, 5);
         tick();
@@ -211,12 +207,12 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         expect(grid.columns[0].width).toEqual('100px');
         expect(grid.columns[1].width).toEqual('100px');
 
-        const headerResArea = headers[0].nativeElement.children[2];
+        const headerResArea = headers[0].parent.children[1].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 100, 0);
         tick();
         fixture.detectChanges();
 
-        let resizer = headers[0].nativeElement.children[2].children[0];
+        let resizer = headers[0].parent.children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 450, 5);
         tick();
@@ -232,7 +228,7 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         tick();
         fixture.detectChanges();
 
-        resizer = headers[0].nativeElement.children[2].children[0];
+        resizer = headers[0].parent.children[1].children[0].nativeElement;
         UIInteractions.simulateMouseEvent('mousemove', resizer, 100, 5);
         tick();
 
@@ -252,12 +248,12 @@ describe('IgxGrid - Deferred Column Resizing', () => {
 
         expect(parseInt(grid.columns[0].width, 10)).not.toBeNaN();
 
-        let headerResArea = headers[0].nativeElement.children[2];
+        let headerResArea = headers[0].parent.children[1].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 126, 5);
         tick();
         fixture.detectChanges();
 
-        let resizer = headers[0].nativeElement.children[2].children[0];
+        let resizer = headers[0].parent.children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 250, 5);
         tick();
@@ -272,7 +268,7 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         tick();
         fixture.detectChanges();
 
-        resizer = headers[0].nativeElement.children[2].children[0];
+        resizer = headers[0].parent.children[1].children[0].nativeElement;
         UIInteractions.simulateMouseEvent('mousemove', resizer, 50, 5);
         tick();
 
@@ -282,14 +278,14 @@ describe('IgxGrid - Deferred Column Resizing', () => {
 
         expect(grid.columns[0].width).toEqual('70px');
 
-        headerResArea = headers[1].nativeElement.children[2];
+        headerResArea = headers[1].parent.children[1].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 197, 5);
         tick();
         fixture.detectChanges();
 
         expect(parseInt(grid.columns[1].width, 10)).not.toBeNaN();
 
-        resizer = headers[1].nativeElement.children[2].children[0];
+        resizer = headers[1].parent.children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 300, 5);
         tick();
@@ -304,7 +300,7 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         tick();
         fixture.detectChanges();
 
-        resizer = headers[1].nativeElement.children[2].children[0];
+        resizer = headers[1].parent.children[1].children[0].nativeElement;
         UIInteractions.simulateMouseEvent('mousemove', resizer, 50, 5);
         tick();
 
@@ -328,12 +324,12 @@ describe('IgxGrid - Deferred Column Resizing', () => {
 
         expect(grid.columns[1].width).toEqual('100px');
 
-        const headerResArea = headers[1].nativeElement.children[2];
+        const headerResArea = headers[1].parent.children[1].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 200, 0);
         tick();
         fixture.detectChanges();
 
-        const resizer = headers[1].nativeElement.children[2].children[0];
+        const resizer = headers[1].parent.children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 350, 5);
         tick();
@@ -350,43 +346,44 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         const grid = fixture.componentInstance.grid;
-        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
+        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
 
         expect(grid.columns[0].width).toEqual('150px');
         expect(grid.columns[1].width).toEqual('150px');
         expect(grid.columns[2].width).toEqual('150px');
 
-        let resizeArea = headers[0].componentInstance.resizeArea.nativeElement;
-        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 148, 5);
+        let resizeArea = headers[0].children[1].nativeElement;
+        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 148, 15);
         tick();
         fixture.detectChanges();
 
         expect(grid.columns[0].width).toEqual('78px');
 
-        resizeArea = headers[1].componentInstance.resizeArea.nativeElement;
+        resizeArea = headers[1].children[1].nativeElement;
+        UIInteractions.simulateMouseEvent('mouseover', resizeArea, 248, 5);
         UIInteractions.simulateMouseEvent('dblclick', resizeArea, 248, 5);
         tick();
         fixture.detectChanges();
 
         expect(grid.columns[1].width).toEqual('195px');
 
-        resizeArea = headers[2].componentInstance.resizeArea.nativeElement;
+        resizeArea = headers[2].children[1].nativeElement;
         UIInteractions.simulateMouseEvent('dblclick', resizeArea, 305, 5);
         tick();
         fixture.detectChanges();
 
         expect(grid.columns[2].width).toEqual('78px');
 
-        resizeArea = headers[3].componentInstance.resizeArea.nativeElement;
+        resizeArea = headers[3].children[1].nativeElement;
         UIInteractions.simulateMouseEvent('dblclick', resizeArea, 400, 5);
         tick();
         fixture.detectChanges();
 
         expect(grid.columns[3].width).toEqual('73px');
 
-        resizeArea = headers[5].componentInstance.resizeArea.nativeElement;
+        resizeArea = headers[5].children[1].nativeElement;
         UIInteractions.simulateMouseEvent('dblclick', resizeArea, 486, 5);
-        tick();
+        tick(100);
         fixture.detectChanges();
 
         expect(grid.columns[5].width).toEqual('89px');
@@ -397,13 +394,13 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         const grid = fixture.componentInstance.grid;
-        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
+        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
 
-        expect(grid.columns[4].cells[0].nativeElement.getBoundingClientRect().width).toEqual(48);
+        expect(grid.columns[4].cells[0].nativeElement.getBoundingClientRect().width).toEqual(50);
         expect(grid.columns[4].maxWidth).toEqual('100px');
 
-        const resizeArea = headers[4].componentInstance.resizeArea.nativeElement;
-        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 498, 5);
+        const resizeArea = headers[4].children[1].nativeElement;
+        UIInteractions.simulateMouseEvent('dblclick', resizeArea, 448, 15);
         tick();
         fixture.detectChanges();
 
@@ -415,11 +412,11 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         const grid = fixture.componentInstance.grid;
-        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
+        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
 
         expect(grid.columns[5].width).toEqual('150px');
 
-        const resizeArea = headers[5].componentInstance.resizeArea.nativeElement;
+        const resizeArea = headers[5].children[1].nativeElement;
         UIInteractions.simulateMouseEvent('dblclick', resizeArea, 898, 5);
         tick();
         fixture.detectChanges();
@@ -432,11 +429,11 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         const grid = fixture.componentInstance.grid;
-        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
+        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
 
         expect(grid.columns[2].width).toEqual('100px');
 
-        const resizeArea = headers[2].componentInstance.resizeArea.nativeElement;
+        const resizeArea = headers[2].children[1].nativeElement;
         UIInteractions.simulateMouseEvent('dblclick', resizeArea, 298, 5);
         tick();
         fixture.detectChanges();
@@ -449,13 +446,13 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         const grid = fixture.componentInstance.grid;
-        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
+        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
 
         expect(grid.columns[0].width).toEqual('100px');
         expect(grid.columns[1].width).toEqual('100px');
         expect(grid.columns[2].width).toEqual('100px');
 
-        const resizeArea = headers[1].componentInstance.resizeArea.nativeElement;
+        const resizeArea = headers[1].children[1].nativeElement;
         UIInteractions.simulateMouseEvent('dblclick', resizeArea, 198, 5);
         tick();
         fixture.detectChanges();
@@ -464,12 +461,12 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         expect(grid.columns[1].width).toEqual('100px');
         expect(grid.columns[2].width).toEqual('100px');
 
-        const headerResArea = headers[0].nativeElement.children[2];
+        const headerResArea = headers[0].children[1].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 100, 0);
         tick();
         fixture.detectChanges();
 
-        const resizer = headers[0].nativeElement.children[2].children[0];
+        const resizer = headers[0].children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 450, 5);
         tick();
@@ -488,17 +485,17 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         const grid = fixture.componentInstance.grid;
-        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
+        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
 
         expect(grid.columns[0].width).toEqual('150px');
         expect(fixture.componentInstance.count).toEqual(0);
 
-        const headerResArea = headers[0].nativeElement.children[2];
+        const headerResArea = headers[0].children[1].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 150, 5);
         tick();
         fixture.detectChanges();
 
-        const resizer = headers[0].nativeElement.children[2].children[0];
+        const resizer = headers[0].children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 300, 5);
         tick();
@@ -515,7 +512,7 @@ describe('IgxGrid - Deferred Column Resizing', () => {
 
         expect(grid.columns[1].width).toEqual('150px');
 
-        const resizeArea = headers[1].componentInstance.resizeArea.nativeElement;
+        const resizeArea = headers[1].children[1].nativeElement;
         UIInteractions.simulateMouseEvent('dblclick', resizeArea, 198, 5);
         tick();
         fixture.detectChanges();
@@ -531,7 +528,7 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         const fixture = TestBed.createComponent(ResizableColumnsComponent);
         fixture.detectChanges();
         const grid = fixture.componentInstance.grid;
-        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
+        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
         const displayContainer: HTMLElement = fixture.componentInstance.grid.tbody.nativeElement.querySelector('igx-display-container');
         let rowsRendered = displayContainer.querySelectorAll('igx-display-container');
         let colsRendered = rowsRendered[0].children;
@@ -540,12 +537,12 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         expect(colsRendered.length).toEqual(4);
 
         // Resize first column
-        const headerResArea = headers[0].nativeElement.children[2];
+        const headerResArea = headers[0].children[1].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 100, 0);
         tick();
         fixture.detectChanges();
 
-        const resizer = headers[0].nativeElement.children[2].children[0];
+        const resizer = headers[0].children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 700, 5);
         tick();
@@ -577,7 +574,7 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         fixture.detectChanges();
 
         const grid = fixture.componentInstance.grid;
-        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
+        const headers: DebugElement[] = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
         const expectedHeight = fixture.debugElement.query(By.css('igx-grid')).nativeElement.getBoundingClientRect().height -
             grid.nativeElement.querySelector('.igx-grid__thead').getBoundingClientRect().height -
             grid.nativeElement.querySelector('.igx-grid__tfoot').getBoundingClientRect().height;
@@ -586,12 +583,12 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         expect(grid.columns[0].width).toEqual('100px');
 
         // Resize first column
-        const headerResArea = headers[0].nativeElement.children[2];
+        const headerResArea = headers[0].children[1].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 100, 0);
         tick();
         fixture.detectChanges();
 
-        const resizer = headers[0].nativeElement.children[2].children[0];
+        const resizer = headers[0].children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 250, 5);
         tick();
@@ -751,7 +748,7 @@ export class PinnedColumnsComponent {
             [formatter]="returnVal"></igx-column>
         <igx-column [field]="'Items'" [pinned]="true" width="100px" dataType="string" [resizable]="true"></igx-column>
         <igx-column [field]="'ID'" [width]="'100px'" [header]="'ID'" [resizable]="true"></igx-column>
-        <igx-column [field]="'ProductName'" width="25px" [maxWidth]="'100px'" dataType="string" [resizable]="true"></igx-column>
+        <igx-column [field]="'ProductName'" width="50px" [maxWidth]="'100px'" dataType="string" [resizable]="true"></igx-column>
         <igx-column [field]="'Test'" width="100px" dataType="string" [resizable]="true">
             <ng-template igxCell>
                 <div></div>

--- a/projects/igniteui-angular/src/lib/grids/grid/column.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/column.spec.ts
@@ -13,6 +13,7 @@ describe('IgxGrid - Column properties', () => {
     configureTestSuite();
 
     const COLUMN_HEADER_CLASS = '.igx-grid__th';
+    const COLUMN_HEADER_GROUP_CLASS = '.igx-grid__thead-item';
 
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -170,10 +171,11 @@ describe('IgxGrid - Column properties', () => {
         fix.componentInstance.grid.columnWidth = '200px';
         fix.detectChanges();
         const cols = fix.componentInstance.grid.columnList;
+
         cols.forEach((item) => {
             expect(item.width).toEqual('200px');
         });
-        const headers = fix.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
+        const headers = fix.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
         expect(headers[0].nativeElement.style['min-width']).toEqual('200px');
     });
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-filtering-ui.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-filtering-ui.spec.ts
@@ -1621,7 +1621,7 @@ describe('IgxGrid - Filtering Row UI actions', () => {
             const grid = fix.componentInstance.grid;
             grid.width = '1500px';
             fix.detectChanges();
-            
+
             const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
             const filteringChips = fix.debugElement.queryAll(By.css('.igx-filtering-chips'));
             expect(filteringCells.length).toBe(6);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-filtering-ui.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-filtering-ui.spec.ts
@@ -1,7 +1,7 @@
 import { Component, ViewChild, DebugElement } from '@angular/core';
-import { async, discardPeriodicTasks, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { async, discardPeriodicTasks, fakeAsync, TestBed, tick, flush } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { Calendar } from '../../calendar/calendar';
 import { IgxInputDirective } from '../../directives/input/input.directive';
 import { IgxGridComponent } from './grid.component';
@@ -23,6 +23,7 @@ import { IgxBadgeComponent } from '../../badge/badge.component';
 import { IgxCheckboxComponent } from '../../checkbox/checkbox.component';
 import { SortingDirection } from '../../data-operations/sorting-expression.interface';
 import { DefaultSortingStrategy } from '../../data-operations/sorting-strategy';
+import { IgxGridHeaderGroupComponent } from '../grid-header-group.component';
 
 const FILTER_UI_ROW = 'igx-grid-filtering-row';
 
@@ -34,7 +35,7 @@ describe('IgxGrid - Filtering actions', () => {
                 IgxGridFilteringComponent
             ],
             imports: [
-                BrowserAnimationsModule,
+                NoopAnimationsModule,
                 IgxGridModule.forRoot()]
         })
             .compileComponents();
@@ -65,8 +66,8 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
 
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         const ddItems = ddList.nativeElement.children;
@@ -76,9 +77,8 @@ describe('IgxGrid - Filtering actions', () => {
         verifyFilterUIPosition(filterUIRow, grid);
 
         ddItems[2].click();
-        // select.nativeElement.dispatchEvent(new Event('change'));
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(8);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -87,12 +87,12 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // ends with
         ddItems[3].click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(8);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -101,12 +101,12 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // does not contain
         ddItems[1].click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(8);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -115,12 +115,12 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // equals
         ddItems[0].click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(8);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -129,12 +129,12 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // does not equal
         ddItems[5].click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(8);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -143,12 +143,12 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // empty
         ddItems[6].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(4);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -159,12 +159,12 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // not empty
         ddItems[7].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(4);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -175,13 +175,13 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // iterate over unary conditions
         // null
         ddItems[8].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(3);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -192,12 +192,12 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // not null
         ddItems[9].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(5);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -206,13 +206,13 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // changing from unary to not unary condition when input is empty - filtering should keep its state
         // contains
         ddItems[0].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         input = filterUIRow.query(By.directive(IgxInputDirective));
         expect(grid.rowList.length).toEqual(5);
@@ -243,21 +243,17 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
 
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         const ddItems = ddList.nativeElement.children;
 
-        filterIcon.nativeElement.click();
-        fix.detectChanges();
-        tick(100);
-
         // iterate over not unary conditions and fill the input
         // contains
         sendInput(input, 'Ignite', fix);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(2);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -266,12 +262,12 @@ describe('IgxGrid - Filtering actions', () => {
 
         // starts with
         ddItems[2].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         sendInput(input, 'Net', fix);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         verifyFilterUIPosition(filterUIRow, grid);
         expect(grid.rowList.length).toEqual(1);
@@ -283,16 +279,16 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // ends with
         ddItems[3].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         sendInput(input, 'script', fix);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(2);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -301,12 +297,12 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // does not contain
         ddItems[1].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(6);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -315,8 +311,8 @@ describe('IgxGrid - Filtering actions', () => {
 
         // use reset button
         reset.nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(8);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -325,16 +321,16 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // equals
         ddItems[4].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         sendInput(input, 'NetAdvantage', fix);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(1);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -343,16 +339,16 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // equals
         ddItems[4].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         sendInput(input, ' ', fix);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(0);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -363,16 +359,16 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // does not equal
         ddItems[5].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         sendInput(input, 'NetAdvantage', fix);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(7);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -402,8 +398,8 @@ describe('IgxGrid - Filtering actions', () => {
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeTruthy();
 
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
 
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         const ddItems = ddList.nativeElement.children;
@@ -413,8 +409,8 @@ describe('IgxGrid - Filtering actions', () => {
         // iterate over not unary conditions and fill the input
         // equals
         sendInput(input, 0, fix);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(1);
         expect(grid.getCellByColumn(0, 'Downloads').value).toEqual(0);
@@ -425,24 +421,32 @@ describe('IgxGrid - Filtering actions', () => {
 
         // clear input value
         GridFunctions.removeFilterChipByIndex(0, filterUIRow);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         // iterate over not unary conditions when input is empty
+        // open dropdown
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // does not equal
         ddItems[1].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(8);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeTruthy();
         expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
+        // open dropdown
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // greater than
         ddItems[2].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(8);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -450,40 +454,56 @@ describe('IgxGrid - Filtering actions', () => {
         expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
         // iterate over unary conditions
-        // null
-        ddItems[6].click();
-        fix.detectChanges();
+        // open dropdown
+        filterIcon.nativeElement.click();
         tick();
+        fix.detectChanges();
+        // empty
+        ddItems[6].click();
+        tick(100);
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(1);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
-        // not null
-        ddItems[7].click();
-        fix.detectChanges();
+        // open dropdown
+        filterIcon.nativeElement.click();
         tick();
+        fix.detectChanges();
+        // not empty
+        ddItems[7].click();
+        tick(100);
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(7);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
-        // empty
-        ddItems[8].click();
-        fix.detectChanges();
+        // open dropdown
+        filterIcon.nativeElement.click();
         tick();
+        fix.detectChanges();
+        // null
+        ddItems[8].click();
+        tick(100);
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(1);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
-        // not empty
-        ddItems[9].click();
-        fix.detectChanges();
+        // open dropdown
+        filterIcon.nativeElement.click();
         tick();
+        fix.detectChanges();
+        // not null
+        ddItems[9].click();
+        tick(100);
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(7);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -491,10 +511,14 @@ describe('IgxGrid - Filtering actions', () => {
         expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
         // changing from unary to not unary condition when input is empty - filtering should keep its state
+        // open dropdown
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // equals - filter should keep its state and not be reset
         ddItems[0].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         input = filterUIRow.query(By.directive(IgxInputDirective));
         expect(grid.rowList.length).toEqual(7);
@@ -506,8 +530,8 @@ describe('IgxGrid - Filtering actions', () => {
         // iterate over not unary conditions and fill the input
         // equals
         sendInput(input, 100, fix);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         clear = filterUIRow.query(By.css('igx-suffix'));
         expect(grid.rowList.length).toEqual(1);
@@ -517,24 +541,32 @@ describe('IgxGrid - Filtering actions', () => {
         expect(clear.nativeElement.offsetHeight).toBeGreaterThan(0);
         expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
+        // open dropdown
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // does not equal
         ddItems[1].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(7);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
+        // open dropdown
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // greater than
         ddItems[2].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         sendInput(input, 300, fix);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(2);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -543,8 +575,8 @@ describe('IgxGrid - Filtering actions', () => {
 
         // use reset button
         reset.nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(8);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -554,16 +586,16 @@ describe('IgxGrid - Filtering actions', () => {
 
         // open dropdown
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
         // less than
         ddItems[3].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         sendInput(input, 100, fix);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(3);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -573,8 +605,8 @@ describe('IgxGrid - Filtering actions', () => {
 
         GridFunctions.removeFilterChipByIndex(0, filterUIRow);
         clear.nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(8);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -583,24 +615,32 @@ describe('IgxGrid - Filtering actions', () => {
         // revert to the default after
         expect(filterIcon.componentInstance.iconName).toMatch('equals');
 
+        // open dropdown
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // greater than or equal to
         ddItems[4].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         sendInput(input, 254, fix);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(3);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(input.nativeElement.offsetHeight).toBeGreaterThan(0);
 
+        // open dropdown
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // less than or equal to
         ddItems[5].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(6);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
@@ -626,8 +666,8 @@ describe('IgxGrid - Filtering actions', () => {
         expect(grid.rowList.length).toEqual(8);
 
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
 
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         const ddItems = ddList.nativeElement.children;
@@ -636,8 +676,8 @@ describe('IgxGrid - Filtering actions', () => {
 
         // false condition
         ddItems[2].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(2);
         expect(grid.getCellByColumn(0, 'Released').value).toBeFalsy();
@@ -645,10 +685,13 @@ describe('IgxGrid - Filtering actions', () => {
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
 
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // true condition
         ddItems[1].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(3);
         expect(grid.getCellByColumn(0, 'Released').value).toBe(true);
@@ -657,19 +700,25 @@ describe('IgxGrid - Filtering actions', () => {
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
 
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // (all) condition
         ddItems[0].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(8);
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
 
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // empty condition
         ddItems[3].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(3);
         expect(grid.getCellByColumn(0, 'Released').value).toEqual(null);
@@ -678,10 +727,13 @@ describe('IgxGrid - Filtering actions', () => {
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
 
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // not empty condition
         ddItems[4].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(5);
         expect(grid.getCellByColumn(0, 'Released').value).toBe(false);
@@ -692,10 +744,13 @@ describe('IgxGrid - Filtering actions', () => {
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
 
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // null condition
         ddItems[5].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(2);
         expect(grid.getCellByColumn(0, 'Released').value).toEqual(null);
@@ -703,10 +758,13 @@ describe('IgxGrid - Filtering actions', () => {
         expect(close.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
         expect(reset.nativeElement.classList.contains('igx-button--disabled')).toBeFalsy();
 
+        filterIcon.nativeElement.click();
+        tick();
+        fix.detectChanges();
         // not null condition
         ddItems[6].click();
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(6);
         expect(grid.getCellByColumn(0, 'Released').value).toBe(false);
@@ -720,61 +778,66 @@ describe('IgxGrid - Filtering actions', () => {
     }));
 
     // UI tests date column
-    it('UI - should correctly filter date column by \'today\' filtering conditions', () => {
+    it('UI - should correctly filter date column by \'today\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
 
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
-        fix.detectChanges();
         verifyFilterUIPosition(filterUIRow, grid);
 
         GridFunctions.selectFilteringCondition('Today', ddList);
+        tick(100);
         fix.detectChanges();
 
         // only one record is populated with 'today' date, this is why rows must be 1
         expect(grid.rowList.length).toEqual(1);
-    });
+    }));
 
-    it('UI - should correctly filter date column by \'yesterday\' filtering conditions', () => {
+    it('UI - should correctly filter date column by \'yesterday\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
 
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
-        fix.detectChanges();
         verifyFilterUIPosition(filterUIRow, grid);
 
         GridFunctions.selectFilteringCondition('Yesterday', ddList);
+        tick(100);
         fix.detectChanges();
 
         // only one record is populated with (today - 1 day)  date, this is why rows must be 1
         expect(grid.rowList.length).toEqual(1);
-    });
+    }));
 
-    it('UI - should correctly filter date column by \'this month\' filtering conditions', () => {
+    it('UI - should correctly filter date column by \'this month\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
@@ -784,25 +847,26 @@ describe('IgxGrid - Filtering actions', () => {
         // Fill expected results based on the current date
         fillExpectedResults(grid, cal, today);
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         verifyFilterUIPosition(filterIcon, grid);
         GridFunctions.selectFilteringCondition('This Month', ddList);
+        tick(100);
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(expectedResults[5]);
-    });
+    }));
 
-    it('UI - should correctly filter date column by \'next month\' filtering conditions', () => {
+    it('UI - should correctly filter date column by \'next month\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
@@ -812,26 +876,27 @@ describe('IgxGrid - Filtering actions', () => {
         // Fill expected results based on the current date
         fillExpectedResults(grid, cal, today);
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
         verifyFilterUIPosition(filterIcon, grid);
+
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         GridFunctions.selectFilteringCondition('Next Month', ddList);
-
+        tick(100);
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(expectedResults[1]);
-    });
+    }));
 
-    it('UI - should correctly filter date column by \'last month\' filtering conditions', () => {
+    it('UI - should correctly filter date column by \'last month\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
@@ -841,118 +906,126 @@ describe('IgxGrid - Filtering actions', () => {
         // Fill expected results based on the current date
         fillExpectedResults(grid, cal, today);
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
         verifyFilterUIPosition(filterIcon, grid);
+
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         GridFunctions.selectFilteringCondition('Last Month', ddList);
-
+        tick(100);
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(expectedResults[0]);
-    });
+    }));
 
-    it('UI - should correctly filter date column by \'empty\' filtering conditions', () => {
+    it('UI - should correctly filter date column by \'empty\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
         verifyFilterUIPosition(filterIcon, grid);
+
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         GridFunctions.selectFilteringCondition('Empty', ddList);
+        tick(100);
         fix.detectChanges();
-
         expect(grid.rowList.length).toEqual(2);
-    });
+    }));
 
-    it('UI - should correctly filter date column by \'notEmpty\' filtering conditions', () => {
+    it('UI - should correctly filter date column by \'notEmpty\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
         verifyFilterUIPosition(filterIcon, grid);
+
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         GridFunctions.selectFilteringCondition('Not Empty', ddList);
+        tick(100);
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(6);
-    });
+    }));
 
-    it('UI - should correctly filter date column by \'null\' filtering conditions', () => {
+    it('UI - should correctly filter date column by \'null\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
         verifyFilterUIPosition(filterIcon, grid);
+
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         GridFunctions.selectFilteringCondition('Null', ddList);
+        tick(100);
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(1);
-    });
+    }));
 
-    it('UI - should correctly filter date column by \'notNull\' filtering conditions', () => {
+    it('UI - should correctly filter date column by \'notNull\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
         verifyFilterUIPosition(filterIcon, grid);
+
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         GridFunctions.selectFilteringCondition('Not Null', ddList);
+        tick(100);
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(7);
-    });
+    }));
 
-    it('UI - should correctly filter date column by \'thisYear\' filtering conditions', () => {
+    it('UI - should correctly filter date column by \'thisYear\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
@@ -962,25 +1035,26 @@ describe('IgxGrid - Filtering actions', () => {
         // Fill expected results based on the current date
         fillExpectedResults(grid, cal, today);
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
         fix.detectChanges();
         verifyFilterUIPosition(filterIcon, grid);
+
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         GridFunctions.selectFilteringCondition('This Year', ddList);
+        tick(100);
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(expectedResults[2]);
-    });
+    }));
 
-    it('UI - should correctly filter date column by \'lastYear\' filtering conditions', () => {
+    it('UI - should correctly filter date column by \'lastYear\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
@@ -990,25 +1064,27 @@ describe('IgxGrid - Filtering actions', () => {
         // Fill expected results based on the current date
         fillExpectedResults(grid, cal, today);
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
         verifyFilterUIPosition(filterIcon, grid);
+
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         GridFunctions.selectFilteringCondition('Last Year', ddList);
+        tick(100);
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(expectedResults[4]);
-    });
+    }));
 
-    it('UI - should correctly filter date column by \'nextYear\' filtering conditions', () => {
+    it('UI - should correctly filter date column by \'nextYear\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
@@ -1018,17 +1094,18 @@ describe('IgxGrid - Filtering actions', () => {
         // Fill expected results based on the current date
         fillExpectedResults(grid, cal, today);
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
         verifyFilterUIPosition(filterIcon, grid);
+
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         GridFunctions.selectFilteringCondition('Next Year', ddList);
+        tick(100);
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(expectedResults[3]);
-    });
+    }));
 
     it('UI - should correctly filter date column by \'equals\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
@@ -1038,32 +1115,31 @@ describe('IgxGrid - Filtering actions', () => {
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
         fix.detectChanges();
+
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
         const input = filterUIRow.query(By.directive(IgxInputDirective));
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
         fix.detectChanges();
-        tick(100);
 
         verifyFilterUIPosition(filterIcon, grid);
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         GridFunctions.selectFilteringCondition('Equals', ddList);
+
         input.nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         const calendar = fix.debugElement.query(By.css('igx-calendar'));
         const currentDay = calendar.query(By.css('span.igx-calendar__date--current'));
         currentDay.nativeElement.click();
+        flush();
         fix.detectChanges();
-        tick();
 
         input.nativeElement.dispatchEvent(new Event('change'));
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(1);
     }));
@@ -1076,37 +1152,37 @@ describe('IgxGrid - Filtering actions', () => {
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
         fix.detectChanges();
+
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
         const input = filterUIRow.query(By.directive(IgxInputDirective));
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
-        tick(100);
+        tick();
+        fix.detectChanges();
 
         verifyFilterUIPosition(filterIcon, grid);
-        fix.detectChanges();
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         GridFunctions.selectFilteringCondition('Does Not Equal', ddList);
+
         input.nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         const calendar = fix.debugElement.query(By.css('igx-calendar'));
         const currentDay = calendar.query(By.css('span.igx-calendar__date--current'));
         currentDay.nativeElement.click();
+        flush();
         fix.detectChanges();
-        tick();
 
         input.nativeElement.dispatchEvent(new Event('change'));
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(7);
     }));
 
-    it('UI - should correctly filter date column by \'after\' filtering conditions', fakeAsync(() => {
+    it('UI - should correctly filter date column by \'after\' filtering conditions', async() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
 
@@ -1114,35 +1190,44 @@ describe('IgxGrid - Filtering actions', () => {
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
         fix.detectChanges();
+
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
         const input = filterUIRow.query(By.directive(IgxInputDirective));
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
         fix.detectChanges();
-        tick(100);
+        await wait();
 
         verifyFilterUIPosition(filterIcon, grid);
+
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
-        GridFunctions.selectFilteringCondition('After', ddList);
+        const ddItems = ddList.nativeElement.children;
+        let i;
+        for (i = 0; i < ddItems.length; i++) {
+            if (ddItems[i].textContent === 'After') {
+                ddItems[i].click();
+                await wait(100);
+                return;
+            }
+        }
+
         input.nativeElement.click();
         fix.detectChanges();
-        tick();
+        await wait(100);
 
         const calendar = fix.debugElement.query(By.css('igx-calendar'));
         const currentDay = calendar.query(By.css('span.igx-calendar__date--current'));
         currentDay.nativeElement.click();
         fix.detectChanges();
-        tick();
+        await wait();
 
         input.nativeElement.dispatchEvent(new Event('change'));
         fix.detectChanges();
-        tick();
+        await wait();
 
         expect(grid.rowList.length).toEqual(3);
-    }));
+    });
 
     it('UI - should correctly filter date column by \'before\' filtering conditions', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
@@ -1152,32 +1237,32 @@ describe('IgxGrid - Filtering actions', () => {
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
         fix.detectChanges();
+
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
         const input = filterUIRow.query(By.directive(IgxInputDirective));
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
 
         verifyFilterUIPosition(filterIcon, grid);
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         GridFunctions.selectFilteringCondition('Before', ddList);
+
         input.nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         const calendar = fix.debugElement.query(By.css('igx-calendar'));
         const currentDay = calendar.query(By.css('span.igx-calendar__date--current'));
         currentDay.nativeElement.click();
+        flush();
         fix.detectChanges();
-        tick();
 
         input.nativeElement.dispatchEvent(new Event('change'));
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(2);
     }));
@@ -1187,31 +1272,30 @@ describe('IgxGrid - Filtering actions', () => {
         fix.detectChanges();
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
         const input = filterUIRow.query(By.directive(IgxInputDirective));
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
 
         input.nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         let calendar = fix.debugElement.query(By.css('igx-calendar'));
         const monthView = calendar.queryAll(By.css('.igx-calendar-picker__date'))[0];
         monthView.nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         const firstMonth = calendar.queryAll(By.css('.igx-calendar__month'))[0];
         firstMonth.nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         calendar = fix.debugElement.query(By.css('igx-calendar'));
         const month = calendar.queryAll(By.css('.igx-calendar-picker__date'))[0];
@@ -1224,31 +1308,30 @@ describe('IgxGrid - Filtering actions', () => {
         fix.detectChanges();
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[4].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
         const input = filterUIRow.query(By.directive(IgxInputDirective));
 
-        filterIcon.triggerEventHandler('mousedown', null);
-        fix.detectChanges();
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
 
         input.nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         let calendar = fix.debugElement.query(By.css('igx-calendar'));
         const monthView = calendar.queryAll(By.css('.igx-calendar-picker__date'))[1];
         monthView.nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         const firstMonth = calendar.queryAll(By.css('.igx-calendar__year'))[0];
         firstMonth.nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         calendar = fix.debugElement.query(By.css('igx-calendar'));
         const month = calendar.queryAll(By.css('.igx-calendar-picker__date'))[1];
@@ -1267,6 +1350,7 @@ describe('IgxGrid - Filtering actions', () => {
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[5].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
@@ -1278,18 +1362,18 @@ describe('IgxGrid - Filtering actions', () => {
         expect(grid.rowList.length).toEqual(8);
 
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
 
         sendInput(input, 'a', fix);
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         // false condition
         GridFunctions.selectFilteringCondition('False', ddList);
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(1);
         expect(grid.getCellByColumn(0, 'AnotherField').value).toMatch('custom');
@@ -1306,6 +1390,7 @@ describe('IgxGrid - Filtering actions', () => {
         const columnName = 'ProductName';
 
         grid.filter(columnName, filterVal, IgxStringFilteringOperand.instance().condition('contains'));
+        tick(100);
         fix.detectChanges();
 
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
@@ -1314,15 +1399,17 @@ describe('IgxGrid - Filtering actions', () => {
         spyOn(grid.onFilteringDone, 'emit');
 
         idCellChips[0].nativeElement.click();
+        tick();
         fix.detectChanges();
+
         const filterUiRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const reset = filterUiRow.queryAll(By.css('button'))[0];
         const input = filterUiRow.query(By.directive(IgxInputDirective));
         sendInput(input, filterVal, fix);
 
         reset.nativeElement.dispatchEvent(new MouseEvent('click'));
-        fix.detectChanges();
         tick(100);
+        fix.detectChanges();
 
         expect(grid.onFilteringDone.emit).toHaveBeenCalledWith(null);
     }));
@@ -1332,12 +1419,13 @@ describe('IgxGrid - Filtering actions', () => {
         fix.detectChanges();
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[1].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
 
         UIInteractions.clickElement(filterIcon);
-        tick(50);
+        tick();
         fix.detectChanges();
 
         // apply two filters for And/Or button
@@ -1346,7 +1434,7 @@ describe('IgxGrid - Filtering actions', () => {
 
         const andButton = fix.debugElement.queryAll(By.css('#operand'));
 
-        tick(50);
+        tick(100);
         fix.detectChanges();
 
         expect(andButton.length).toEqual(1);
@@ -1361,6 +1449,7 @@ describe('IgxGrid - Filtering actions', () => {
         const grid = fix.componentInstance.grid;
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[1].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const filterIcon = filterUIRow.query(By.css('igx-icon'));
@@ -1368,21 +1457,18 @@ describe('IgxGrid - Filtering actions', () => {
         expect(grid.rowList.length).toEqual(8);
 
         filterIcon.nativeElement.click();
+        tick();
         fix.detectChanges();
-        tick(100);
 
         verifyFilterUIPosition(filterUIRow, grid);
 
         GridFunctions.filterBy('Contains', 'I', fix);
+        tick(100);
         fix.detectChanges();
-        tick();
-
-        fix.detectChanges();
-        tick();
 
         GridFunctions.filterBy('Contains', 'g', fix);
+        tick(100);
         fix.detectChanges();
-        tick();
 
         expect(grid.rowList.length).toEqual(2);
         let andButton = fix.debugElement.queryAll(By.css('#operand'));
@@ -1391,8 +1477,8 @@ describe('IgxGrid - Filtering actions', () => {
         // remove the second chip
         const secondChip = filterUIRow.queryAll(By.css('igx-chip'))[1];
         secondChip.query(By.css('div.igx-chip__remove')).nativeElement.click();
-        fix.detectChanges();
         tick();
+        fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(3);
         andButton = fix.debugElement.queryAll(By.css('#operand'));
@@ -1407,10 +1493,12 @@ describe('IgxGrid - Filtering actions', () => {
         const columnName = 'ProductName';
         const filterValue = 'search';
         grid.filter(columnName, filterValue, IgxStringFilteringOperand.instance().condition('contains'));
+        tick(100);
         fix.detectChanges();
 
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[1].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const input = filterUIRow.query(By.directive(IgxInputDirective));
@@ -1423,8 +1511,8 @@ describe('IgxGrid - Filtering actions', () => {
 
         clearSuffix.nativeElement.dispatchEvent(new MouseEvent('click'));
         GridFunctions.simulateKeyboardEvent(input, 'keydown', 'Enter');
-        fix.detectChanges();
         tick(100);
+        fix.detectChanges();
 
         const columnFilteringExpressionsTree = grid.filteringExpressionsTree.find(columnName);
         expect(grid.onFilteringDone.emit).toHaveBeenCalledWith(columnFilteringExpressionsTree);
@@ -1439,6 +1527,7 @@ describe('IgxGrid - Filtering actions', () => {
         const headerOfTypeNumber = gridheaders.find(gh => gh.nativeElement.classList.contains('igx-grid__th--number'));
         const filterCellsForTypeNumber = headerOfTypeNumber.parent.query(By.css('igx-grid-filtering-cell'));
         filterCellsForTypeNumber.query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
 
         const filterUiRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
@@ -1446,21 +1535,19 @@ describe('IgxGrid - Filtering actions', () => {
         const input = filterUiRow.query(By.directive(IgxInputDirective));
 
         filterIcon.nativeElement.click();
-        fix.detectChanges();
         tick();
         fix.detectChanges();
 
         sendInput(input, 0, fix);
-        fix.detectChanges();
         tick();
         fix.detectChanges();
 
         grid.nativeElement.click();
-        fix.detectChanges();
         tick();
         fix.detectChanges();
 
         filterUiRow.queryAll(By.css('button'))[1].nativeElement.click();
+        tick();
         fix.detectChanges();
         expect(filterCellsForTypeNumber.queryAll(By.css('.igx-filtering-chips')).length).toBe(1);
     }));
@@ -1481,20 +1568,23 @@ describe('IgxGrid - Filtering actions', () => {
         filteringExpressionsTree.filteringOperands.push(expression);
         grid.filteringExpressionsTree = filteringExpressionsTree;
 
+        tick(100);
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(2);
 
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         filteringCells[1].query(By.css('igx-chip')).nativeElement.click();
+        tick();
         fix.detectChanges();
+
         const filterUIContainer = fix.debugElement.queryAll(By.css(FILTER_UI_ROW))[0];
         const filterIcon = filterUIContainer.query(By.css('igx-icon'));
         const input = filterUIContainer.query(By.directive(IgxInputDirective));
 
         filterIcon.nativeElement.click();
-        fix.detectChanges();
         tick(100);
+        fix.detectChanges();
 
         verifyFilterUIPosition(filterUIContainer, grid);
 
@@ -1514,26 +1604,24 @@ describe('IgxGrid - Filtering Row UI actions', () => {
                 IgxGridFilteringMCHComponent
             ],
             imports: [
-                BrowserAnimationsModule,
+                NoopAnimationsModule,
                 IgxGridModule.forRoot()]
-        })
-            .compileComponents();
+        }).compileComponents();
     }));
 
     afterEach(() => {
         UIInteractions.clearOverlay();
     });
 
-    // TODO - add new tests based on the test plan in the spec.
-
     it('should render Filter chip for filterable columns and render empty cell for a column when filterable is set to false',
         fakeAsync(() => {
             const fix = TestBed.createComponent(IgxGridFilteringComponent);
             fix.detectChanges();
-            tick(100);
+
             const grid = fix.componentInstance.grid;
             grid.width = '1500px';
             fix.detectChanges();
+            
             const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
             const filteringChips = fix.debugElement.queryAll(By.css('.igx-filtering-chips'));
             expect(filteringCells.length).toBe(6);
@@ -1562,7 +1650,6 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         // open for string
         stringCellChip.nativeElement.click();
         fix.detectChanges();
-        tick(200);
 
         checkUIForType('string', fix.debugElement);
 
@@ -1570,40 +1657,44 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         let filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         let close = filterUIRow.queryAll(By.css('button'))[1];
         close.nativeElement.click();
+        tick(100);
         fix.detectChanges();
-        tick(200);
 
         // open for number
         numberCellChip.nativeElement.click();
         fix.detectChanges();
-        tick(200);
         checkUIForType('number', fix.debugElement);
 
         // close
         filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         close = filterUIRow.queryAll(By.css('button'))[1];
         close.nativeElement.click();
+        tick(100);
         fix.detectChanges();
-        tick(200);
 
         // open for date
         dateCellChip.nativeElement.click();
         fix.detectChanges();
-        tick(200);
         checkUIForType('date', fix.debugElement);
 
         // close
         filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         close = filterUIRow.queryAll(By.css('button'))[1];
         close.nativeElement.click();
+        tick(100);
         fix.detectChanges();
-        tick(200);
 
         // open for bool
         boolCellChip.nativeElement.click();
         fix.detectChanges();
-        tick(200);
         checkUIForType('bool', fix.debugElement);
+
+        // close
+        filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
+        close = filterUIRow.queryAll(By.css('button'))[1];
+        close.nativeElement.click();
+        tick(100);
+        fix.detectChanges();
     }));
 
     it('should apply  multiple conditions to grid immediately while the filter row is still open', fakeAsync(() => {
@@ -1616,9 +1707,9 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         const boolCellChip = filteringCells[3].query(By.css('igx-chip'));
         const dateCellChip = filteringCells[4].query(By.css('igx-chip'));
         const grid = fix.componentInstance.grid;
+
         // open for string
         stringCellChip.nativeElement.click();
-        tick();
         fix.detectChanges();
 
         GridFunctions.filterBy('Starts With', 'I', fix);
@@ -1632,7 +1723,6 @@ describe('IgxGrid - Filtering Row UI actions', () => {
 
         // open for number
         numberCellChip.nativeElement.click();
-        tick();
         fix.detectChanges();
 
         GridFunctions.filterBy('Less Than', '100', fix);
@@ -1643,15 +1733,15 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         // Reset and Close
         GridFunctions.resetFilterRow(fix);
         GridFunctions.closeFilterRow(fix);
+
         // open for bool
         boolCellChip.nativeElement.click();
-        tick();
         fix.detectChanges();
 
         GridFunctions.filterBy('False', '', fix);
         expect(grid.rowList.length).toEqual(2);
         GridFunctions.filterBy('Empty', '', fix);
-        expect(grid.rowList.length).toEqual(0);
+        expect(grid.rowList.length).toEqual(3);
 
         // Reset and Close
         GridFunctions.resetFilterRow(fix);
@@ -1660,6 +1750,7 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         // open for date
         dateCellChip.nativeElement.click();
         fix.detectChanges();
+
         GridFunctions.filterBy('Today', '', fix);
         expect(grid.rowList.length).toEqual(1);
         GridFunctions.filterBy('Null', '', fix);
@@ -1679,7 +1770,6 @@ describe('IgxGrid - Filtering Row UI actions', () => {
 
         for (let i = 0; i < 10; i++) {
             GridFunctions.filterBy('Starts With', 'I', fix);
-            tick(200);
         }
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         const startArrow = filterUIRow.query(By.css('.igx-grid__filtering-row-scroll-start'));
@@ -1692,13 +1782,15 @@ describe('IgxGrid - Filtering Row UI actions', () => {
     it('should update UI when chip is removed from header cell.', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
+
         let filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         let stringCellChip = filteringCells[1].query(By.css('igx-chip'));
         const grid = fix.componentInstance.grid;
+
         // filter string col
         stringCellChip.nativeElement.click();
-        tick();
         fix.detectChanges();
+
         GridFunctions.filterBy('Starts With', 'I', fix);
         expect(grid.rowList.length).toEqual(2);
 
@@ -1710,7 +1802,6 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         // remove chip
         const removeButton = stringCellChip.query(By.css('div.igx-chip__remove'));
         removeButton.nativeElement.click();
-        tick();
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(8);
@@ -1719,56 +1810,62 @@ describe('IgxGrid - Filtering Row UI actions', () => {
     it('should update UI when chip is removed from filter row.', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         fix.detectChanges();
+
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         const stringCellChip = filteringCells[1].query(By.css('igx-chip'));
         const grid = fix.componentInstance.grid;
+
         // filter string col
         stringCellChip.nativeElement.click();
-        tick();
         fix.detectChanges();
+
         GridFunctions.filterBy('Starts With', 'I', fix);
         expect(grid.rowList.length).toEqual(2);
 
         // remove from row
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         GridFunctions.removeFilterChipByIndex(0, filterUIRow);
-        tick();
+        tick(100);
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(8);
     }));
 
     it('should not render chip in header if condition that requires value is applied and then value is cleared in filter row.',
-        fakeAsync(() => {
-            const fix = TestBed.createComponent(IgxGridFilteringComponent);
-            fix.detectChanges();
-            let filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
-            const stringCellChip = filteringCells[1].query(By.css('igx-chip'));
-            const grid = fix.componentInstance.grid;
-            // filter string col
-            stringCellChip.nativeElement.click();
-            tick();
-            fix.detectChanges();
-            GridFunctions.filterBy('Starts With', 'I', fix);
-            // remote text from input
-            const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
-            const input = filterUIRow.query(By.directive(IgxInputDirective));
-            input.nativeElement.value = null;
-            const exprList = filterUIRow.componentInstance.expressionsList;
-            exprList[0].expression.searchVal = null;
-            tick();
-            fix.detectChanges();
-            GridFunctions.closeFilterRow(fix);
+    fakeAsync(() => {
+        const fix = TestBed.createComponent(IgxGridFilteringComponent);
+        fix.detectChanges();
 
-            // check no condition is applied
-            expect(grid.rowList.length).toEqual(8);
+        let filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
+        const stringCellChip = filteringCells[1].query(By.css('igx-chip'));
+        const grid = fix.componentInstance.grid;
 
-            filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
-            const stringCellText = filteringCells[1].query(By.css('igx-chip')).query(By.css('.igx-chip__content'));
-            expect(stringCellText.nativeElement.textContent).toBe('Filter');
-        }));
+        // filter string col
+        stringCellChip.nativeElement.click();
+        fix.detectChanges();
 
-    it('Should correctly update empty filter cells when scrolling horizontally.', async () => {
+        GridFunctions.filterBy('Starts With', 'I', fix);
+
+        // remove text from input
+        const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
+        const input = filterUIRow.query(By.directive(IgxInputDirective));
+        input.nativeElement.value = null;
+
+        const exprList = filterUIRow.componentInstance.expressionsList;
+        exprList[0].expression.searchVal = null;
+        fix.detectChanges();
+
+        GridFunctions.closeFilterRow(fix);
+
+        // check no condition is applied
+        expect(grid.rowList.length).toEqual(8);
+
+        filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
+        const stringCellText = filteringCells[1].query(By.css('igx-chip')).query(By.css('.igx-chip__content'));
+        expect(stringCellText.nativeElement.textContent).toBe('Filter');
+    }));
+
+    it('Should correctly update empty filter cells when scrolling horizontally.', async() => {
         const fix = TestBed.createComponent(IgxGridFilteringScrollComponent);
         const grid = fix.componentInstance.grid;
         fix.detectChanges();
@@ -1810,28 +1907,24 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         fix.detectChanges();
 
         checkUIForType('string', fix.debugElement);
-        tick(200);
 
         // Click on number column.
         numberHeader.nativeElement.click();
         fix.detectChanges();
 
         checkUIForType('number', fix.debugElement);
-        tick(200);
 
         // Click on boolean column
         boolHeader.nativeElement.click();
         fix.detectChanges();
 
         checkUIForType('bool', fix.debugElement);
-        tick(200);
 
         // Click on date column
         dateHeader.nativeElement.click();
         fix.detectChanges();
 
         checkUIForType('date', fix.debugElement);
-        tick(200);
     }));
 
     it('Should correctly render read-only input when selecting read-only condition and should create a chip.', fakeAsync(() => {
@@ -1918,7 +2011,6 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         expect(filterChip.componentInstance.selected).toBeTruthy();
 
         GridFunctions.filterBy('Starts With', 'S', fix);
-        tick(200);
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(1);
@@ -1977,6 +2069,7 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         grid.width = '1600px';
         grid.columnWidth = '400px';
         fix.detectChanges();
+
         const filteringExpressionsTree = new FilteringExpressionsTree(FilteringLogic.And, 'ProductName');
         const expression = {
             fieldName: 'ProductName',
@@ -1992,7 +2085,6 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         filteringExpressionsTree.filteringOperands.push(expression1);
         grid.filter('ProductName', null, filteringExpressionsTree);
         grid.filter('Released', true, IgxBooleanFilteringOperand.instance().condition('false'));
-        tick();
         fix.detectChanges();
 
         expect(grid.rowList.length).toEqual(0);
@@ -2023,14 +2115,16 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         fix.detectChanges();
 
         let filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
+
         const stringCellChip = filteringCells[1].query(By.css('igx-chip'));
         // filter string col
         stringCellChip.nativeElement.click();
-        tick();
         fix.detectChanges();
+
         GridFunctions.filterBy('Starts With', 'IgniteUI', fix);
         GridFunctions.filterBy('Contains', 'for', fix);
         GridFunctions.closeFilterRow(fix);
+
         // check 1 chip and view more icon is displayed.
         const chips = filteringCells[1].queryAll(By.css('igx-chip'));
         expect(chips.length).toEqual(1);
@@ -2056,7 +2150,6 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         ];
         gridFilteringExpressionsTree.filteringOperands.push(columnsFilteringTree);
         grid.filteringExpressionsTree = gridFilteringExpressionsTree;
-        tick();
         fix.detectChanges();
 
         const colChips = GridFunctions.getFilterChipsForColumn('ProductName', fix);
@@ -2084,9 +2177,9 @@ describe('IgxGrid - Filtering Row UI actions', () => {
 
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         const stringCellChip = filteringCells[1].query(By.css('igx-chip'));
+
         // filter string col
         stringCellChip.nativeElement.click();
-        tick();
         fix.detectChanges();
 
         const filteringRow = fix.debugElement.query(By.directive(IgxGridFilteringRowComponent));
@@ -2109,7 +2202,7 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         expect(cellElem.offsetParent.offsetHeight + cellElem.offsetHeight).toBeCloseTo(thead.clientHeight, 10);
 
         idCellChip.nativeElement.click();
-        tick();
+        // tick();
         fix.detectChanges();
 
         // check if it is positioned at the bottom of the thead.
@@ -2120,7 +2213,10 @@ describe('IgxGrid - Filtering Row UI actions', () => {
 
     it('should position filter row and chips correctly when grid has column groups and one is hidden.', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringMCHComponent);
+        fix.detectChanges();
+
         const grid = fix.componentInstance.grid;
+
         const filteringExpressionsTree = new FilteringExpressionsTree(FilteringLogic.And, 'ProductName');
         const expression = {
             fieldName: 'ProductName',
@@ -2129,7 +2225,6 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         };
         filteringExpressionsTree.filteringOperands.push(expression);
         grid.filteringExpressionsTree = filteringExpressionsTree;
-        tick();
         fix.detectChanges();
         let filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         expect(filteringCells.length).toEqual(6);
@@ -2137,12 +2232,12 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         const groupCol = grid.getColumnByName('General');
         groupCol.hidden = true;
         fix.detectChanges();
+
         filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         expect(filteringCells.length).toEqual(1);
 
         const chip = filteringCells[0].query(By.css('igx-chip'));
         chip.nativeElement.click();
-        tick();
         fix.detectChanges();
 
         // check if it is positioned at the bottom of the thead.
@@ -2154,7 +2249,6 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         GridFunctions.closeFilterRow(fix);
 
         groupCol.hidden = false;
-        tick();
         fix.detectChanges();
 
         filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
@@ -2167,14 +2261,17 @@ describe('IgxGrid - Filtering Row UI actions', () => {
     // Filtering + Moving
     it('should move chip under the correct column when column is moved and filter row should open for correct column.', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        const grid = fix.componentInstance.grid;
         fix.detectChanges();
+
+        const grid = fix.componentInstance.grid;
 
         let filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         let stringCellChip = filteringCells[1].query(By.css('igx-chip'));
+
         // filter string col
         stringCellChip.nativeElement.click();
         fix.detectChanges();
+
         GridFunctions.filterBy('Contains', 'Angular', fix);
         GridFunctions.closeFilterRow(fix);
 
@@ -2210,22 +2307,27 @@ describe('IgxGrid - Filtering Row UI actions', () => {
     // Filtering + Hiding
     it('should not display filter cell for hidden columns and chips should show under correct column.', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        const grid = fix.componentInstance.grid;
         fix.detectChanges();
+
+        const grid = fix.componentInstance.grid;
 
         let filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         let stringCellChip = filteringCells[1].query(By.css('igx-chip'));
+
         // filter string col
         stringCellChip.nativeElement.click();
         fix.detectChanges();
+
         GridFunctions.filterBy('Contains', 'Angular', fix);
         GridFunctions.closeFilterRow(fix);
+
         filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         expect(filteringCells.length).toEqual(6);
+
         // hide column
         grid.getColumnByName('ID').hidden = true;
-        tick();
         fix.detectChanges();
+
         filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         expect(filteringCells.length).toEqual(5);
         stringCellChip = filteringCells[0].query(By.css('igx-chip'));
@@ -2237,6 +2339,7 @@ describe('IgxGrid - Filtering Row UI actions', () => {
 
         grid.getColumnByName('ProductName').hidden = true;
         fix.detectChanges();
+
         filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         expect(filteringCells.length).toEqual(4);
 
@@ -2250,8 +2353,10 @@ describe('IgxGrid - Filtering Row UI actions', () => {
     // Filtering + Grouping
     it('should display the header expand/collapse icon for groupby above the filter row.', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        const grid = fix.componentInstance.grid;
         fix.detectChanges();
+
+        const grid = fix.componentInstance.grid;
+
         grid.getColumnByName('ProductName').groupable = true;
         grid.groupBy({
             fieldName: 'ProductName',
@@ -2263,6 +2368,7 @@ describe('IgxGrid - Filtering Row UI actions', () => {
 
         const filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         const stringCellChip = filteringCells[1].query(By.css('igx-chip'));
+
         // filter string col
         stringCellChip.nativeElement.click();
         fix.detectChanges();
@@ -2277,15 +2383,20 @@ describe('IgxGrid - Filtering Row UI actions', () => {
     // Filtering + Pinning
     it('should position chips correctly after pinning column.', fakeAsync(() => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
-        const grid = fix.componentInstance.grid;
         fix.detectChanges();
+
+        const grid = fix.componentInstance.grid;
+
         let filteringCells = fix.debugElement.queryAll(By.css('igx-grid-filtering-cell'));
         let stringCellChip = filteringCells[1].query(By.css('igx-chip'));
+
         // filter string col
         stringCellChip.nativeElement.click();
         fix.detectChanges();
+
         GridFunctions.filterBy('Contains', 'Angular', fix);
         GridFunctions.closeFilterRow(fix);
+
         grid.getColumnByName('ProductName').pinned = true;
         fix.detectChanges();
 
@@ -2301,6 +2412,7 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         const fix = TestBed.createComponent(IgxGridFilteringComponent);
         const grid = fix.componentInstance.grid;
         grid.columnWidth = '250px';
+        fix.detectChanges();
 
         // Add initial filtering conditions
         const gridFilteringExpressionsTree = new FilteringExpressionsTree(FilteringLogic.And);
@@ -2311,11 +2423,6 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         ];
         gridFilteringExpressionsTree.filteringOperands.push(columnsFilteringTree);
         grid.filteringExpressionsTree = gridFilteringExpressionsTree;
-        tick();
-        fix.detectChanges();
-
-        // Enable resizing
-        grid.columns.forEach(col => col.resizable = true);
         fix.detectChanges();
 
         let colChips = GridFunctions.getFilterChipsForColumn('ProductName', fix);
@@ -2326,14 +2433,18 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         expect(colOperands.length).toEqual(1);
         expect(colIndicator.length).toEqual(0);
 
+        // Enable resizing
+        fix.componentInstance.resizable = true;
+        fix.detectChanges();
+
         // Make 'ProductName' column smaller
-        const headers: DebugElement[] = fix.debugElement.queryAll(By.directive(IgxGridHeaderComponent));
-        const headerResArea = headers[1].nativeElement.children[2];
+        const headers: DebugElement[] = fix.debugElement.queryAll(By.directive(IgxGridHeaderGroupComponent));
+        const headerResArea = headers[1].children[2].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 200, 0);
         tick();
         fix.detectChanges();
 
-        const resizer = headers[1].nativeElement.children[2].children[0];
+        const resizer = headers[1].children[2].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 100, 5);
         tick();
@@ -2372,8 +2483,8 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         stringCellChip.click();
         fix.detectChanges();
 
-        const headers: DebugElement[] = fix.debugElement.queryAll(By.directive(IgxGridHeaderComponent));
-        const headerResArea = headers[1].nativeElement.children[2];
+        const headers: DebugElement[] = fix.debugElement.queryAll(By.directive(IgxGridHeaderGroupComponent));
+        const headerResArea = headers[1].children[2].nativeElement;
         let filteringRow = fix.debugElement.query(By.directive(IgxGridFilteringRowComponent));
 
         expect(filteringRow).toBeTruthy();
@@ -2383,7 +2494,7 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         tick();
         fix.detectChanges();
 
-        const resizer = headers[1].nativeElement.children[2].children[0];
+        const resizer = headers[1].children[2].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 100, 5);
         tick();
@@ -2432,13 +2543,13 @@ describe('IgxGrid - Filtering Row UI actions', () => {
         expect(indicatorBadge.nativeElement.innerText.trim()).toEqual('2');
 
         // Make 'Downloads' column bigger
-        const headers: DebugElement[] = fix.debugElement.queryAll(By.directive(IgxGridHeaderComponent));
-        const headerResArea = headers[2].nativeElement.children[2];
+        const headers: DebugElement[] = fix.debugElement.queryAll(By.directive(IgxGridHeaderGroupComponent));
+        const headerResArea = headers[2].children[2].nativeElement;
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 100, 0);
         tick();
         fix.detectChanges();
 
-        const resizer = headers[2].nativeElement.children[2].children[0];
+        const resizer = headers[2].children[2].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 300, 5);
         tick();
@@ -2502,15 +2613,15 @@ export class CustomFilter extends IgxFilteringOperand {
 
 @Component({
     template: `<igx-grid [data]="data" height="500px" [allowFiltering]="true">
-        <igx-column [field]="'ID'" [header]="'ID'" [filterable]="false"></igx-column>
-        <igx-column [field]="'ProductName'" dataType="string"></igx-column>
-        <igx-column [field]="'Downloads'" dataType="number"></igx-column>
-        <igx-column [field]="'Released'" dataType="boolean"></igx-column>
+        <igx-column [field]="'ID'" [header]="'ID'" [filterable]="false" [resizable]="resizable"></igx-column>
+        <igx-column [field]="'ProductName'" dataType="string" [resizable]="resizable"></igx-column>
+        <igx-column [field]="'Downloads'" dataType="number" [resizable]="resizable"></igx-column>
+        <igx-column [field]="'Released'" dataType="boolean" [resizable]="resizable"></igx-column>
         <igx-column [field]="'ReleaseDate'" [header]="'ReleaseDate'" headerClasses="header-release-date"
-            dataType="date">
+            dataType="date" [resizable]="resizable">
         </igx-column>
         <igx-column [field]="'AnotherField'" [header]="'Anogther Field'"
-            dataType="string" [filters]="customFilter">
+            dataType="string" [filters]="customFilter" [resizable]="resizable">
         </igx-column>
     </igx-grid>`
 })
@@ -2519,6 +2630,7 @@ export class IgxGridFilteringComponent {
     public timeGenerator: Calendar = new Calendar();
     public today: Date = new Date(new Date().getFullYear(), new Date().getMonth(), new Date().getDate(), 0, 0, 0);
     public customFilter = CustomFilter;
+    public resizable = false;
 
     public data = [
         {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.html
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.html
@@ -40,7 +40,7 @@
 
 <div class="igx-grid__thead" role="rowgroup" [style.width.px]='calcWidth' #theadRow>
     <div class="igx-grid__tr" [style.width.px]='calcWidth' role="row">
-        <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length <= 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-left"></span>
+        <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length <= 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-left" [style.left.px]="headerCheckboxWidth"></span>
         <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length > 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-pinned" [style.left.px]="pinnedWidth"></span>
         <ng-container *ngIf="groupingExpressions.length > 0">
             <div class="igx-grid__header-indentation igx-grid__row-indentation--level-{{groupingExpressions.length}}" #headerGroupContainer>
@@ -54,22 +54,12 @@
         </ng-container>
         <ng-container *ngIf="pinnedColumns.length > 0">
             <ng-template ngFor let-col [ngForOf]="onlyTopLevel(pinnedColumns)">
-                <div class="igx-grid__thead-item igx-grid__th--pinned">
-                    <igx-grid-header [igxColumnMovingDrag]="col" [attr.droppable]="true" [igxColumnMovingDrop]="col" [gridID]="id"
-                        [column]="col" [style.min-width.px]="col.width" [style.flex-basis.px]="col.width" [style.max-width.px]='col.width'></igx-grid-header>
-                    <igx-grid-filtering-cell *ngIf="allowFiltering && !col.columnGroup"
-                        [column]="col" [style.min-width.px]="col.width" [style.flex-basis.px]='col.width' [style.max-width.px]='col.width'></igx-grid-filtering-cell>
-                </div>
+                <igx-grid-header-group [igxColumnMovingDrag]="col" [attr.droppable]="true" [igxColumnMovingDrop]="col" [column]="col" [gridID]="id" [style.min-width.px]="col.width" [style.flex-basis.px]="col.width"></igx-grid-header-group>
             </ng-template>
         </ng-container>
         <ng-template igxGridFor let-col [igxGridForOf]="onlyTopLevel(unpinnedColumns)" [igxForScrollOrientation]="'horizontal'" [igxForScrollContainer]="parentVirtDir"
             [igxForContainerSize]='unpinnedWidth' [igxForTrackBy]='trackColumnChanges' #headerContainer>
-            <div class="igx-grid__thead-item">
-                <igx-grid-header [igxColumnMovingDrag]="col" [attr.droppable]="true" [igxColumnMovingDrop]="col" [gridID]="id" [column]="col"
-                    [style.min-width.px]="col.width" [style.flex-basis.px]='col.width' [style.max-width.px]='col.width'></igx-grid-header>
-                <igx-grid-filtering-cell *ngIf="allowFiltering && !col.columnGroup" [column]="col"
-                    [style.min-width.px]="col.width" [style.flex-basis.px]='col.width' [style.max-width.px]='col.width'></igx-grid-filtering-cell>
-            </div>
+            <igx-grid-header-group [igxColumnMovingDrag]="col" [attr.droppable]="true" [igxColumnMovingDrop]="col" [column]="col" [gridID]="id" [style.min-width.px]="col.width" [style.flex-basis.px]="col.width"></igx-grid-header-group>
         </ng-template>
         <span *ngIf="hasMovableColumns && draggedColumn" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="right" class="igx-grid__scroll-on-drag-right"></span>
     </div>

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -32,6 +32,7 @@ const DEBOUNCETIME = 30;
 describe('IgxGrid Component Tests', () => {
     const MIN_COL_WIDTH = '136px';
     const COLUMN_HEADER_CLASS = '.igx-grid__th';
+    const COLUMN_HEADER_GROUP_CLASS = '.igx-grid__thead-item';
     const CELL_CLASS = '.igx-grid__td';
     const ROW_CLASS = '.igx-grid__tr';
     const ROW_EDITING_OUTLET_CLASS = '.igx-grid__row-editing-outlet';
@@ -2345,13 +2346,13 @@ describe('IgxGrid Component Tests', () => {
                 column.resizable = true;
                 fix.detectChanges();
 
-                const headers: DebugElement[] = fix.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
-                const headerResArea = headers[2].nativeElement.children[2];
+                const headers: DebugElement[] = fix.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
+                const headerResArea = headers[2].children[1].nativeElement;
                 UIInteractions.simulateMouseEvent('mousedown', headerResArea, 500, 0);
                 tick();
                 fix.detectChanges();
 
-                const resizer = headers[2].nativeElement.children[2].children[0];
+                const resizer = headers[2].children[1].children[0].nativeElement;
                 expect(resizer).toBeDefined();
                 UIInteractions.simulateMouseEvent('mousemove', resizer, 550, 0);
                 tick();

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
@@ -24,6 +24,7 @@ import { IgxColumnComponent } from '../column.component';
 import { takeUntil } from 'rxjs/operators';
 import { IgxFilteringService } from '../filtering/grid-filtering.service';
 import { IGroupingExpression } from '../../data-operations/grouping-expression.interface';
+import { IgxColumnResizingService } from '../grid-column-resizing.service';
 
 let NEXT_ID = 0;
 
@@ -58,7 +59,7 @@ export interface IGroupingDoneEventArgs {
     providers: [IgxGridNavigationService,
         { provide: GridBaseAPIService, useClass: IgxGridAPIService },
         { provide: IgxGridBaseComponent, useExisting: forwardRef(() => IgxGridComponent) },
-        IgxFilteringService
+        IgxFilteringService, IgxColumnResizingService
     ],
     selector: 'igx-grid',
     templateUrl: './grid.component.html'

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
@@ -22,6 +22,7 @@ import { MultiColumnHeadersWithGroupingComponent } from '../../test-utils/grid-s
 describe('IgxGrid - GroupBy', () => {
     configureTestSuite();
     const COLUMN_HEADER_CLASS = '.igx-grid__th';
+    const COLUMN_HEADER_GROUP_CLASS = '.igx-grid__thead-item';
     const CELL_CSS_CLASS = '.igx-grid__td';
     const SORTING_ICON_ASC_CONTENT = 'arrow_upward';
     const SORTING_ICON_DESC_CONTENT = 'arrow_downward';
@@ -1549,8 +1550,8 @@ describe('IgxGrid - GroupBy', () => {
             expect(grRow.element.nativeElement.clientWidth).toEqual(1200);
         }
 
-        const headers = fix.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS));
-        const headerResArea = headers[0].nativeElement.children[2];
+        const headers = fix.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
+        const headerResArea = headers[0].children[1].nativeElement;
         UIInteractions.simulateMouseEvent('mouseover', headerResArea, 200, 5);
         UIInteractions.simulateMouseEvent('mousedown', headerResArea, 200, 5);
         UIInteractions.simulateMouseEvent('mouseup', headerResArea, 200, 5);
@@ -1560,7 +1561,7 @@ describe('IgxGrid - GroupBy', () => {
         tick(100);
         fix.detectChanges();
 
-        const resizer = headers[0].nativeElement.children[2].children[0];
+        const resizer = headers[0].children[1].children[0].nativeElement;
         expect(resizer).toBeDefined();
         UIInteractions.simulateMouseEvent('mousemove', resizer, 550, 5);
         tick(100);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.pinning.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.pinning.spec.ts
@@ -14,6 +14,7 @@ import { wait, UIInteractions } from '../../test-utils/ui-interactions.spec';
 import { IgxStringFilteringOperand } from '../../data-operations/filtering-condition';
 import { DefaultSortingStrategy } from '../../data-operations/sorting-strategy';
 import { configureTestSuite } from '../../test-utils/configure-suite';
+import { IgxGridHeaderGroupComponent } from '../grid-header-group.component';
 
 describe('IgxGrid - Column Pinning ', () => {
     configureTestSuite();
@@ -579,7 +580,7 @@ describe('IgxGrid - Column Pinning ', () => {
         fix.detectChanges();
         const grid = fix.componentInstance.instance;
 
-        let headers = fix.debugElement.queryAll(By.directive(IgxGridHeaderComponent));
+        let headers = fix.debugElement.queryAll(By.directive(IgxGridHeaderGroupComponent));
 
         // First two headers are pinned
         expect(headers[0].componentInstance.zIndex).toEqual(9999);
@@ -590,7 +591,7 @@ describe('IgxGrid - Column Pinning ', () => {
         fix.detectChanges();
 
         // First three headers are pinned
-        headers = fix.debugElement.queryAll(By.directive(IgxGridHeaderComponent));
+        headers = fix.debugElement.queryAll(By.directive(IgxGridHeaderGroupComponent));
         expect(headers[2].componentInstance.zIndex).toEqual(9997);
     }));
 

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-cell.component.ts
@@ -3,7 +3,7 @@ import { IgxGridCellComponent } from '../cell.component';
 import { IgxTreeGridAPIService } from './tree-grid-api.service';
 import { GridBaseAPIService } from '../api.service';
 import { IgxSelectionAPIService } from '../../core/selection';
-import { valToPxlsUsingRange } from '../../core/utils';
+import { getNodeSizeViaRange } from '../../core/utils';
 import { DOCUMENT } from '@angular/common';
 import { IgxGridBaseComponent } from '../grid';
 
@@ -86,7 +86,7 @@ export class IgxTreeGridCellComponent extends IgxGridCellComponent {
             leftPadding = parseFloat(indentationStyle.paddingLeft);
         }
         const largestWidth = Math.max(...Array.from(this.nativeElement.children)
-            .map((child) => valToPxlsUsingRange(range, child)));
+            .map((child) => getNodeSizeViaRange(range, child)));
         return largestWidth + indicatorWidth + indicatorMargin + leftPadding;
     }
 }

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-indentation.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-indentation.spec.ts
@@ -131,7 +131,7 @@ describe('IgxTreeGrid - Indentation', () => {
             fix.detectChanges();
 
             const header = TreeGridFunctions.getHeaderCell(fix, 'ID');
-            const resizer = header.query(By.css('.igx-grid__th-resize-handle')).nativeElement;
+            const resizer = header.parent.query(By.css('.igx-grid__th-resize-handle')).nativeElement;
 
             // Verify before resizing width
             expect((<HTMLElement>header.nativeElement).getBoundingClientRect().width).toBe(225);
@@ -284,7 +284,7 @@ describe('IgxTreeGrid - Indentation', () => {
             fix.detectChanges();
 
             const header = TreeGridFunctions.getHeaderCell(fix, 'ID');
-            const resizer = header.query(By.css('.igx-grid__th-resize-handle')).nativeElement;
+            const resizer = header.parent.query(By.css('.igx-grid__th-resize-handle')).nativeElement;
 
             // Verify before resizing width
             expect((<HTMLElement>header.nativeElement).getBoundingClientRect().width).toBe(180);

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-integration.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-integration.spec.ts
@@ -602,12 +602,16 @@ describe('IgxTreeGrid - Integration', () => {
             column.movable = true;
             fix.detectChanges();
 
-            const header = TreeGridFunctions.getHeaderCell(fix, 'General Information').nativeElement;
+            const header = fix.debugElement.queryAll(By.css('.igx-grid__thead-item'))[0].nativeElement;
+
             UIInteractions.simulatePointerEvent('pointerdown', header, 100, 40);
-            UIInteractions.simulatePointerEvent('pointermove', header, 106, 46);
             await wait();
+            UIInteractions.simulatePointerEvent('pointermove', header, 106, 46);
+            await wait(50);
             UIInteractions.simulatePointerEvent('pointermove', header, 700, 40);
+            await wait();
             UIInteractions.simulatePointerEvent('pointerup', header, 700, 40);
+            await wait();
             fix.detectChanges();
 
             TreeGridFunctions.verifyTreeColumnInMultiColHeaders(fix, 'HireDate', 4);

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-integration.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-integration.spec.ts
@@ -161,7 +161,7 @@ describe('IgxTreeGrid - Integration', () => {
         });
 
         it('(UI) should autosize tree-column', () => {
-            const headerCell = TreeGridFunctions.getHeaderCell(fix, 'ID');
+            const headerCell = TreeGridFunctions.getHeaderCell(fix, 'ID').parent;
             const column = treeGrid.columnList.filter(c => c.field === 'ID')[0];
             column.resizable = true;
 
@@ -272,7 +272,7 @@ describe('IgxTreeGrid - Integration', () => {
         });
 
         it('(UI) should autosize tree-column', () => {
-            const headerCell = TreeGridFunctions.getHeaderCell(fix, 'ID');
+            const headerCell = TreeGridFunctions.getHeaderCell(fix, 'ID').parent;
             const column = treeGrid.columnList.filter(c => c.field === 'ID')[0];
             column.resizable = true;
 

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.html
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.html
@@ -22,7 +22,7 @@
 
 <div class="igx-grid__thead" role="rowgroup" [style.width.px]='calcWidth' #theadRow>
     <div class="igx-grid__tr" [style.width.px]='calcWidth' role="row">
-        <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length <= 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-left"></span>
+        <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length <= 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-left" [style.left.px]="headerCheckboxWidth"></span>
         <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length > 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-pinned" [style.left.px]="pinnedWidth"></span>
         <ng-container *ngIf="rowSelectable">
             <div class="igx-grid__cbx-selection" #headerCheckboxContainer>
@@ -31,22 +31,12 @@
         </ng-container>
         <ng-container *ngIf="pinnedColumns.length > 0">
             <ng-template ngFor let-col [ngForOf]="onlyTopLevel(pinnedColumns)">
-                <div class="igx-grid__thead-item igx-grid__th--pinned">
-                    <igx-grid-header [igxColumnMovingDrag]="col" [attr.droppable]="true" [igxColumnMovingDrop]="col" [gridID]="id"
-                        [column]="col" [style.min-width.px]="col.width" [style.flex-basis.px]="col.width"></igx-grid-header>
-                    <igx-grid-filtering-cell *ngIf="allowFiltering && !col.columnGroup"
-                        [column]="col" [style.min-width.px]="col.width" [style.flex-basis.px]='col.width' [style.max-width.px]='col.width'></igx-grid-filtering-cell>
-                </div>
+                <igx-grid-header-group [igxColumnMovingDrag]="col" [attr.droppable]="true" [igxColumnMovingDrop]="col" [column]="col" [gridID]="id" [style.min-width.px]="col.width" [style.flex-basis.px]="col.width"></igx-grid-header-group>
             </ng-template>
         </ng-container>
         <ng-template igxGridFor let-col [igxGridForOf]="onlyTopLevel(unpinnedColumns)" [igxForScrollOrientation]="'horizontal'" [igxForScrollContainer]="parentVirtDir"
             [igxForContainerSize]='unpinnedWidth' [igxForTrackBy]='trackColumnChanges' #headerContainer>
-            <div class="igx-grid__thead-item">
-                <igx-grid-header [igxColumnMovingDrag]="col" [attr.droppable]="true" [igxColumnMovingDrop]="col" [gridID]="id" [column]="col"
-                    [style.min-width.px]="col.width" [style.flex-basis.px]='col.width'></igx-grid-header>
-                <igx-grid-filtering-cell *ngIf="allowFiltering && !col.columnGroup"
-                    [column]="col" [style.min-width.px]="col.width" [style.flex-basis.px]='col.width' [style.max-width.px]='col.width'></igx-grid-filtering-cell>
-            </div>
+            <igx-grid-header-group [igxColumnMovingDrag]="col" [attr.droppable]="true" [igxColumnMovingDrop]="col" [column]="col" [gridID]="id" [style.min-width.px]="col.width" [style.flex-basis.px]="col.width"></igx-grid-header-group>
         </ng-template>
         <span *ngIf="hasMovableColumns && draggedColumn" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="right" class="igx-grid__scroll-on-drag-right"></span>
     </div>
@@ -56,10 +46,10 @@
 <div class="igx-grid__tbody" role="rowgroup" [style.height.px]='calcHeight' [style.width.px]='calcWidth' #tbody (scroll)='scrollHandler($event)' (wheel)="wheelHandler()">
     <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length <= 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-left"></span>
     <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length > 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-pinned" [style.left.px]="pinnedWidth"></span>
-    <ng-template igxGridFor let-rowData [igxGridForOf]="data 
-	| treeGridTransaction:id:pipeTrigger	
+    <ng-template igxGridFor let-rowData [igxGridForOf]="data
+	| treeGridTransaction:id:pipeTrigger
 	| treeGridHierarchizing:primaryKey:foreignKey:childDataKey:id:pipeTrigger
-    | treeGridFiltering:filteringExpressionsTree:id:pipeTrigger 
+    | treeGridFiltering:filteringExpressionsTree:id:pipeTrigger
     | treeGridSorting:sortingExpressions:id:pipeTrigger
     | treeGridFlattening:id:expansionDepth:expansionStates:pipeTrigger
     | treeGridPaging:page:perPage:id:pipeTrigger"
@@ -70,7 +60,7 @@
             <igx-tree-grid-row [gridID]="id" [index]="rowIndex" [treeRow]="rowData" #row>
             </igx-tree-grid-row>
         </ng-template>
-     
+
         <ng-container *igxTemplateOutlet="record_template; context: getContext(rowData) "></ng-container>
     </ng-template>
     <ng-container *ngTemplateOutlet="template"></ng-container>
@@ -119,7 +109,7 @@
 </ng-template>
 
 <div *ngIf="rowEditable" igxToggle>
-    <div [className]="bannerClass"> 
+    <div [className]="bannerClass">
         <ng-container *ngTemplateOutlet="rowEditContainer; context: { rowChangesCount: rowChangesCount, endEdit: endEdit.bind(this) }"></ng-container>
     </div>
 </div>

--- a/projects/igniteui-angular/src/lib/test-utils/grid-functions.spec.ts
+++ b/projects/igniteui-angular/src/lib/test-utils/grid-functions.spec.ts
@@ -6,7 +6,7 @@ import { Calendar,
     IgxCheckboxComponent } from '../../public_api';
 import { DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { ComponentFixture } from '@angular/core/testing';
+import { ComponentFixture, tick } from '@angular/core/testing';
 import { IgxInputDirective } from '../input-group';
 import { IgxGridHeaderComponent } from '../grids/grid-header.component';
 import { IgxChipComponent } from '../chips';
@@ -408,6 +408,7 @@ export class GridFunctions {
         for ( i = 0; i < ddItems.length; i++) {
             if (ddItems[i].textContent === cond) {
                 ddItems[i].click();
+                tick(100);
                 return;
             }
         }
@@ -417,11 +418,12 @@ export class GridFunctions {
         const filterUIRow = fix.debugElement.query(By.css(FILTER_UI_ROW));
         // open dropdown
         this.openFilterDD(fix.debugElement);
+        fix.detectChanges();
 
         const ddList = fix.debugElement.query(By.css('div.igx-drop-down__list.igx-toggle'));
         this.selectFilteringCondition(condition, ddList);
-        const input = filterUIRow.query(By.directive(IgxInputDirective));
 
+        const input = filterUIRow.query(By.directive(IgxInputDirective));
         input.nativeElement.value = value;
         input.nativeElement.dispatchEvent(new Event('input'));
         fix.detectChanges();
@@ -436,6 +438,7 @@ export class GridFunctions {
         const editingBtns = filterUIRow.query(By.css('.igx-grid__filtering-row-editing-buttons'));
         const reset = editingBtns.queryAll(By.css('button'))[0];
         reset.nativeElement.click();
+        tick(100);
         fix.detectChanges();
     }
 
@@ -444,6 +447,7 @@ export class GridFunctions {
         const editingBtns = filterUIRow.query(By.css('.igx-grid__filtering-row-editing-buttons'));
         const close = editingBtns.queryAll(By.css('button'))[1];
         close.nativeElement.click();
+        tick(100);
         fix.detectChanges();
     }
 

--- a/projects/igniteui-angular/src/lib/test-utils/tree-grid-functions.spec.ts
+++ b/projects/igniteui-angular/src/lib/test-utils/tree-grid-functions.spec.ts
@@ -158,7 +158,8 @@ export class TreeGridFunctions {
      * Verifies that the specified column is the tree column, that contains the tree cells.
     */
     public static verifyTreeColumn(fix, expectedTreeColumnKey, expectedColumnsCount) {
-        const headerCell = TreeGridFunctions.getHeaderCell(fix, expectedTreeColumnKey);
+        const headerCell = TreeGridFunctions.getHeaderCell(fix, expectedTreeColumnKey).parent;
+
         const treeCells = TreeGridFunctions.getTreeCells(fix);
         const rows = TreeGridFunctions.getAllRows(fix);
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -149,6 +149,11 @@ export class AppComponent implements OnInit {
             name: 'Grid Performance'
         },
         {
+            link: '/gridPercentage',
+            icon: 'view_column',
+            name: 'Grid Percentage'
+        },
+        {
             link: '/gridRemoteVirtualization',
             icon: 'view_column',
             name: 'Grid Remote Virtualization'

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -74,6 +74,7 @@ import { GridRowEditSampleComponent } from './grid-row-edit/grid-row-edit-sample
 import { GridWithTransactionsComponent } from './grid-row-edit/grid-with-transactions.component';
 import { TreeGridSampleComponent } from './tree-grid/tree-grid.sample';
 import { TreeGridFlatDataSampleComponent } from './tree-grid-flat-data/tree-grid-flat-data.sample';
+import { GridColumnPercentageWidthsSampleComponent } from './grid-percentage-columns/grid-percantge-widths.sample';
 
 const components = [
     AppComponent,
@@ -136,7 +137,8 @@ const components = [
     ShadowsSampleComponent,
     TypographySampleComponent,
     RadioSampleComponent,
-    TooltipSampleComponent
+    TooltipSampleComponent,
+    GridColumnPercentageWidthsSampleComponent
 ];
 
 @NgModule({

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -44,6 +44,7 @@ import { GridCellStylingSampleComponent } from './gird-cell-styling/grid-cell-st
 import { GridRowEditSampleComponent } from './grid-row-edit/grid-row-edit-sample.component';
 import { TreeGridSampleComponent } from './tree-grid/tree-grid.sample';
 import { TreeGridFlatDataSampleComponent } from './tree-grid-flat-data/tree-grid-flat-data.sample';
+import { GridColumnPercentageWidthsSampleComponent } from './grid-percentage-columns/grid-percantge-widths.sample';
 
 const appRoutes = [
     {
@@ -231,6 +232,10 @@ const appRoutes = [
     {
         path: 'tooltip',
         component: TooltipSampleComponent
+    },
+    {
+        path: 'gridPercentage',
+        component: GridColumnPercentageWidthsSampleComponent
     }
 ];
 

--- a/src/app/grid-column-groups/grid-column-groups.sample.html
+++ b/src/app/grid-column-groups/grid-column-groups.sample.html
@@ -61,7 +61,6 @@
                 <igx-column filterable="true" sortable="true" resizable="true" field="PostalCode"></igx-column>
             </igx-column-group>
         </igx-grid>
-
         <span igxButton (click)="pinGroup()">Pin first group</span>
         <span igxButton (click)="hideGroup()">Hide first group</span>
     </section>

--- a/src/app/grid-column-moving/grid-column-moving.sample.html
+++ b/src/app/grid-column-moving/grid-column-moving.sample.html
@@ -15,8 +15,7 @@
                 [rowSelectable]="true"
                 [paging]="false"
                 [width]="'900px'"
-                [height]="'500px'"
-            >
+                [height]="'500px'">
                 <igx-column *ngFor="let c of columns" [field]="c.field"
                                                     [header]="c.field"
                                                     [movable]="c.movable"

--- a/src/app/grid-column-moving/grid-column-moving.sample.ts
+++ b/src/app/grid-column-moving/grid-column-moving.sample.ts
@@ -18,7 +18,7 @@ export class GridColumnMovingSampleComponent implements OnInit {
 
     public ngOnInit(): void {
         this.columns = [
-            { field: 'ID', width: 150, resizable: true, movable: true },
+            { field: 'ID', width: 40, resizable: true, movable: true },
             { field: 'CompanyName', width: 150, resizable: true, movable: true, type: 'string'},
             { field: 'ContactName', width: 150, resizable: true, movable: true, type: 'string' },
             { field: 'ContactTitle', width: 150, resizable: true, movable: true, type: 'string' },

--- a/src/app/grid-percentage-columns/grid-percantge-widths.sample.html
+++ b/src/app/grid-percentage-columns/grid-percantge-widths.sample.html
@@ -1,0 +1,51 @@
+<div class="wrapper">
+<app-page-header title="Grid Percentage Columns">
+    Grid with column widths in %
+</app-page-header>
+<div class="sample-content">
+    <div class="sample-column">
+        <igx-grid [allowFiltering]="true" [data]="data" [autoGenerate]="false" displayDensity="comfortable" width="100%" height="600px" [paging]="true" [perPage]="10">
+            <igx-column field="ProductName" [pinned]="true" [movable]="true" header="Product Name" width="19%" [dataType]="'string'" [sortable]="true" [hasSummary]="false" [editable]="true" [filterable]="true" [resizable]="true">
+            </igx-column>
+            <igx-column field="UnitsInStock" [pinned]="false" [movable]="true"  header="Units In Stock" width="19%" [dataType]="'number'" [sortable]="true" [hasSummary]="false" [editable]="true" [filterable]="true" [resizable]="true">
+            </igx-column>
+            <igx-column field="OrderDate" [movable]="true" header="Order Date" width="19%" [dataType]="'date'" [sortable]="true" [hasSummary]="false" [editable]="true" [filterable]="true" [resizable]="true">
+                <ng-template igxCell let-cell="cell" let-val>
+                    {{val | date:'dd/MM/yyyy'}}
+                </ng-template>
+            </igx-column>
+            <igx-column field="Discontinued" [movable]="true" [resizable]="true"  header="Discontinued" width="15%" [dataType]="'boolean'" [sortable]="false" [hasSummary]="false" [editable]="true" [filterable]="false" [resizable]="true">
+            </igx-column>
+            <igx-column field="ReorderLevel" header="Reorder Level" [movable]="true" [resizable]="true" [dataType]="'number'" width="19%" [sortable]="false" [hasSummary]="false" [editable]="true" >
+                <ng-template igxCellEditor let-cell="cell">
+                    <input type="number" [(ngModel)]="cell.value" style="color: black"/>
+                </ng-template>
+            </igx-column>
+        </igx-grid>
+    </div>
+</div>
+<igx-input-group class="sample-column">
+    <input igxInput type="text" placeholder="Filter by product name" (input)="filter($event.target.value)">
+</igx-input-group>
+<div class="sample-content">
+    <igx-grid #grid1 [data]="data" [autoGenerate]="false" height="520px" width="100%" [allowFiltering]="true">
+        <igx-column field="ProductName" header="Product Name" [dataType]="'string'">
+        </igx-column>
+        <igx-column field="QuantityPerUnit" [pinned]="true" [filterable]="false" header="Quantity Per Unit" [dataType]="'string'">
+        </igx-column>
+        <igx-column field="UnitPrice" header="Unit Price" [dataType]="'number'">
+            <ng-template igxCell let-cell="cell" let-val let-row>
+                {{+val | currency}}
+            </ng-template>
+        </igx-column>
+        <igx-column field="OrderDate" [editable]="true" header="Order Date" [dataType]="'date'" [formatter]="formatDate">
+        </igx-column>
+        <igx-column field="Discontinued" header="Discontinued" [dataType]="'boolean'">
+            <ng-template igxCell let-cell="cell" let-val>
+                <img *ngIf="val" src="https://staging.infragistics.local/angular-demos/assets/images/grid/active.png" title="Continued" alt="Continued" />
+                <img *ngIf="!val" src="https://staging.infragistics.local/angular-demos/assets/images/grid/expired.png" title="Discontinued" alt="Discontinued" />
+            </ng-template>
+        </igx-column>
+    </igx-grid>
+</div>
+</div>

--- a/src/app/grid-percentage-columns/grid-percantge-widths.sample.ts
+++ b/src/app/grid-percentage-columns/grid-percantge-widths.sample.ts
@@ -1,0 +1,453 @@
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { IgxGridComponent, IgxStringFilteringOperand } from 'igniteui-angular';
+ @Component({
+    providers: [],
+    selector: 'ap-grid-percantge-widths.sample',
+    templateUrl: 'grid-percantge-widths.sample.html'
+})
+ export class GridColumnPercentageWidthsSampleComponent implements OnInit {
+     public data: Array<any>;
+     public data1: Array<any>;
+
+     @ViewChild("grid1", { read: IgxGridComponent })
+     public grid1: IgxGridComponent;
+
+     public ngOnInit(): void {
+       this.data1 = [{
+        ProductID: 1,
+        ProductName: "Chai",
+        SupplierID: 1,
+        CategoryID: 1,
+        QuantityPerUnit: "10 boxes x 20 bags",
+        UnitPrice: 18.0000,
+        UnitsInStock: 39,
+        UnitsOnOrder: 0,
+        ReorderLevel: 10,
+        Discontinued: false,
+        OrderDate: new Date("2012-02-12")
+      }, {
+        ProductID: 2,
+        ProductName: "Chang",
+        SupplierID: 1,
+        CategoryID: 1,
+        QuantityPerUnit: "24 - 12 oz bottles",
+        UnitPrice: 19.0000,
+        UnitsInStock: 17,
+        UnitsOnOrder: 40,
+        ReorderLevel: 25,
+        Discontinued: false,
+        OrderDate: new Date("2003-03-17")
+      }, {
+        ProductID: 3,
+        ProductName: "Aniseed Syrup",
+        SupplierID: 1,
+        CategoryID: 2,
+        QuantityPerUnit: "12 - 550 ml bottles",
+        UnitPrice: 10.0000,
+        UnitsInStock: 13,
+        UnitsOnOrder: 70,
+        ReorderLevel: 25,
+        Discontinued: false,
+        OrderDate: new Date("2006-03-17")
+      }, {
+        ProductID: 4,
+        ProductName: "Chef Antons Cajun Seasoning",
+        SupplierID: 2,
+        CategoryID: 2,
+        QuantityPerUnit: "48 - 6 oz jars",
+        UnitPrice: 22.0000,
+        UnitsInStock: 53,
+        UnitsOnOrder: 0,
+        ReorderLevel: 0,
+        Discontinued: false,
+        OrderDate: new Date("2016-03-17")
+      }, {
+        ProductID: 5,
+        ProductName: "Chef Antons Gumbo Mix",
+        SupplierID: 2,
+        CategoryID: 2,
+        QuantityPerUnit: "36 boxes",
+        UnitPrice: 21.3500,
+        UnitsInStock: 0,
+        UnitsOnOrder: 0,
+        ReorderLevel: 0,
+        Discontinued: true,
+        OrderDate: new Date("2011-11-11")
+      }, {
+        ProductID: 6,
+        ProductName: "Grandmas Boysenberry Spread",
+        SupplierID: 3,
+        CategoryID: 2,
+        QuantityPerUnit: "12 - 8 oz jars",
+        UnitPrice: 25.0000,
+        UnitsInStock: 0,
+        UnitsOnOrder: 0,
+        ReorderLevel: 25,
+        Discontinued: false,
+        OrderDate: new Date("2017-12-17")
+      }, {
+        ProductID: 7,
+        ProductName: "Uncle Bobs Organic Dried Pears",
+        SupplierID: 3,
+        CategoryID: 7,
+        QuantityPerUnit: "12 - 1 lb pkgs.",
+        UnitPrice: 30.0000,
+        UnitsInStock: 150,
+        UnitsOnOrder: 0,
+        ReorderLevel: 10,
+        Discontinued: false,
+        OrderDate: new Date("2016-07-17")
+      }, {
+        ProductID: 8,
+        ProductName: "Northwoods Cranberry Sauce",
+        SupplierID: 3,
+        CategoryID: 2,
+        QuantityPerUnit: "12 - 12 oz jars",
+        UnitPrice: 40.0000,
+        UnitsInStock: 6,
+        UnitsOnOrder: 0,
+        ReorderLevel: 0,
+        Discontinued: false,
+        OrderDate: new Date("2018-01-17")
+      }, {
+        ProductID: 9,
+        ProductName: "Mishi Kobe Niku",
+        SupplierID: 4,
+        CategoryID: 6,
+        QuantityPerUnit: "18 - 500 g pkgs.",
+        UnitPrice: 97.0000,
+        UnitsInStock: 29,
+        UnitsOnOrder: 0,
+        ReorderLevel: 0,
+        Discontinued: true,
+        OrderDate: new Date("2010-02-17")
+      }, {
+        ProductID: 10,
+        ProductName: "Ikura",
+        SupplierID: 4,
+        CategoryID: 8,
+        QuantityPerUnit: "12 - 200 ml jars",
+        UnitPrice: 31.0000,
+        UnitsInStock: 31,
+        UnitsOnOrder: 0,
+        ReorderLevel: 0,
+        Discontinued: false,
+        OrderDate: new Date("2008-05-17")
+      }, {
+        ProductID: 11,
+        ProductName: "Queso Cabrales",
+        SupplierID: 5,
+        CategoryID: 4,
+        QuantityPerUnit: "1 kg pkg.",
+        UnitPrice: 21.0000,
+        UnitsInStock: 22,
+        UnitsOnOrder: 30,
+        ReorderLevel: 30,
+        Discontinued: false,
+        OrderDate: new Date("2009-01-17")
+      }, {
+        ProductID: 12,
+        ProductName: "Queso Manchego La Pastora",
+        SupplierID: 5,
+        CategoryID: 4,
+        QuantityPerUnit: "10 - 500 g pkgs.",
+        UnitPrice: 38.0000,
+        UnitsInStock: 86,
+        UnitsOnOrder: 0,
+        ReorderLevel: 0,
+        Discontinued: false,
+        OrderDate: new Date("2015-11-17")
+      }, {
+        ProductID: 13,
+        ProductName: "Konbu",
+        SupplierID: 6,
+        CategoryID: 8,
+        QuantityPerUnit: "2 kg box",
+        UnitPrice: 6.0000,
+        UnitsInStock: 24,
+        UnitsOnOrder: 0,
+        ReorderLevel: 5,
+        Discontinued: false,
+        OrderDate: new Date("2015-03-17")
+      }, {
+        ProductID: 14,
+        ProductName: "Tofu",
+        SupplierID: 6,
+        CategoryID: 7,
+        QuantityPerUnit: "40 - 100 g pkgs.",
+        UnitPrice: 23.2500,
+        UnitsInStock: 35,
+        UnitsOnOrder: 0,
+        ReorderLevel: 0,
+        Discontinued: false,
+        OrderDate: new Date("2017-06-17")
+      }, {
+        ProductID: 15,
+        ProductName: "Genen Shouyu",
+        SupplierID: 6,
+        CategoryID: 2,
+        QuantityPerUnit: "24 - 250 ml bottles",
+        UnitPrice: 15.5000,
+        UnitsInStock: 39,
+        UnitsOnOrder: 0,
+        ReorderLevel: 5,
+        Discontinued: false,
+        OrderDate: new Date("2014-03-17")
+      }, {
+        ProductID: 16,
+        ProductName: "Pavlova",
+        SupplierID: 7,
+        CategoryID: 3,
+        QuantityPerUnit: "32 - 500 g boxes",
+        UnitPrice: 17.4500,
+        UnitsInStock: 29,
+        UnitsOnOrder: 0,
+        ReorderLevel: 10,
+        Discontinued: false,
+        OrderDate: new Date("2018-03-28")
+      }, {
+        ProductID: 17,
+        ProductName: "Alice Mutton",
+        SupplierID: 7,
+        CategoryID: 6,
+        QuantityPerUnit: "20 - 1 kg tins",
+        UnitPrice: 39.0000,
+        UnitsInStock: 0,
+        UnitsOnOrder: 0,
+        ReorderLevel: 0,
+        Discontinued: true,
+        OrderDate: new Date("2015-08-17")
+      }, {
+        ProductID: 18,
+        ProductName: "Carnarvon Tigers",
+        SupplierID: 7,
+        CategoryID: 8,
+        QuantityPerUnit: "16 kg pkg.",
+        UnitPrice: 62.5000,
+        UnitsInStock: 42,
+        UnitsOnOrder: 0,
+        ReorderLevel: 0,
+        Discontinued: false,
+        OrderDate: new Date("2005-09-27")
+      }, {
+        ProductID: 19,
+        ProductName: "Teatime Chocolate Biscuits",
+        SupplierID: 8,
+        CategoryID: 3,
+        QuantityPerUnit: "",
+        UnitPrice: 9.2000,
+        UnitsInStock: 25,
+        UnitsOnOrder: 0,
+        ReorderLevel: 5,
+        Discontinued: false,
+        OrderDate: new Date("2001-03-17")
+      }, {
+        ProductID: 20,
+        ProductName: "Sir Rodneys Marmalade",
+        SupplierID: 8,
+        CategoryID: 3,
+        QuantityPerUnit: undefined,
+        UnitPrice: undefined,
+        UnitsInStock: 40,
+        UnitsOnOrder: 0,
+        ReorderLevel: 0,
+        Discontinued: false,
+        OrderDate: new Date("2005-03-17")
+      }];
+
+      this.data = [{
+            ProductID: 1,
+            ProductName: "Chai",
+            QuantityPerUnit: "10 boxes x 20 bags",
+            UnitPrice: 18.0000,
+            UnitsInStock: 39,
+            ReorderLevel: 10,
+            Discontinued: false,
+            OrderDate: new Date("2012-02-12")
+          }, {
+            ProductID: 2,
+            ProductName: "Chang",
+            QuantityPerUnit: "24 - 12 oz bottles",
+            UnitPrice: 19.0000,
+            UnitsInStock: 17,
+            ReorderLevel: 25,
+            Discontinued: false,
+            OrderDate: new Date("2003-03-17")
+          }, {
+            ProductID: 3,
+            ProductName: "Aniseed Syrup",
+            QuantityPerUnit: "12 - 550 ml bottles",
+            UnitPrice: 10.0000,
+            UnitsInStock: 13,
+            ReorderLevel: 25,
+            Discontinued: false,
+            OrderDate: new Date("2006-03-17")
+          }, {
+            ProductID: 4,
+            ProductName: "Chef Antons Cajun Seasoning",
+            QuantityPerUnit: "48 - 6 oz jars",
+            UnitPrice: 22.0000,
+            UnitsInStock: 53,
+            ReorderLevel: 0,
+            Discontinued: false,
+            OrderDate: new Date("2016-03-17")
+          }, {
+            ProductID: 5,
+            ProductName: "Chef Antons Gumbo Mix",
+            QuantityPerUnit: "36 boxes",
+            UnitPrice: 21.3500,
+            UnitsInStock: 0,
+            ReorderLevel: 0,
+            Discontinued: true,
+            OrderDate: new Date("2011-11-11")
+          }, {
+            ProductID: 6,
+            ProductName: "Grandmas Boysenberry Spread",
+            QuantityPerUnit: "12 - 8 oz jars",
+            UnitPrice: 25.0000,
+            UnitsInStock: 0,
+            ReorderLevel: 25,
+            Discontinued: false,
+            OrderDate: new Date("2017-12-17")
+          }, {
+            ProductID: 7,
+            ProductName: "Uncle Bobs Organic Dried Pears",
+            QuantityPerUnit: "12 - 1 lb pkgs.",
+            UnitPrice: 30.0000,
+            UnitsInStock: 150,
+            ReorderLevel: 10,
+            Discontinued: false,
+            OrderDate: new Date("2016-07-17")
+          }, {
+            ProductID: 8,
+            ProductName: "Northwoods Cranberry Sauce",
+            QuantityPerUnit: "12 - 12 oz jars",
+            UnitPrice: 40.0000,
+            UnitsInStock: 6,
+            ReorderLevel: 0,
+            Discontinued: false,
+            OrderDate: new Date("2018-01-17")
+          }, {
+            ProductID: 9,
+            ProductName: "Mishi Kobe Niku",
+            QuantityPerUnit: "18 - 500 g pkgs.",
+            UnitPrice: 97.0000,
+            UnitsInStock: 29,
+            ReorderLevel: 0,
+            Discontinued: true,
+            OrderDate: new Date("2010-02-17")
+          }, {
+            ProductID: 10,
+            ProductName: "Ikura",
+            QuantityPerUnit: "12 - 200 ml jars",
+            UnitPrice: 31.0000,
+            UnitsInStock: 31,
+            ReorderLevel: 0,
+            Discontinued: false,
+            OrderDate: new Date("2008-05-17")
+          }, {
+            ProductID: 11,
+            ProductName: "Queso Cabrales",
+            QuantityPerUnit: "1 kg pkg.",
+            UnitPrice: 21.0000,
+            UnitsInStock: 22,
+            ReorderLevel: 30,
+            Discontinued: false,
+            OrderDate: new Date("2009-01-17")
+          }, {
+            ProductID: 12,
+            ProductName: "Queso Manchego La Pastora",
+            QuantityPerUnit: "10 - 500 g pkgs.",
+            UnitPrice: 38.0000,
+            UnitsInStock: 86,
+            ReorderLevel: 0,
+            Discontinued: false,
+            OrderDate: new Date("2015-11-17")
+          }, {
+            ProductID: 13,
+            ProductName: "Konbu",
+            QuantityPerUnit: "2 kg box",
+            UnitPrice: 6.0000,
+            UnitsInStock: 24,
+            ReorderLevel: 5,
+            Discontinued: false,
+            OrderDate: new Date("2015-03-17")
+          }, {
+            ProductID: 14,
+            ProductName: "Tofu",
+            QuantityPerUnit: "40 - 100 g pkgs.",
+            UnitPrice: 23.2500,
+            UnitsInStock: 35,
+            ReorderLevel: 0,
+            Discontinued: false,
+            OrderDate: new Date("2017-06-17")
+          }, {
+            ProductID: 15,
+            ProductName: "Genen Shouyu",
+            QuantityPerUnit: "24 - 250 ml bottles",
+            UnitPrice: 15.5000,
+            UnitsInStock: 39,
+            ReorderLevel: 5,
+            Discontinued: false,
+            OrderDate: new Date("2014-03-17")
+          }, {
+            ProductID: 16,
+            ProductName: "Pavlova",
+            QuantityPerUnit: "32 - 500 g boxes",
+            UnitPrice: 17.4500,
+            UnitsInStock: 29,
+            ReorderLevel: 10,
+            Discontinued: false,
+            OrderDate: new Date("2018-03-28")
+          }, {
+            ProductID: 17,
+            ProductName: "Alice Mutton",
+            QuantityPerUnit: "20 - 1 kg tins",
+            UnitPrice: 39.0000,
+            UnitsInStock: 0,
+            ReorderLevel: 0,
+            Discontinued: true,
+            OrderDate: new Date("2015-08-17")
+          }, {
+            ProductID: 18,
+            ProductName: "Carnarvon Tigers",
+            QuantityPerUnit: "16 kg pkg.",
+            UnitPrice: 62.5000,
+            UnitsInStock: 42,
+            ReorderLevel: 0,
+            Discontinued: false,
+            OrderDate: new Date("2005-09-27")
+          }, {
+            ProductID: 19,
+            ProductName: "Teatime Chocolate Biscuits",
+            QuantityPerUnit: "",
+            UnitPrice: 9.2000,
+            UnitsInStock: 25,
+            ReorderLevel: 5,
+            Discontinued: false,
+            OrderDate: new Date("2001-03-17")
+          }, {
+            ProductID: 20,
+            ProductName: "Sir Rodneys Marmalade",
+            QuantityPerUnit: undefined,
+            UnitPrice: undefined,
+            UnitsInStock: 40,
+            ReorderLevel: 0,
+            Discontinued: false,
+            OrderDate: new Date("2005-03-17")
+          }];
+        }
+
+
+        public formatDate(val: Date) {
+          return new Intl.DateTimeFormat("en-US").format(val);
+      }
+
+      public formatCurrency(val: string) {
+          return parseInt(val, 10).toFixed(2);
+      }
+
+      public filter(term) {
+        this.grid1.filter("ProductName", term, IgxStringFilteringOperand.instance().condition("contains"));
+    }
+}

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -55,6 +55,7 @@ import { GridCellStylingSampleComponent } from './gird-cell-styling/grid-cell-st
 import { GridRowEditSampleComponent } from './grid-row-edit/grid-row-edit-sample.component';
 import { TreeGridSampleComponent } from './tree-grid/tree-grid.sample';
 import { TreeGridFlatDataSampleComponent } from './tree-grid-flat-data/tree-grid-flat-data.sample';
+import { GridColumnPercentageWidthsSampleComponent } from './grid-percentage-columns/grid-percantge-widths.sample';
 
 const appRoutes = [
     {
@@ -286,6 +287,10 @@ const appRoutes = [
     {
         path: 'tooltip',
         component: TooltipSampleComponent
+    },
+    {
+        path: 'gridPercentage',
+        component: GridColumnPercentageWidthsSampleComponent
     }
 ];
 


### PR DESCRIPTION
Closes #2972, Closes #2926, Closes #2923, Closes #2917, Closes #2783, Closes #3027, Closes #2938.  

**This PR introduces the following changes that are with high regression potential:** 
- a new component (header group) to accommodate the header and filtering cell components; 
- all column moving and column resizing related DOM structures are moved to the new header group component;
- MCH are hierarchical structure, comprising of these header group components, only the deepest groups should have a header and a filter cell;
- the old header component is cleaned up, it takes care only for sorting;
- column resizing base logic is moved to a separate service;
