### PR TITLE
Provide IgxIconService in root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes for each version of this project will be documented in this 
 ## 6.2.2
 - `igx-checkbox`:
     - Added a new input property - `disableTransitions`. It allows disabling all CSS transitions on the `igx-checkbox` component for performance optimization.
+- `IgxIconModule`:
+    - **Breaking change** `igxIconService` is now provided in root (providedIn: 'root') and `IgxIconModule.forRoot()` method is deprecated.
+    - **Breaking change** `glyphName` property of the `igxIconComponent` is deprecated.
 
 ## 6.2.1
 ### Features

--- a/projects/igniteui-angular/src/lib/avatar/avatar.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/avatar/avatar.component.spec.ts
@@ -21,7 +21,7 @@ describe('Avatar', () => {
                 InitImageAvatarComponent,
                 InitAvatarWithAriaComponent
             ],
-            imports: [IgxIconModule.forRoot()]
+            imports: [IgxIconModule]
         })
             .compileComponents();
     }));

--- a/projects/igniteui-angular/src/lib/badge/badge.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/badge/badge.component.spec.ts
@@ -20,7 +20,7 @@ describe('Badge', () => {
                 IgxBadgeComponent,
                 InitBadgeWithIconARIAComponent
             ],
-            imports: [IgxIconModule.forRoot()]
+            imports: [IgxIconModule]
         }).compileComponents();
     }));
 

--- a/projects/igniteui-angular/src/lib/icon/icon.component.html
+++ b/projects/igniteui-angular/src/lib/icon/icon.component.html
@@ -4,11 +4,6 @@
     <ng-content></ng-content>
 </ng-template>
 
-<!-- TODO: remove this after glyphName property is deprecated. -->
-<ng-template #implicitLigature>
-    {{getIconName}}
-</ng-template>
-
 <ng-template #svgImage>
     <svg>
         <use [attr.href]="getSvgKey"></use>

