### PR TITLE
refactor(themes): don't include contrast colors in the palettes

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/base/utilities/_functions.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/base/utilities/_functions.scss
@@ -115,8 +115,9 @@
 /// @param {number|variant} $variant - The target color shade from the color palette.
 /// @returns {Color} [#fff] - Returns white if now palette, color and/or variant matches found.
 @function igx-contrast-color($palette, $color, $variant: 500) {
-    @if map-exists($palette) and map-key-exists($palette, $color) and map-key-exists($color, $variant) {
-        @return map-get(map-get(map-get($palette, $color), 'contrast'), $variant);
+    $_color: igx-color($palette, $color, $variant);
+    @if $_color {
+        @return text-contrast($_color);
     }
     @return #fff;
 }
@@ -241,17 +242,12 @@
 /// @returns {Map} - A map consisting of 14 color variations and 14
 /// text contrast colors for each variation.
 @function generate-palette($color, $saturations) {
-    $shades: ();
-    $contrasts: ();
-
+    $result: ();
     @each $saturation in $saturations {
         $shade: gen-color($color, $saturation);
-        $contrast: text-contrast($shade);
-
-        $shades: map-merge($shades, ($saturation: $shade));
-        $contrasts: map-merge($contrasts, ($saturation: $contrast));
+        $result: map-merge($result, ($saturation: $shade));
     }
-    @return extend($shades, (contrast: $contrasts));
+    @return $result;
 }
 
 /// Generates grayscale color palette from a color.
@@ -265,18 +261,12 @@
 /// @returns {Map} - A map consisting of 10 grayscale color variations and 10
 /// text contrast colors for each variation.
 @function grayscale-palette($color, $shades) {
-    $colors: ();
-    $contrasts: ();
-
+    $result: ();
     @each $saturation, $opacity in $shades {
         $shade: rgba(grayscale($color), $opacity);
-        $contrast: text-contrast(hexrgba($shade));
-
-        $colors: map-merge($colors, ($saturation: $shade));
-        $contrasts: map-merge($contrasts, ($saturation: $contrast));
+        $result: map-merge($result, ($saturation: $shade));
     }
-
-    @return extend($colors, (contrast: $contrasts));
+    @return $result;
 }
 
 /// Generates a color palette.

--- a/projects/igniteui-angular/src/lib/core/styles/themes/_index.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/themes/_index.scss
@@ -48,7 +48,9 @@
 
 /// Generates an Ignite UI for Angular global theme.
 /// @param {Map} $palette - An igx-palette to be used by the global theme.
-/// @param {List} $exclude [()] - A list of igx components to be excluded from the global theme styles.
+/// @param {Map} $schema [$light-schema] - The schema used as basis for styling the components.
+/// @param {List} $exclude [( )] - A list of igx components to be excluded from the global theme styles.
+/// @param {Boolean} $legacy-support - Turn off support for IE11, allowing you to use css variables to style components.
 /// @requires {variable} $components
 /// @requires {variable} $default-palette
 /// @requires {function} is-component
@@ -264,6 +266,10 @@
     }
 }
 
+/// Creates a global theme that can be used with light backgrounds.
+/// @param {Map} $palette - An igx-palette to be used by the global theme.
+/// @param {List} $exclude [( )] - A list of igx components to be excluded from the global theme styles.
+/// @param {Boolean} $legacy-support - Turn off support for IE11, allowing you to use css variables to style components.
 @mixin igx-light-theme(
     $palette,
     $exclude: (),
@@ -280,6 +286,10 @@
     );
 }
 
+/// Creates a global theme that can be used with dark backgrounds.
+/// @param {Map} $palette - An igx-palette to be used by the global theme.
+/// @param {List} $exclude [( )] - A list of igx components to be excluded from the global theme styles.
+/// @param {Boolean} $legacy-support - Turn off support for IE11, allowing you to use css variables to style components.
 @mixin igx-dark-theme(
     $palette,
     $exclude: (),

--- a/projects/igniteui-angular/src/lib/core/styles/themes/_palettes.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/themes/_palettes.scss
@@ -71,4 +71,5 @@ $elevations: igx-elevations(
 
 /// Green palette
 /// @type {Map}
+/// @group palettes
 $green-palette: igx-palette($primary: #09f, $secondary: #72da67) !default;

--- a/projects/igniteui-angular/src/lib/core/styles/themes/schemas/dark/_index.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/themes/schemas/dark/_index.scss
@@ -1,3 +1,8 @@
+////
+/// @group schemas
+/// @access public
+/// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>
+////
 @import './avatar';
 @import './badge';
 @import './banner';

--- a/projects/igniteui-angular/src/lib/core/styles/themes/schemas/light/_index.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/themes/schemas/light/_index.scss
@@ -1,6 +1,6 @@
 ////
 /// @group schemas
-/// @access private
+/// @access public
 /// @author <a href="https://github.com/simeonoff" target="_blank">Simeon Simeonoff</a>
 ////
 


### PR DESCRIPTION
We can still resolve the contrast colors for each color in the palette
'just-in-time'. No need to resolve all contrast colors beforehand.

Closes #  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [x] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [x] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 