### PR TITLE
Deprecate IgxDropDownItemBase isSelected && isFocused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes for each version of this project will be documented in this 
 ## 7.2.0
 - `igxCombo`
     - **Breaking Change** `combo.value` is now only a getter.
+- `igxDropDown`
+    - `IgxDropDownItemBase` and it's descendants (of which `IgxDropDownItem`) have had their `isSelected` and `isFocused` properties **deprecated**. Instead, use `selected` and `focused` properties.
+
 ## 7.1.2
 ### Features
 - `igx-circular-bar` and `igx-linear-bar` now feature an indeterminate input property. When this property is set to true the indicator will be continually growing and shrinking along the track.

--- a/projects/igniteui-angular/migrations/common/UpdateChanges.spec.ts
+++ b/projects/igniteui-angular/migrations/common/UpdateChanges.spec.ts
@@ -194,19 +194,15 @@ describe('UpdateChanges', () => {
         expect(appTree.readContent('test.component.html')).toEqual(
             `<one [replaceMe]="a"> <comp\r\ntag [replaced]="dwdw"> </other> <another oldProp="b" />`);
 
-        inputJson.changes[1] = {
-            name: 'oldProp', remove: true,
-                    owner: { type: 'component' as any, selector: 'another' }
-        };
-
+        inputJson.changes[1].owner = { type: 'component' as any, selector: 'another' };
         inputJson.changes[0].owner = { type: 'component' as any, selector: 'comp' };
         const fileContent2 =
-        `<comp\r\ntag [replaced]="NOT.replaceMe" ><another oldProp="g" /></comp>`;
+        `<comp\r\ntag [oldProp]="g" [replaceMe]="NOT.replaceMe" ><another oldProp="g" [otherProp]="oldProp" /></comp>`;
         appTree.overwrite('test.component.html', fileContent2);
         const update4 = new UnitUpdateChanges(__dirname, appTree);
         update4.applyChanges();
         expect(appTree.readContent('test.component.html')).toEqual(
-            `<comp\r\ntag [replaced]="NOT.replaceMe" ><another /></comp>`);
+            `<comp\r\ntag [oldProp]="g" [replaced]="NOT.replaceMe" ><another [otherProp]="oldProp" /></comp>`);
         done();
     });
 

--- a/projects/igniteui-angular/migrations/common/UpdateChanges.spec.ts
+++ b/projects/igniteui-angular/migrations/common/UpdateChanges.spec.ts
@@ -193,6 +193,20 @@ describe('UpdateChanges', () => {
         update3.applyChanges();
         expect(appTree.readContent('test.component.html')).toEqual(
             `<one [replaceMe]="a"> <comp\r\ntag [replaced]="dwdw"> </other> <another oldProp="b" />`);
+
+        inputJson.changes[1] = {
+            name: 'oldProp', remove: true,
+                    owner: { type: 'component' as any, selector: 'another' }
+        };
+
+        inputJson.changes[0].owner = { type: 'component' as any, selector: 'comp' };
+        const fileContent2 =
+        `<comp\r\ntag [replaced]="NOT.replaceMe" ><another oldProp="g" /></comp>`;
+        appTree.overwrite('test.component.html', fileContent2);
+        const update4 = new UnitUpdateChanges(__dirname, appTree);
+        update4.applyChanges();
+        expect(appTree.readContent('test.component.html')).toEqual(
+            `<comp\r\ntag [replaced]="NOT.replaceMe" ><another /></comp>`);
         done();
     });
 

--- a/projects/igniteui-angular/migrations/common/UpdateChanges.ts
+++ b/projects/igniteui-angular/migrations/common/UpdateChanges.ts
@@ -201,18 +201,19 @@ export class UpdateChanges {
             let searchPattern;
 
             if (type === BindingType.output) {
-                base = String.raw`\(${change.name}\)`;
-                replace = `(${change.replaceWith})`;
+                base = String.raw`\(${change.name}\)=(["'])`;
+                replace = `(${change.replaceWith})=$1`;
             } else {
-                base = String.raw`(\[?)${change.name}(\]?)`;
-                replace = String.raw`$1${change.replaceWith}$2`;
+                // Match both bound - [name] - and regular - name
+                base = String.raw`(\s\[?)${change.name}(\s*\]?=)(["'])`;
+                replace = String.raw`$1${change.replaceWith}$2$3`;
                 groups = 3;
             }
 
             let reg = new RegExp(base, 'g');
             if (change.remove || change.moveBetweenElementTags) {
                 // Group match (\1) as variable as it looks like octal escape (error in strict)
-                reg = new RegExp(String.raw`\s*${base}=(["']).*?${'\\' + groups}(?=\s|\>)`, 'g');
+                reg = new RegExp(String.raw`\s*${base}.*?${'\\' + groups}(?=\s|\>)`, 'g');
                 replace = '';
             }
             switch (change.owner.type) {

--- a/projects/igniteui-angular/migrations/migration-collection.json
+++ b/projects/igniteui-angular/migrations/migration-collection.json
@@ -35,6 +35,11 @@
             "version": "7.0.2",
             "description": "Updates Ignite UI for Angular from v6.2.1 to v7.0.2",
             "factory": "./update-7_0_2"
+        },
+        "migration-08": {
+            "version": "7.2.0",
+            "description": "Updates Ignite UI for Angular from v7.0.2 to v7.2.0",
+            "factory": "./update-7_2_0"
         }
     }
 }