--- a/projects/igniteui-angular/src/lib/icon/icon.component.ts
+++ b/projects/igniteui-angular/src/lib/icon/icon.component.ts
@@ -1,6 +1,6 @@
 import { Component, ElementRef, HostBinding, Input, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { IgxIconService } from './icon.service';
-import { DeprecateProperty } from '../core/deprecateDecorators';
+
 /**
  * **Ignite UI for Angular Icon** -
  * [Documentation](https://www.infragistics.com/products/ignite-ui-angular/angular/components/icon.html)
@@ -27,10 +27,6 @@ export class IgxIconComponent implements OnInit {
 
     @ViewChild('explicitLigature', { read: TemplateRef })
     private explicitLigature: TemplateRef<HTMLElement>;
-
-    // TODO: remove this after glyphName property is deprecated.
-    @ViewChild('implicitLigature', { read: TemplateRef })
-    private implicitLigature: TemplateRef<HTMLElement>;
 
     @ViewChild('svgImage', { read: TemplateRef })
     private svgImage: TemplateRef<HTMLElement>;
@@ -109,19 +105,6 @@ export class IgxIconComponent implements OnInit {
     */
     @Input('name')
     public iconName: string;
-
-    /**
-    *    An @Input property that allows you to change the `glyphName` of the icon.
-    *    The `glyphName` can be set using `iconName`.
-    *    You can provide either ligature `name` or glyph `iconName`, but not both at the same time.
-    *```html
-    *<igx-icon iconName="question_answer" color="blue" [isActive]="true" fontSet="material"></igx-icon>
-    *```
-    */
-    @DeprecateProperty(`'iconName' property is deprecated. To set the icon name for 'material' icons place the name of the icon between ` +
-        `the opening and closing tags. For 'Font Awesome' and SVG icons use 'name' property.`)
-    @Input('iconName')
-    public glyphName: string;
 
     /**
      * An ElementRef property of the `igx-icon` component.
@@ -246,14 +229,6 @@ export class IgxIconComponent implements OnInit {
         if (this.iconName) {
             if (this.iconService.isSvgIconCached(this.iconName, this.font)) {
                 return this.svgImage;
-            }
-
-            // TODO: remove this after glyphName property is deprecated.
-            const materialFS = 'material-icons';
-            const materialFSAlias = 'material';
-            if (this.font === materialFS || this.font === materialFSAlias ||
-                (!this.font && (this.iconService.defaultFontSet === materialFS || this.iconService.defaultFontSet === materialFSAlias))) {
-                return this.implicitLigature;
             }
 
             return this.noLigature;

--- a/projects/igniteui-angular/src/lib/icon/icon.service.ts
+++ b/projects/igniteui-angular/src/lib/icon/icon.service.ts
@@ -16,7 +16,9 @@ import { DOCUMENT } from '@angular/common';
  * ```
  */
 
-@Injectable()
+@Injectable({
+    providedIn: 'root'
+})
 export class IgxIconService {
     private _fontSet = 'material-icons';
     private _fontSetAliases = new Map<string, string>();

--- a/projects/igniteui-angular/src/lib/icon/index.ts
+++ b/projects/igniteui-angular/src/lib/icon/index.ts
@@ -3,13 +3,21 @@ import { NgModule } from '@angular/core';
 
 import { IgxIconComponent } from './icon.component';
 import { HttpClientModule } from '@angular/common/http';
+import { DeprecateMethod } from '../core/deprecateDecorators';
 
 @NgModule({
     declarations: [IgxIconComponent],
     exports: [IgxIconComponent],
     imports: [CommonModule, HttpClientModule]
 })
-export class IgxIconModule {}
+export class IgxIconModule {
+    @DeprecateMethod('IgxIconModule.forRoot method is deprecated. Use IgxIconModule instead.')
+    public static forRoot() {
+        return {
+            ngModule: IgxIconModule
+        };
+    }
+}
 
 export * from './icon.component';
 export * from './icon.service';

--- a/projects/igniteui-angular/src/lib/icon/index.ts
+++ b/projects/igniteui-angular/src/lib/icon/index.ts
@@ -2,23 +2,14 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { IgxIconComponent } from './icon.component';
-import { IgxIconService } from './icon.service';
 import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
     declarations: [IgxIconComponent],
     exports: [IgxIconComponent],
-    imports: [CommonModule, HttpClientModule],
-    providers: [IgxIconService]
+    imports: [CommonModule, HttpClientModule]
 })
