### PR TITLE
chore(ng-add): bump Ignite UI CLI version

### DIFF
--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -68,7 +68,7 @@
     "web-animations-js": "^2.3.1"
   },
   "devDependencies": {
-    "igniteui-cli": "~3.1.0"
+    "igniteui-cli": "~3.2.0"
   },
   "ng-update": {
     "migrations": "./migrations/migration-collection.json"


### PR DESCRIPTION
Closes #  

### Additional information (check all that apply):
Bumping dep version used by `ng add` to install the latest Ignite UI CLI version [v3.2.0](https://github.com/IgniteUI/igniteui-cli/releases/tag/v3.2.0). Affects only the add schematic, so it's a contained change.


### Checklist:
 - [x] All relevant tags have been applied to this PR
 