### PR TITLE
#3550 Fixed an issue with the initial validation fix.

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/input/input.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/input/input.directive.spec.ts
@@ -18,7 +18,7 @@ const INPUT_GROUP_REQUIRED_CSS_CLASS = 'igx-input-group--required';
 const INPUT_GROUP_VALID_CSS_CLASS = 'igx-input-group--valid';
 const INPUT_GROUP_INVALID_CSS_CLASS = 'igx-input-group--invalid';
 
-fdescribe('IgxInput', () => {
+describe('IgxInput', () => {
     configureTestSuite();
     beforeEach(async(() => {
         TestBed.configureTestingModule({

--- a/projects/igniteui-angular/src/lib/directives/input/input.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/input/input.directive.spec.ts
@@ -200,21 +200,24 @@ describe('IgxInput', () => {
         const igxInput = fixture.componentInstance.igxInput;
         const inputElement = fixture.debugElement.query(By.directive(IgxInputDirective)).nativeElement;
 
+        const inputGroupElement = fixture.debugElement.query(By.css('igx-input-group')).nativeElement;
+        expect(inputGroupElement.classList.contains(INPUT_GROUP_INVALID_CSS_CLASS)).toBe(false);
+        expect(igxInput.valid).toBe(IgxInputState.INITIAL);
+
         dispatchInputEvent('focus', inputElement, fixture);
         dispatchInputEvent('blur', inputElement, fixture);
 
-        const inputGroupElement = fixture.debugElement.query(By.css('igx-input-group')).nativeElement;
         expect(inputGroupElement.classList.contains(INPUT_GROUP_INVALID_CSS_CLASS)).toBe(true);
         expect(igxInput.valid).toBe(IgxInputState.INVALID);
 
-        igxInput.value = 'test';
+        fixture.componentInstance.value = 'test';
         fixture.detectChanges();
 
         expect(inputGroupElement.classList.contains(INPUT_GROUP_INVALID_CSS_CLASS)).toBe(false);
         expect(igxInput.valid).toBe(IgxInputState.VALID);
 
 
-        igxInput.value = '';
+        fixture.componentInstance.value = '';
         fixture.detectChanges();
 
         dispatchInputEvent('focus', inputElement, fixture);
@@ -386,11 +389,12 @@ class DisabledInputComponent {
 
 @Component({ template: `<igx-input-group #igxInputGroup>
                             <label for="test" igxLabel>Test</label>
-                            <input name="test" #igxInput type="text" igxInput required="required" />
+                            <input name="test" #igxInput type="text" igxInput [value]="value" required="required" />
                         </igx-input-group>` })
 class RequiredInputComponent {
     @ViewChild('igxInputGroup') public igxInputGroup: IgxInputGroupComponent;
     @ViewChild(IgxInputDirective) public igxInput: IgxInputDirective;
+    value = '';
 }
 
 @Component({ template: `<igx-input-group #igxInputGroup>

--- a/projects/igniteui-angular/src/lib/directives/input/input.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/input/input.directive.spec.ts
@@ -18,7 +18,7 @@ const INPUT_GROUP_REQUIRED_CSS_CLASS = 'igx-input-group--required';
 const INPUT_GROUP_VALID_CSS_CLASS = 'igx-input-group--valid';
 const INPUT_GROUP_INVALID_CSS_CLASS = 'igx-input-group--invalid';
 
-describe('IgxInput', () => {
+fdescribe('IgxInput', () => {
     configureTestSuite();
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -201,8 +201,8 @@ describe('IgxInput', () => {
         const inputElement = fixture.debugElement.query(By.directive(IgxInputDirective)).nativeElement;
 
         const inputGroupElement = fixture.debugElement.query(By.css('igx-input-group')).nativeElement;
-        expect(inputGroupElement.classList.contains(INPUT_GROUP_INVALID_CSS_CLASS)).toBe(false);
-        expect(igxInput.valid).toBe(IgxInputState.INITIAL);
+        expect(inputGroupElement.classList.contains(INPUT_GROUP_INVALID_CSS_CLASS)).toBe(true);
+        expect(igxInput.valid).toBe(IgxInputState.INVALID);
 
         dispatchInputEvent('focus', inputElement, fixture);
         dispatchInputEvent('blur', inputElement, fixture);

--- a/projects/igniteui-angular/src/lib/directives/input/input.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/input/input.directive.ts
@@ -28,7 +28,7 @@ export enum IgxInputState {
 @Directive({
     selector: '[igxInput]'
 })
-export class IgxInputDirective implements AfterViewInit, OnChanges, OnDestroy {
+export class IgxInputDirective implements AfterViewInit, OnDestroy {
     private _valid = IgxInputState.INITIAL;
     private _statusChanges$: Subscription;
 
@@ -54,6 +54,7 @@ export class IgxInputDirective implements AfterViewInit, OnChanges, OnDestroy {
     @Input('value')
     set value(value: any) {
         this.nativeElement.value = value;
+        this.checkValidity();
     }
     /**
      * Gets the `value` propery.
@@ -179,14 +180,6 @@ export class IgxInputDirective implements AfterViewInit, OnChanges, OnDestroy {
     /**
      *@hidden
      */
-    ngOnChanges(changes: SimpleChanges) {
-        if (changes.value && !changes.value.firstChange) {
-            this.checkValidity();
-        }
-    }
-    /**
-     *@hidden
-     */
     ngOnDestroy() {
         if (this._statusChanges$) {
             this._statusChanges$.unsubscribe();
@@ -304,7 +297,7 @@ export class IgxInputDirective implements AfterViewInit, OnChanges, OnDestroy {
     }
 
     private checkValidity() {
-        if (!this.ngControl && this._hasValidators) {
+        if (!this.ngControl && this._hasValidators()) {
             this._valid = this.nativeElement.checkValidity() ? IgxInputState.VALID : IgxInputState.INVALID;
         }
     }

--- a/projects/igniteui-angular/src/lib/directives/input/input.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/input/input.directive.ts
@@ -9,7 +9,9 @@ import {
     Input,
     OnDestroy,
     Optional,
-    Self
+    Self,
+    OnChanges,
+    SimpleChanges
 } from '@angular/core';
 import { AbstractControl, FormControlName, NgControl, NgModel } from '@angular/forms';
 import { Subscription } from 'rxjs';
@@ -26,7 +28,7 @@ export enum IgxInputState {
 @Directive({
     selector: '[igxInput]'
 })
-export class IgxInputDirective implements AfterViewInit, OnDestroy {
+export class IgxInputDirective implements AfterViewInit, OnChanges, OnDestroy {
     private _valid = IgxInputState.INITIAL;
     private _statusChanges$: Subscription;
 
@@ -52,7 +54,6 @@ export class IgxInputDirective implements AfterViewInit, OnDestroy {
     @Input('value')
     set value(value: any) {
         this.nativeElement.value = value;
-        this.checkValidity();
     }
     /**
      * Gets the `value` propery.
@@ -174,6 +175,14 @@ export class IgxInputDirective implements AfterViewInit, OnDestroy {
         }
 
         this.cdr.detectChanges();
+    }
+    /**
+     *@hidden
+     */
+    ngOnChanges(changes: SimpleChanges) {
+        if (changes.value && !changes.value.firstChange) {
+            this.checkValidity();
+        }
     }
     /**
      *@hidden


### PR DESCRIPTION
Closes #3550 

Unnecessary valid/invalid styles were applied because _hasValidators was used a property instead of a method.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 