-export class IgxIconModule {
-    public static forRoot() {
-        return {
-            ngModule: IgxIconModule,
-            providers: [IgxIconService]
-        };
-    }
-}
+export class IgxIconModule {}
 
 export * from './icon.component';
 export * from './icon.service';

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -149,7 +149,7 @@ const components = [
         FormsModule,
         ReactiveFormsModule,
         HttpClientModule,
-        IgxIconModule.forRoot(),
+        IgxIconModule,
         IgxGridModule.forRoot(),
         IgxTreeGridModule,
         IgxColumnHidingModule,

--- a/src/app/icon/LazyModule/LazyComponent/lazyIcon.sample.css
+++ b/src/app/icon/LazyModule/LazyComponent/lazyIcon.sample.css
@@ -1,0 +1,9 @@
+.sample-icons {
+    display: flex;
+    flex-flow: row wrap;
+}
+
+.sample-icons igx-icon {
+    flex: 1 0 20%;
+    margin-bottom: 72px;
+}

--- a/src/app/icon/LazyModule/LazyComponent/lazyIcon.sample.html
+++ b/src/app/icon/LazyModule/LazyComponent/lazyIcon.sample.html
@@ -1,0 +1,18 @@
+<div class="sample-wrapper">
+    <!-- <app-page-header title="Icons">Allows you to add icons to your application.</app-page-header> -->
+    <section class="sample-content">
+        <article class="sample-column">
+            <h4 class="sample-title">Lazy loaded component with SVG icons</h4>
+            <div class="sample-icons">
+                <igx-icon fontSet="svg-flags" name="contains"></igx-icon>
+                <igx-icon fontSet="svg-flags" name="does_not_contain"></igx-icon>
+                <igx-icon fontSet="svg-flags" name="does_not_equal"></igx-icon>
+                <igx-icon fontSet="svg-flags" name="ends_with"></igx-icon>
+                <igx-icon fontSet="svg-flags" name="equals"></igx-icon>
+                <igx-icon fontSet="svg-flags" name="is_empty"></igx-icon>
+                <igx-icon fontSet="svg-flags" name="starts_with"></igx-icon>
+            </div>
+        </article>
+    </section>
+
+</div>

--- a/src/app/icon/LazyModule/LazyComponent/lazyIcon.sample.ts
+++ b/src/app/icon/LazyModule/LazyComponent/lazyIcon.sample.ts
@@ -1,0 +1,9 @@
+import { Component } from '@angular/core';
+
+@Component({
+    selector: 'app-lazy-icon-sample',
+    styleUrls: ['./lazyIcon.sample.css'],
+    templateUrl: 'lazyIcon.sample.html'
+})
+export class LazyIconSampleComponent {
+}

--- a/src/app/icon/LazyModule/lazyIcon.module.ts
+++ b/src/app/icon/LazyModule/lazyIcon.module.ts
@@ -1,0 +1,15 @@
+import { NgModule } from '@angular/core';
+import { IgxIconModule } from 'igniteui-angular';
+import { LazyIconSampleComponent } from './LazyComponent/lazyIcon.sample';
+import { LazyIconRoutingModule } from './lazyIcon.routing.module';
+
+@NgModule({
+    declarations: [
+        LazyIconSampleComponent
+    ],
+    imports: [
+        IgxIconModule,
+        LazyIconRoutingModule
+    ]
+})
+export class LazyIconModule { }

--- a/src/app/icon/LazyModule/lazyIcon.routing.module.ts
+++ b/src/app/icon/LazyModule/lazyIcon.routing.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { LazyIconSampleComponent } from './LazyComponent/lazyIcon.sample';
+
+const routes: Routes = [
+    {
+        path: '',
+        component: LazyIconSampleComponent
+    }
+];
+
+@NgModule({
+    imports: [RouterModule.forChild(routes)],
+    exports: [RouterModule]
+  })
+  export class LazyIconRoutingModule {}

--- a/src/app/icon/icon.sample.html
+++ b/src/app/icon/icon.sample.html
@@ -90,6 +90,13 @@
                 <igx-icon fontSet="svg-flags" name="starts_with"></igx-icon>
             </div>
         </article>
+
+        <article class="sample-column">
+            <h4 class="sample-title">Lazy loaded module with cached SVG icons</h4>
+            <div class="sample-icons">
+                <button igxButton (click)="router.navigate(['lazyIconModule'])">Lazy load icon module</button>
+            </div>
+        </article>
     </section>
 
 </div>

--- a/src/app/icon/icon.sample.ts
+++ b/src/app/icon/icon.sample.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { IgxIconService } from 'igniteui-angular';
+import { Router } from '@angular/router';
 
 @Component({
     selector: 'app-icon-sample',
@@ -7,7 +8,7 @@ import { IgxIconService } from 'igniteui-angular';
     templateUrl: 'icon.sample.html'
 })
 export class IconSampleComponent implements OnInit {
-    constructor (private _iconService: IgxIconService) {}
+    constructor (public router: Router, private _iconService: IgxIconService) {}
 
     ngOnInit(): void {
         // register custom svg icons

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -120,6 +120,10 @@ const appRoutes = [
         component: IconSampleComponent
     },
     {
+        path: 'lazyIconModule',
+        loadChildren: './icon/LazyModule/lazyIcon.module#LazyIconModule'
+    },
+    {
         path: 'inputs',
         component: InputSampleComponent
     },


### PR DESCRIPTION
Closes #3026

- Provide IgxIconService in root.
- Remove IgxIconModule.forRoot() method.
- Remove deprecated glyphName property of IgxIconComponent.
- Add dev demo demonstrating how svg icons could be used in lazy loaded module.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [x] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [x] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [x] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 