--- a/projects/igniteui-angular/migrations/update-7_2_0/changes/inputs.json
+++ b/projects/igniteui-angular/migrations/update-7_2_0/changes/inputs.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "../../common/schema/binding.schema.json",
+    "changes": [
+        {
+            "name": "isSelected",
+            "replaceWith": "selected",
+            "owner": {
+                "selector": "igx-drop-down-item",
+                "type": "component"
+            }
+        },
+        {
+            "name": "isFocused",
+            "replaceWith": "focused",
+            "owner": {
+                "selector": "igx-drop-down-item",
+                "type": "component"
+            }
+        }
+    ]
+}

--- a/projects/igniteui-angular/migrations/update-7_2_0/index.spec.ts
+++ b/projects/igniteui-angular/migrations/update-7_2_0/index.spec.ts
@@ -27,64 +27,6 @@ describe('Update 7.2.0', () => {
         appTree.create('/angular.json', JSON.stringify(configJson));
     });
 
-    it(`should replace bound 'isSelected' and 'isFocused'`, done => {
-        appTree.create(
-            '/testSrc/appPrefix/component/custom.component.html',
-            `<igx-drop-down #myDropDown>
-                <igx-drop-down-item *ngFor="let item of items"
-                    [value]="item.value"
-                    [isSelected]="item.isSelected"
-                    [isFocused]="item.isFocused"
-                    [isHeader]="item.thisPropertyIsNOTisSelectedORisFocused"
-                >Selected: {{ item.isSelected }}, Focused {{ item.isFocused }}
-                </igx-drop-down-item>
-            </igx-drop-down>`);
-
-        const tree = schematicRunner.runSchematic('migration-08', {}, appTree);
-        expect(tree.readContent('/testSrc/appPrefix/component/custom.component.html'))
-            .toEqual(
-                `<igx-drop-down #myDropDown>
-                <igx-drop-down-item *ngFor="let item of items"
-                    [value]="item.value"
-                    [selected]="item.isSelected"
-                    [focused]="item.isFocused"
-                    [isHeader]="item.thisPropertyIsNOTisSelectedORisFocused"
-                >Selected: {{ item.isSelected }}, Focused {{ item.isFocused }}
-                </igx-drop-down-item>
-            </igx-drop-down>`);
-
-        done();
-    });
-
-    it(`should replace 'isSelected' and 'isFocused'`, done => {
-        appTree.create(
-            '/testSrc/appPrefix/component/custom.component.html',
-            `<igx-drop-down #myDropDown>
-                <igx-drop-down-item *ngFor="let item of items"
-                    [value]="item.value"
-                    isSelected="true"
-                    isFocused="true"
-                    [isHeader]="item.thisPropertyIsNOTisSelectedORisFocused"
-                >Selected: {{ item.isSelected }}, Focused {{ item.isFocused }}
-                </igx-drop-down-item>
-            </igx-drop-down>`);
-
-        const tree = schematicRunner.runSchematic('migration-08', {}, appTree);
-        expect(tree.readContent('/testSrc/appPrefix/component/custom.component.html'))
-            .toEqual(
-                `<igx-drop-down #myDropDown>
-                <igx-drop-down-item *ngFor="let item of items"
-                    [value]="item.value"
-                    selected="true"
-                    focused="true"
-                    [isHeader]="item.thisPropertyIsNOTisSelectedORisFocused"
-                >Selected: {{ item.isSelected }}, Focused {{ item.isFocused }}
-                </igx-drop-down-item>
-            </igx-drop-down>`);
-
-        done();
-    });
-
     it(`should replace **ONLY** 'isSelected' and 'isFocused'`, done => {
         appTree.create(
             '/testSrc/appPrefix/component/custom.component.html',

--- a/projects/igniteui-angular/migrations/update-7_2_0/index.spec.ts
+++ b/projects/igniteui-angular/migrations/update-7_2_0/index.spec.ts
@@ -1,0 +1,144 @@
+import * as path from 'path';
+
+// tslint:disable:no-implicit-dependencies
+import { EmptyTree } from '@angular-devkit/schematics';
+// tslint:disable-next-line:no-submodule-imports
+import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
+
+describe('Update 7.2.0', () => {
+    let appTree: UnitTestTree;
+    const schematicRunner = new SchematicTestRunner('ig-migrate', path.join(__dirname, '../migration-collection.json'));
+    const configJson = {
+        defaultProject: 'testProj',
+        projects: {
+            testProj: {
+                sourceRoot: '/testSrc'
+            }
+        },
+        schematics: {
+            '@schematics/angular:component': {
+                prefix: 'appPrefix'
+            }
+        }
+    };
+
+    beforeEach(() => {
+        appTree = new UnitTestTree(new EmptyTree());
+        appTree.create('/angular.json', JSON.stringify(configJson));
+    });
+
+    it(`should replace bound 'isSelected' and 'isFocused'`, done => {
+        appTree.create(
+            '/testSrc/appPrefix/component/custom.component.html',
+            `<igx-drop-down #myDropDown>
+                <igx-drop-down-item *ngFor="let item of items"
+                    [value]="item.value"
+                    [isSelected]="item.isSelected"
+                    [isFocused]="item.isFocused"
+                    [isHeader]="item.thisPropertyIsNOTisSelectedORisFocused"
+                >Selected: {{ item.isSelected }}, Focused {{ item.isFocused }}
+                </igx-drop-down-item>
+            </igx-drop-down>`);
+
+        const tree = schematicRunner.runSchematic('migration-08', {}, appTree);
+        expect(tree.readContent('/testSrc/appPrefix/component/custom.component.html'))
+            .toEqual(
+                `<igx-drop-down #myDropDown>
+                <igx-drop-down-item *ngFor="let item of items"
+                    [value]="item.value"
+                    [selected]="item.isSelected"
+                    [focused]="item.isFocused"
+                    [isHeader]="item.thisPropertyIsNOTisSelectedORisFocused"
+                >Selected: {{ item.isSelected }}, Focused {{ item.isFocused }}
+                </igx-drop-down-item>
+            </igx-drop-down>`);
+
+        done();
+    });
+
+    it(`should replace 'isSelected' and 'isFocused'`, done => {
+        appTree.create(
+            '/testSrc/appPrefix/component/custom.component.html',
+            `<igx-drop-down #myDropDown>
+                <igx-drop-down-item *ngFor="let item of items"
+                    [value]="item.value"
+                    isSelected="true"
+                    isFocused="true"
+                    [isHeader]="item.thisPropertyIsNOTisSelectedORisFocused"
+                >Selected: {{ item.isSelected }}, Focused {{ item.isFocused }}
+                </igx-drop-down-item>
+            </igx-drop-down>`);
+
+        const tree = schematicRunner.runSchematic('migration-08', {}, appTree);
+        expect(tree.readContent('/testSrc/appPrefix/component/custom.component.html'))
+            .toEqual(
+                `<igx-drop-down #myDropDown>
+                <igx-drop-down-item *ngFor="let item of items"
+                    [value]="item.value"
+                    selected="true"
+                    focused="true"
+                    [isHeader]="item.thisPropertyIsNOTisSelectedORisFocused"
+                >Selected: {{ item.isSelected }}, Focused {{ item.isFocused }}
+                </igx-drop-down-item>
+            </igx-drop-down>`);
+
+        done();
+    });
+
+    it(`should replace **ONLY** 'isSelected' and 'isFocused'`, done => {
+        appTree.create(
+            '/testSrc/appPrefix/component/custom.component.html',
+            `<igx-drop-down #myDropDown>
+                <igx-drop-down-item
+                    isSelected="something"
+                    isFocused="isSelected"
+                >1
+                </igx-drop-down-item>
+                <igx-drop-down-item
+                    [isSelected]="something2"
+                    [isFocused]="isFocused == 2"
+                >2
+                </igx-drop-down-item>
+                <igx-drop-down-item
+                    [ isSelected ]="something3"
+                    [ isFocused ]=" isFocused === '7'"
+                >3
+                </igx-drop-down-item>
+                <igx-drop-down-item
+                    [isSelected]="something3"
+                    [isFocused]="isFocused === '7'"
+                    myCustomDirective [myCustomItem_isSelected]="true"
+                >4
+                </igx-drop-down-item>
+            </igx-drop-down>`);
+
+        const tree = schematicRunner.runSchematic('migration-08', {}, appTree);
+        expect(tree.readContent('/testSrc/appPrefix/component/custom.component.html'))
+            .toEqual(
+            `<igx-drop-down #myDropDown>
+                <igx-drop-down-item
+                    selected="something"
+                    focused="isSelected"
+                >1
+                </igx-drop-down-item>
+                <igx-drop-down-item
+                    [selected]="something2"
+                    [focused]="isFocused == 2"
+                >2
+                </igx-drop-down-item>
+                <igx-drop-down-item
+                    [ selected ]="something3"
+                    [ focused ]=" isFocused === '7'"
+                >3
+                </igx-drop-down-item>
+                <igx-drop-down-item
+                    [selected]="something3"
+                    [focused]="isFocused === '7'"
+                    myCustomDirective [myCustomItem_isSelected]="true"
+                >4
+                </igx-drop-down-item>
+            </igx-drop-down>`);
+
+        done();
+    });
+});

--- a/projects/igniteui-angular/migrations/update-7_2_0/index.ts
+++ b/projects/igniteui-angular/migrations/update-7_2_0/index.ts
@@ -1,0 +1,17 @@
+import {
+    Rule,
+    SchematicContext,
+    Tree
+} from '@angular-devkit/schematics';
+import { UpdateChanges } from '../common/UpdateChanges';
+
+const version = '7.2.0';
+export default function (): Rule {
+    return (host: Tree, context: SchematicContext) => {
+        context.logger.info(`Applying migration for Ignite UI for Angular to version ${version}`);
+
+        const update = new UpdateChanges(__dirname, host, context);
+        update.applyChanges();
+    };
+}
+

--- a/projects/igniteui-angular/src/lib/combo/combo-add-item.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo-add-item.component.ts
@@ -7,10 +7,10 @@ import { Component } from '@angular/core';
     providers: [{ provide: IgxComboItemComponent, useExisting: IgxComboAddItemComponent}]
 })
 export class IgxComboAddItemComponent extends IgxComboItemComponent {
-    get isSelected(): boolean {
+    get selected(): boolean {
         return false;
     }
-    set isSelected(value: boolean) {
+    set selected(value: boolean) {
     }
 
     clicked(event?) {

--- a/projects/igniteui-angular/src/lib/combo/combo-dropdown.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo-dropdown.component.ts
@@ -277,7 +277,7 @@ export class IgxComboDropDownComponent extends IgxDropDownComponent implements I
     private focusComboSearch() {
         this.combo.focusSearchInput(false);
         if (this.focusedItem) {
-            this.focusedItem.isFocused = false;
+            this.focusedItem.focused = false;
         }
         this.focusedItem = null;
     }

--- a/projects/igniteui-angular/src/lib/combo/combo-item.component.html
+++ b/projects/igniteui-angular/src/lib/combo/combo-item.component.html
@@ -1,4 +1,4 @@
 <ng-container *ngIf="!isHeader">
-    <igx-checkbox [checked]="isSelected" disableRipple="true" [disableTransitions]="disableTransitions" disabled="true" class="igx-combo__checkbox"></igx-checkbox>
+    <igx-checkbox [checked]="selected" disableRipple="true" [disableTransitions]="disableTransitions" disabled="true" class="igx-combo__checkbox"></igx-checkbox>
 </ng-container>
 <ng-content></ng-content>

--- a/projects/igniteui-angular/src/lib/combo/combo-item.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo-item.component.ts
@@ -62,11 +62,11 @@ export class IgxComboItemComponent extends IgxDropDownItemComponent implements D
     /**
      * @hidden
      */
-    get isSelected(): boolean {
+    get selected(): boolean {
         return this.comboAPI.is_item_selected(this.itemID);
     }
 
-    set isSelected(value: boolean) {
+    set selected(value: boolean) {
         if (this.isHeader) {
             return;
         }
@@ -77,7 +77,7 @@ export class IgxComboItemComponent extends IgxDropDownItemComponent implements D
     clicked(event) {
         this.comboAPI.disableTransitions = false;
         if (this.disabled || this.isHeader) {
-            const focusedItem = this.dropDown.items.find((item) => item.isFocused);
+            const focusedItem = this.dropDown.items.find((item) => item.focused);
             if (this.dropDown.allowItemsFocus && focusedItem) {
                 focusedItem.element.nativeElement.focus({ preventScroll: true });
             }

--- a/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
@@ -404,7 +404,7 @@ describe('igxCombo', () => {
             expect(dropdown.items.length).toBeTruthy();
             dropdown.onFocus();
             expect(dropdown.focusedItem).toEqual(dropdown.items[0]);
-            expect(dropdown.focusedItem.isFocused).toEqual(true);
+            expect(dropdown.focusedItem.focused).toEqual(true);
             dropdown.onFocus();
             dropdown.onBlur();
             expect(dropdown.focusedItem).toEqual(null);

--- a/projects/igniteui-angular/src/lib/drop-down/README.md
+++ b/projects/igniteui-angular/src/lib/drop-down/README.md
@@ -82,10 +82,10 @@ The following inputs are available in the **igx-drop-down-item** component:
 
 | Name | Type | Description |
 | :--- | :--- | :--- |
-| `isSelected` | boolean| Defines if the item is the selected item. Only one item can be selected at time. |
+| `selected` | boolean| Defines if the item is the selected item. Only one item can be selected at time. |
 | `isHeader` | boolean| Defines if the item is a group header. |
 | `disabled` | boolean| Disables the given item. |
-| `isFocused` | boolean| Defines if the given item is focused. |
+| `focused` | boolean| Defines if the given item is focused. |
 | `value` | any | The value of the drop-down item. |
 
 #### Getters

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down-item.base.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down-item.base.ts
@@ -79,17 +79,14 @@ export abstract class IgxDropDownItemBase implements DoCheck {
     @DeprecateProperty(`IgxDropDownItemBase \`isSelected\` property is depracated.\n` +
         `Use \`selected\` instead.`)
     get isSelected(): boolean {
-        return this._isSelected;
+        return this.selected;
     }
 
     /**
      * @hidden
      */
     set isSelected(value: boolean) {
-        if (this.isHeader) {
-            return;
-        }
-        this._isSelected = value;
+        this.selected = value;
     }
 
     /**

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down-item.base.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down-item.base.ts
@@ -130,13 +130,13 @@ export abstract class IgxDropDownItemBase implements DoCheck {
     @DeprecateProperty(`IgxDropDownItemBase \`isFocused\` property is depracated.\n` +
         `Use \`focused\` instead.`)
     get isFocused(): boolean {
-        return (!this.isHeader && !this.disabled) && this._isFocused;
+        return this.focused;
     }
     /**
      * @hidden
      */
     set isFocused(value: boolean) {
-        this._isFocused = value;
+        this.focused = value;
     }
 
     /**

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down-item.base.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down-item.base.ts
@@ -1,6 +1,7 @@
 import { IDropDownBase, IGX_DROPDOWN_BASE } from './drop-down.common';
 import { Input, HostBinding, HostListener, ElementRef, Optional, Inject, DoCheck } from '@angular/core';
 import { IgxSelectionAPIService } from '../core/selection';
+import { DeprecateProperty } from '../core/deprecateDecorators';
 
 /**
  * An abstract class defining a drop-down item:
@@ -56,14 +57,34 @@ export abstract class IgxDropDownItemBase implements DoCheck {
      *
      * ```typescript
      *  let mySelectedItem = this.dropdown.selectedItem;
-     *  let isMyItemSelected = mySelectedItem.isSelected; // true
+     *  let isMyItemSelected = mySelectedItem.selected; // true
      * ```
      */
     @Input()
+    get selected(): boolean {
+        return this._isSelected;
+    }
+
+    set selected(value: boolean) {
+        if (this.isHeader) {
+            return;
+        }
+        this._isSelected = value;
+    }
+
+    /**
+     * @hidden
+     */
+    @Input()
+    @DeprecateProperty(`IgxDropDownItemBase \`isSelected\` property is depracated.\n` +
+        `Use \`selected\` instead.`)
     get isSelected(): boolean {
         return this._isSelected;
     }
 
+    /**
+     * @hidden
+     */
     set isSelected(value: boolean) {
         if (this.isHeader) {
             return;
@@ -77,7 +98,7 @@ export abstract class IgxDropDownItemBase implements DoCheck {
     @HostBinding('attr.aria-selected')
     @HostBinding('class.igx-drop-down__item--selected')
     get selectedStyle(): boolean {
-        return this.isSelected;
+        return this.selected;
     }
 
     /**
@@ -88,7 +109,7 @@ export abstract class IgxDropDownItemBase implements DoCheck {
      * ```
      */
     @HostBinding('class.igx-drop-down__item--focused')
-    get isFocused(): boolean {
+    get focused(): boolean {
         return (!this.isHeader && !this.disabled) && this._isFocused;
     }
 
@@ -100,6 +121,22 @@ export abstract class IgxDropDownItemBase implements DoCheck {
      *      </div>
      *  </igx-drop-down-item>
      * ```
+     */
+    set focused(value: boolean) {
+        this._isFocused = value;
+    }
+
+    /**
+     * @hidden
+     */
+    @HostBinding('class.igx-drop-down__item--focused')
+    @DeprecateProperty(`IgxDropDownItemBase \`isFocused\` property is depracated.\n` +
+        `Use \`focused\` instead.`)
+    get isFocused(): boolean {
+        return (!this.isHeader && !this.disabled) && this._isFocused;
+    }
+    /**
+     * @hidden
      */
     set isFocused(value: boolean) {
         this._isFocused = value;
@@ -185,7 +222,7 @@ export abstract class IgxDropDownItemBase implements DoCheck {
     }
 
     ngDoCheck(): void {
-        if (this.isSelected) {
+        if (this.selected) {
             const dropDownSelectedItem = this.selection.first_item(this.dropDown.id);
             if (!dropDownSelectedItem || this !== dropDownSelectedItem) {
                 this.dropDown.selectItem(this);

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down-item.component.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down-item.component.ts
@@ -35,7 +35,7 @@ export class IgxDropDownItemComponent extends IgxDropDownItemBase implements DoC
     @HostListener('click', ['$event'])
     clicked(event) {
         if (this.disabled || this.isHeader) {
-            const focusedItem = this.dropDown.items.find((item) => item.isFocused);
+            const focusedItem = this.dropDown.items.find((item) => item.focused);
             if (this.dropDown.allowItemsFocus && focusedItem) {
                 focusedItem.element.nativeElement.focus({ preventScroll: true });
             }

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down.component.spec.ts
@@ -587,21 +587,21 @@ describe('IgxDropDown ', () => {
             tick();
 
             fixture.detectChanges();
-            expect(listItems[0].isSelected).toBeTruthy();
+            expect(listItems[0].selected).toBeTruthy();
             currentItem = fixture.debugElement.query(By.css('.' + CSS_CLASS_SELECTED));
             expect(currentItem.componentInstance.index).toEqual(0);
             list.setSelectedItem(24);
             tick();
 
             fixture.detectChanges();
-            expect(listItems[0].isSelected).toBeTruthy();
+            expect(listItems[0].selected).toBeTruthy();
             currentItem = fixture.debugElement.query(By.css('.' + CSS_CLASS_SELECTED));
             expect(currentItem.componentInstance.index).toEqual(0);
             list.setSelectedItem(5);
             tick();
 
             fixture.detectChanges();
-            expect(listItems[5].isSelected).toBeTruthy();
+            expect(listItems[5].selected).toBeTruthy();
             currentItem = fixture.debugElement.query(By.css('.' + CSS_CLASS_SELECTED));
             expect(currentItem.componentInstance.index).toEqual(5);
             // TODO: verify selecting the already selected element is not affecting selection
@@ -609,7 +609,7 @@ describe('IgxDropDown ', () => {
             tick();
 
             fixture.detectChanges();
-            expect(listItems[5].isSelected).toBeTruthy();
+            expect(listItems[5].selected).toBeTruthy();
             currentItem = fixture.debugElement.query(By.css('.' + CSS_CLASS_SELECTED));
             expect(currentItem.componentInstance.index).toEqual(5);
         }));
@@ -636,7 +636,7 @@ describe('IgxDropDown ', () => {
             tick();
 
             fixture.detectChanges();
-            expect(listItems[1].isFocused).toBeTruthy();
+            expect(listItems[1].focused).toBeTruthy();
             currentItem = fixture.debugElement.query(By.css('.' + CSS_CLASS_FOCUSED));
             expect(currentItem.componentInstance.index).toEqual(1);
         }));
@@ -662,12 +662,12 @@ describe('IgxDropDown ', () => {
 
             fixture.detectChanges();
             let currentItem: DebugElement = fixture.debugElement.query(By.css('.' + CSS_CLASS_SELECTED));
-            expect(list.items[8].isSelected).toBeTruthy();
+            expect(list.items[8].selected).toBeTruthy();
             currentItem.triggerEventHandler('keydown', mockObj);
             tick();
 
             fixture.detectChanges();
-            expect(listItems[11].isFocused).toBeTruthy();
+            expect(listItems[11].focused).toBeTruthy();
             currentItem = fixture.debugElement.query(By.css('.' + CSS_CLASS_FOCUSED));
             expect(currentItem.componentInstance.index).toEqual(11);
             mockObj.key = 'ArrowDown';
@@ -676,7 +676,7 @@ describe('IgxDropDown ', () => {
             tick();
 
             fixture.detectChanges();
-            expect(listItems[11].isFocused).toBeTruthy();
+            expect(listItems[11].focused).toBeTruthy();
             currentItem = fixture.debugElement.query(By.css('.' + CSS_CLASS_FOCUSED));
             expect(currentItem.componentInstance.index).toEqual(11);
         }));
@@ -706,7 +706,7 @@ describe('IgxDropDown ', () => {
             tick();
 
             fixture.detectChanges();
-            expect(list.items[10].isFocused).toBeTruthy();
+            expect(list.items[10].focused).toBeTruthy();
             currentItem = fixture.debugElement.queryAll(By.css('.igx-drop-down__item'))[0];
             mockObj.key = 'ArrowUp';
             mockObj.code = 'ArrowUp';
@@ -714,7 +714,7 @@ describe('IgxDropDown ', () => {
             tick();
 
             fixture.detectChanges();
-            expect(listItems[8].isFocused).toBeTruthy();
+            expect(listItems[8].focused).toBeTruthy();
             currentItem = fixture.debugElement.query(By.css('.' + CSS_CLASS_FOCUSED));
             expect(currentItem.componentInstance.index).toEqual(8);
         }));
@@ -746,12 +746,12 @@ describe('IgxDropDown ', () => {
             const list = fixture.componentInstance.dropdownDisabled;
             expect(list).toBeDefined();
             expect(list.items.length).toEqual(13);
-            list.items[0].isFocused = true;
+            list.items[0].focused = true;
             button.click();
             tick();
 
             fixture.detectChanges();
-            expect(list.items[0].isFocused).toEqual(false);
+            expect(list.items[0].focused).toEqual(false);
         }));
 
         it('Disabled items can be set selected via code behind', fakeAsync(() => {
@@ -766,7 +766,7 @@ describe('IgxDropDown ', () => {
             tick();
 
             fixture.detectChanges();
-            expect(list.items[0].isSelected).toBeTruthy();
+            expect(list.items[0].selected).toBeTruthy();
             button.click();
         }));
 
@@ -789,7 +789,7 @@ describe('IgxDropDown ', () => {
             tick();
 
             fixture.detectChanges();
-            expect(list.items[8].isFocused).toEqual(true);
+            expect(list.items[8].focused).toEqual(true);
             const currentItem = fixture.debugElement.query(By.css('.' + CSS_CLASS_SELECTED));
             mockObj.code = 'ArrowDown';
             mockObj.key = 'ArrowDown';
@@ -797,20 +797,20 @@ describe('IgxDropDown ', () => {
             tick();
 
             fixture.detectChanges();
-            expect(list.items[10].isFocused).toEqual(true);
+            expect(list.items[10].focused).toEqual(true);
             const firstItem = list.items[0].element.nativeElement;
             firstItem.click({});
             tick();
 
             fixture.detectChanges();
-            expect(list.items[10].isFocused).toEqual(true);
+            expect(list.items[10].focused).toEqual(true);
             mockObj.code = 'ArrowDown';
             mockObj.key = 'ArrowDown';
             currentItem.triggerEventHandler('keydown', mockObj);
             tick();
 
             fixture.detectChanges();
-            expect(list.items[11].isFocused).toEqual(true);
+            expect(list.items[11].focused).toEqual(true);
         }));
 
         it('Should select item and close on Enter keydown', fakeAsync(() => {
@@ -1122,19 +1122,19 @@ describe('IgxDropDown ', () => {
             fixture.detectChanges();
             expect(componentInstance.dropdown.selectedItem).toBeNull();
             const items = componentInstance.dropdown.items as IgxDropDownItemComponent[];
-            items[2].isSelected = true;
+            items[2].selected = true;
             tick();
             fixture.detectChanges();
 
-            expect(items[2].isSelected).toBeTruthy();
+            expect(items[2].selected).toBeTruthy();
             expect(componentInstance.dropdown.selectedItem.index).toEqual(2);
 
-            items[1].isSelected = true;
+            items[1].selected = true;
             tick();
             fixture.detectChanges();
 
-            expect(items[2].isSelected).toBeFalsy();
-            expect(items[1].isSelected).toBeTruthy();
+            expect(items[2].selected).toBeFalsy();
+            expect(items[1].selected).toBeTruthy();
             expect(componentInstance.dropdown.selectedItem.index).toEqual(1);
 
             button.click();
@@ -1158,24 +1158,24 @@ describe('IgxDropDown ', () => {
             const headerItems = componentInstance.dropdownDisabledAny.headers as IgxDropDownItemComponent[];
 
             // try to select header item
-            headerItems[0].isSelected = true;
+            headerItems[0].selected = true;
             tick();
             fixture.detectChanges();
 
-            expect(headerItems[0].isSelected).toBeFalsy();
+            expect(headerItems[0].selected).toBeFalsy();
             expect(componentInstance.dropdownDisabledAny.selectedItem).toBeNull();
 
             // try to select disabled item
-            items[2].isSelected = true;
+            items[2].selected = true;
             tick();
             fixture.detectChanges();
 
-            expect(items[2].isSelected).toBeTruthy();
+            expect(items[2].selected).toBeTruthy();
             expect(componentInstance.dropdownDisabledAny.selectedItem.index).toEqual(2);
 
             // try to select header item
-            headerItems[1].isSelected = true;
-            expect(headerItems[1].isSelected).toBeFalsy();
+            headerItems[1].selected = true;
+            expect(headerItems[1].selected).toBeFalsy();
             expect(componentInstance.dropdownDisabledAny.selectedItem.index).toEqual(2);
 
             button.click();
@@ -1373,7 +1373,7 @@ class IgxDropDownTestDisabledAnyComponent {
     <button (click)="selectItem5()">Select 5</button>
     <igx-drop-down #dropdownDisabled>
         <igx-drop-down-item [igxDropDownItemNavigation]="dropdownDisabled" *ngFor="let item of items"
-        [disabled]="item.disabled" [isHeader]="item.header" [isSelected]="item.selected">
+        [disabled]="item.disabled" [isHeader]="item.header" [selected]="item.selected">
             {{ item.field }}
         </igx-drop-down-item>
     </igx-drop-down>

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down.component.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down.component.ts
@@ -135,10 +135,10 @@ export class IgxDropDownComponent extends IgxDropDownBase implements IDropDownBa
      * let currentItem = this.dropdown.selectedItem;
      * ```
      */
-    public get selectedItem(): any {
+    public get selectedItem(): IgxDropDownItemBase {
         const selectedItem = this.selection.first_item(this.id);
         if (selectedItem) {
-            if (selectedItem.isSelected) {
+            if (selectedItem.selected) {
                 return selectedItem;
             }
             this.selection.clear(this.id);
@@ -352,10 +352,10 @@ export class IgxDropDownComponent extends IgxDropDownBase implements IDropDownBa
         if (!args.cancel) {
             this.selection.set(this.id, new Set([newSelection]));
             if (oldSelection) {
-                oldSelection.isSelected = false;
+                oldSelection.selected = false;
             }
             if (newSelection) {
-                newSelection.isSelected = true;
+                newSelection.selected = true;
             }
             if (event) {
                 this.toggleDirective.close();

--- a/src/app/drop-down/drop-down.sample.html
+++ b/src/app/drop-down/drop-down.sample.html
@@ -5,7 +5,7 @@
             dropdown</button>
         <igx-drop-down #dropdown1 (onSelection)="onSelection($event)" (onOpening)="onOpening($event)">
             <igx-drop-down-item *ngFor="let item of items" [disabled]="item.disabled" [isHeader]="item.header"
-                [isSelected]="item.selected">
+                [selected]="item.selected">
                 <div class="igx-drop-down__item-template">
                     {{ item.field }}
                 </div>


### PR DESCRIPTION
Closes #3612  

Rename `isSelected` and `isFocused` accessors. Add `selected` and `focused` accessors (with the same functionality)
 
### Additional information (check all that apply):
 - [x] Refactor

### Checklist:
 - [x] All relevant tags have been applied to this PR
 