### PR TITLE
Fix - Combo, Drop Down - Fix TAB key navigation - 7.0.x

### DIFF
--- a/projects/igniteui-angular/src/lib/drop-down/drop-down.component.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down.component.ts
@@ -65,10 +65,10 @@ export class IgxDropDownItemNavigationDirective {
             switch (key) {
                 case 'esc':
                 case 'escape':
+                case 'tab':
                     this.onEscapeKeyDown(event);
                     break;
                 case 'enter':
-                case 'tab':
                     this.onEnterKeyDown(event);
                     break;
                 case 'space':


### PR DESCRIPTION
Closes #3200 

Combo and Drop Down `Tab` key handlers were no calling the proper method (`onEnterKeydown` was called instead of `onEscapeKeydown`), causing them to try and make a selection when press `Tab`

### Additional information (check all that apply):
 - [x] Bug fix

### Checklist:
 - [x] All relevant tags have been applied to this PR
 