### PR TITLE
Using separate element in grid for vertical scrolling and adding scroll thumb elements in header/footer areas.

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-component.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-component.scss
@@ -24,6 +24,10 @@
         }
     }
 
+    @include e(thead-container) {
+        @extend %grid-thead-container !optional;
+    }
+
     @include e(thead-title) {
         @extend %grid-cell-display !optional;
         @extend %grid-cell-header !optional;
@@ -50,6 +54,10 @@
         @extend %grid-tbody !optional;
     }
 
+    @include e(tbody-container) {
+        @extend %grid-tbody-container !optional;
+    }
+
     @include e(tbody-message) {
         @extend %grid-tbody-message !optional;
     }
@@ -64,6 +72,10 @@
 
     @include e(scroll-main) {
         @extend %grid-scroll-main !optional;
+    }
+
+    @include e(scroll-thumb) {
+        @extend %grid-scroll-thumb !optional;
     }
 
     @include e(tfoot) {
@@ -391,7 +403,7 @@
 
         @include e(thead-title) {
             @extend %grid-thead-title--cosy !optional;
-        }
+        }        
 
         @include e(th-title) {
             @extend %grid-cell-header-title--cosy !optional;

--- a/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
@@ -527,7 +527,6 @@
     }
 
     %grid-thead {
-        grid-row: 3;
         border-bottom: $grid-header-border;
         z-index: 2;
 
@@ -545,6 +544,11 @@
         %grid-row:last-of-type {
             border-bottom: none;
         }
+    }
+
+    %grid-thead-container {
+        grid-row: 3;
+        display: flex;
     }
 
     %grid-thead--cosy {
@@ -617,11 +621,14 @@
 
     %grid-tbody {
         position: relative;
-        grid-row: 4;
         background: --var($theme, 'content-background');
         color: --var($theme, 'content-text-color');
         overflow: hidden;
         z-index: 1;
+    }
+    %grid-tbody-container {
+        display: flex;
+        grid-row: 4;
     }
 
     %grid-tbody-message {
@@ -639,6 +646,11 @@
         width: 100%;
         background: --var($theme, 'header-background');
         z-index: 10001;
+    }
+
+    %grid-scroll-thumb {
+        display: inline-flex;
+        background: --var($theme, 'header-background');
     }
 
     %grid-scroll-start {
@@ -1064,7 +1076,8 @@
     }
 
     %grid-summaries {
-        display: flex;
+        overflow: hidden;
+        display: inline-flex;
         background: --var($theme, 'root-summaries-background');
 
         // %igx-grid-summary__label,
@@ -1387,7 +1400,7 @@
         padding-left: map-get($grid-grouping-indicator-padding, 'compact');
     }
 
-    %igx-grid__grouparea {
+    %igx-grid__grouparea {        
         grid-row: 2;
         display: flex;
         align-items: center;

--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
@@ -278,7 +278,8 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
         if (this.igxForScrollOrientation === 'vertical') {
             this.dc.instance._viewContainer.element.nativeElement.style.top = '0px';
             const factory: ComponentFactory<VirtualHelperComponent> = this.resolver.resolveComponentFactory(VirtualHelperComponent);
-            this.vh = this._viewContainer.createComponent(factory, 1);
+            this.vh = vc.createComponent(factory);
+
             this._maxHeight = this._calcMaxBrowserHeight();
             this.vh.instance.height = this.igxForOf ? this._calcHeight() : 0;
             this._zone.runOutsideAngular(() => {

--- a/projects/igniteui-angular/src/lib/grids/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/column.component.ts
@@ -1219,9 +1219,7 @@ export class IgxColumnComponent implements AfterContentInit {
             const unpinnedColumns = this.grid.unpinnedColumns;
             const isLastUnpinned = unpinnedColumns[unpinnedColumns.length - 1] === this;
 
-            let cellWidth = isLastUnpinned && hasVerticalScroll &&
-            (this.grid.unpinnedWidth - this.grid.totalWidth < 0) ?
-                parseInt(colWidth, 10) - 18 + '' : colWidth;
+            let cellWidth = colWidth;
 
             if (typeof cellWidth !== 'string' || cellWidth.endsWith('px') === false) {
                 cellWidth += 'px';

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -3666,7 +3666,6 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
     protected getGroupAreaHeight(): number {
         return 0;
     }
-
     /**
      * @hidden
      */
@@ -3685,6 +3684,9 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
             this.scr.nativeElement.clientHeight);
     }
 
+    public get headerHeight() {
+       return this.theadRow ? this.theadRow.nativeElement.clientHeight : 0;
+    }
     /**
      * @hidden
      */

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -1447,6 +1447,12 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
     @ViewChild('verticalScrollContainer', { read: IgxGridForOfDirective })
     public verticalScrollContainer: IgxGridForOfDirective<any>;
 
+        /**
+     * @hidden
+     */
+    @ViewChild('verticalScrollHolder', { read: IgxGridForOfDirective })
+    public verticalScroll: IgxGridForOfDirective<any>;
+
     /**
      * @hidden
      */
@@ -3685,7 +3691,9 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
     protected getPossibleColumnWidth() {
         let computedWidth = parseInt(
             this.document.defaultView.getComputedStyle(this.nativeElement).getPropertyValue('width'), 10);
-
+        if (this.hasVerticalSroll()) {
+            computedWidth -= 18;
+        }
         if (this.showRowCheckboxes) {
             computedWidth -= this.headerCheckboxContainer.nativeElement.clientWidth;
         }
@@ -3738,10 +3746,19 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
             width = this.columnList.reduce((sum, item) =>  sum + parseInt((item.width || item.defaultWidth), 10), 0);
         }
 
+        if (this.hasVerticalSroll()) {
+            width -= 18;
+        }
         if (Number.isFinite(width) && width !== this.calcWidth) {
             this.calcWidth = width;
             this.cdr.markForCheck();
         }
+    }
+
+    public hasVerticalSroll() {
+        return this.verticalScrollContainer.igxForOf &&
+        this.verticalScrollContainer.igxForOf.length > 0 &&
+        !this.verticalScrollContainer.dc.instance.notVirtual;
     }
 
     /**
@@ -3793,9 +3810,12 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
      * @memberof IgxGridBaseComponent
      */
     protected getUnpinnedWidth(takeHidden = false) {
-        const width = this._width && this._width.indexOf('%') !== -1 ?
+        let width = this._width && this._width.indexOf('%') !== -1 ?
             this.calcWidth :
             parseInt(this._width, 10);
+            if (this.hasVerticalSroll()) {
+                width -= 18;
+            }
         return width - this.getPinnedWidth(takeHidden);
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -3687,6 +3687,10 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
     public get headerHeight() {
        return this.theadRow ? this.theadRow.nativeElement.clientHeight : 0;
     }
+
+    public get outerWidth() {
+        return this.hasVerticalSroll() ? this.calcWidth + 18 : this.calcWidth;
+    }
     /**
      * @hidden
      */

--- a/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
@@ -622,7 +622,7 @@ describe('IgxGrid - Cell component', () => {
         fix.detectChanges();
         const rows = fix.componentInstance.instance.rowList;
         rows.forEach((item) => {
-            expect(item.cells.last.width).toEqual('182px');
+            expect(item.cells.last.width).toEqual('200px');
         });
     }));
 
@@ -665,7 +665,7 @@ describe('IgxGrid - Cell component', () => {
         // Calculate where the end of the cell is. Relative left position should equal the grid calculated width
         expect(lastCell.getBoundingClientRect().left +
             lastCell.offsetWidth +
-            verticalScroll.offsetWidth).toEqual(grid.calcWidth);
+            verticalScroll.offsetWidth).toEqual(grid.outerWidth);
     }));
 
     it('should not reduce the width of last pinned cell when there is vertical scroll.', fakeAsync(() => {
@@ -681,7 +681,7 @@ describe('IgxGrid - Cell component', () => {
         });
         const rows = fix.componentInstance.instance.rowList;
         rows.forEach((item) => {
-            expect(item.cells.last.width).toEqual('182px');
+            expect(item.cells.last.width).toEqual('200px');
         });
     }));
 
@@ -707,7 +707,7 @@ describe('IgxGrid - Cell component', () => {
         });
     });
 
-    it('should make last column smaller when vertical scrollbar is on the left of last cell', async () => {
+    it('should not make last column smaller when vertical scrollbar is on the left of last cell', async () => {
         GridColumnWidthsComponent.COLUMN_WIDTH = '500px';
         const fix = TestBed.createComponent(GridColumnWidthsComponent);
         fix.detectChanges();
@@ -722,7 +722,7 @@ describe('IgxGrid - Cell component', () => {
         const lastColumnCells = grid.columns[grid.columns.length - 1].cells;
         fix.detectChanges();
         lastColumnCells.forEach(function (item) {
-            expect(item.width).toEqual('482px');
+            expect(item.width).toEqual('500px');
         });
     });
 

--- a/projects/igniteui-angular/src/lib/grids/grid/column-moving.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/column-moving.spec.ts
@@ -552,7 +552,7 @@ describe('IgxGrid - Column Moving', () => {
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 56, 56);
             await wait(50);
-            UIInteractions.simulatePointerEvent('pointermove', header, 490, 30);
+            UIInteractions.simulatePointerEvent('pointermove', header, 475, 30);
             await wait(1000);
             fixture.detectChanges();
 
@@ -577,7 +577,7 @@ describe('IgxGrid - Column Moving', () => {
 
             // step 2 - start moving a column and verify columns are scrolled into view,
             // when holding the drag ghost over the left edge of the grid
-            const header = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS))[5].nativeElement;
+            const header = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS))[4].nativeElement;
             UIInteractions.simulatePointerEvent('pointerdown', header, 350, 50);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 356, 56);
@@ -610,7 +610,7 @@ describe('IgxGrid - Column Moving', () => {
 
             // step 2 - start moving a column and verify columns are scrolled into view,
             // when holding the drag ghost before pinned area edge
-            const header = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS))[6].nativeElement;
+            const header = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS))[5].nativeElement;
             UIInteractions.simulatePointerEvent('pointerdown', header, 450, 50);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 456, 56);
@@ -729,7 +729,7 @@ describe('IgxGrid - Column Moving', () => {
             fixture.detectChanges();
 
             // step 4 - reorder that column among columns that are currently out of view
-            const header = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS))[5].nativeElement;
+            const header = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_CLASS))[4].nativeElement;
             UIInteractions.simulatePointerEvent('pointerdown', header, 350, 50);
             await wait();
             UIInteractions.simulatePointerEvent('pointermove', header, 356, 56);
@@ -892,7 +892,6 @@ describe('IgxGrid - Column Moving', () => {
             grid.getColumnByName('Address').pinned = true;
             grid.getColumnByName('ID').pinned = true;
             grid.getColumnByName('ContactTitle').pinned = true;
-            grid.getColumnByName('ContactName').pinned = true;
             fixture.detectChanges();
 
             // step 2 - try drag/drop an unpinned column among pinned columns
@@ -908,7 +907,7 @@ describe('IgxGrid - Column Moving', () => {
             fixture.detectChanges();
 
             // step 3 - verify column cannot be pinned
-            expect(grid.pinnedColumns.length).toEqual(4);
+            expect(grid.pinnedColumns.length).toEqual(3);
             expect(grid.unpinnedColumns[0].field).toEqual('CompanyName');
             expect(grid.getColumnByName('CompanyName').pinned).toBeFalsy();
         }));

--- a/projects/igniteui-angular/src/lib/grids/grid/column-pinning.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/column-pinning.spec.ts
@@ -234,7 +234,9 @@ describe('Column Pinning UI', () => {
         });
 
         it('- pinning group column pins all children.', () => {
+            fix.detectChanges();
             const columnName = 'General Information';
+            GridFunctions.getCheckboxInput('Missing', columnChooserElement, fix).click();
             GridFunctions.getCheckboxInput(columnName, columnChooserElement, fix).click();
 
             fix.detectChanges();
@@ -245,6 +247,7 @@ describe('Column Pinning UI', () => {
 
         it('- unpinning group column unpins all children.', () => {
             const columnName = 'General Information';
+            grid.columns[0].unpin();
             grid.columns[1].pin();
             fix.detectChanges();
 

--- a/projects/igniteui-angular/src/lib/grids/grid/column-resizing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/column-resizing.spec.ts
@@ -752,20 +752,20 @@ describe('IgxGrid - Deferred Column Resizing', () => {
         const headerGroups = fixture.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
         const filteringCells = fixture.debugElement.queryAll(By.css(COLUMN_FILTER_CELL_SELECTOR));
 
-        expect(headers[0].nativeElement.getBoundingClientRect().width).toBe(100);
-        expect(headers[1].nativeElement.getBoundingClientRect().width).toBe(100);
-        expect(headers[2].nativeElement.getBoundingClientRect().width).toBe(100);
-        expect(headers[3].nativeElement.getBoundingClientRect().width).toBe(100);
+        expect(headers[0].nativeElement.getBoundingClientRect().width).toBeCloseTo(100, 0);
+        expect(headers[1].nativeElement.getBoundingClientRect().width).toBeCloseTo(100, 0);
+        expect(headers[2].nativeElement.getBoundingClientRect().width).toBeCloseTo(100, 0);
+        expect(headers[3].nativeElement.getBoundingClientRect().width).toBeCloseTo(100, 0);
 
-        expect(filteringCells[0].nativeElement.getBoundingClientRect().width).toBe(100);
-        expect(filteringCells[1].nativeElement.getBoundingClientRect().width).toBe(100);
-        expect(filteringCells[2].nativeElement.getBoundingClientRect().width).toBe(100);
-        expect(filteringCells[3].nativeElement.getBoundingClientRect().width).toBe(100);
+        expect(filteringCells[0].nativeElement.getBoundingClientRect().width).toBeCloseTo(100, 0);
+        expect(filteringCells[1].nativeElement.getBoundingClientRect().width).toBeCloseTo(100, 0);
+        expect(filteringCells[2].nativeElement.getBoundingClientRect().width).toBeCloseTo(100, 0);
+        expect(filteringCells[3].nativeElement.getBoundingClientRect().width).toBeCloseTo(100, 0);
 
-        expect(headerGroups[0].nativeElement.getBoundingClientRect().width).toBe(100);
-        expect(headerGroups[1].nativeElement.getBoundingClientRect().width).toBe(100);
-        expect(headerGroups[2].nativeElement.getBoundingClientRect().width).toBe(100);
-        expect(headerGroups[3].nativeElement.getBoundingClientRect().width).toBe(100);
+        expect(headerGroups[0].nativeElement.getBoundingClientRect().width).toBeCloseTo(100, 0);
+        expect(headerGroups[1].nativeElement.getBoundingClientRect().width).toBeCloseTo(100, 0);
+        expect(headerGroups[2].nativeElement.getBoundingClientRect().width).toBeCloseTo(100, 0);
+        expect(headerGroups[3].nativeElement.getBoundingClientRect().width).toBeCloseTo(100, 0);
     }));
 });
 
@@ -790,7 +790,7 @@ export class PinnedColumnsComponent {
 }
 
 @Component({
-    template: GridTemplateStrings.declareGrid(`width="600px" height="600px"`, ``,
+    template: GridTemplateStrings.declareGrid(`width="618px" height="600px"`, ``,
         `<igx-column [field]="'Released'" [pinned]="true" width="100px" dataType="boolean" [resizable]="true"></igx-column>
         <igx-column [field]="'ReleaseDate'" [pinned]="true" width="100px" dataType="date" [resizable]="true"
             [formatter]="returnVal"></igx-column>

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-keyBoardNav.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-keyBoardNav.spec.ts
@@ -432,7 +432,7 @@ describe('IgxGrid - Keyboard navigation', () => {
 
         expect(fix.componentInstance.selectedCell.value).toEqual('Ana Trujillo Emparedados y helados');
         expect(fix.componentInstance.selectedCell.column.field).toMatch('CompanyName');
-        cell = cells[6];
+        cell = cells[5];
 
         UIInteractions.triggerKeyDownEvtUponElem('arrowup', cell.nativeElement, true);
 
@@ -763,12 +763,13 @@ describe('IgxGrid - Keyboard navigation', () => {
             await wait(DEBOUNCETIME);
             fix.detectChanges();
 
-            expect(rowDisplayContainer.style.left).toEqual('-25px');
+            expect(rowDisplayContainer.style.left).toEqual('-43px');
             expect(fix.componentInstance.selectedCell.value).toEqual(30);
             expect(fix.componentInstance.selectedCell.column.field).toMatch('3');
         });
 
         it('should scroll first row into view when pressing arrow up', (async () => {
+            grid.reflow();
             fix.componentInstance.scrollTop(25);
             await wait(100);
             fix.detectChanges();

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
@@ -78,7 +78,7 @@ describe('IgxGrid - Summaries', () => {
             expect(grid.getColumnByName('OrderDate').hasSummary).toBe(false);
 
             tFoot = fixture.debugElement.query(By.css('.igx-grid__tfoot')).nativeElement.getBoundingClientRect().height;
-            expect(tFoot).toEqual(grid.defaultRowHeight + 1);
+            expect(tFoot).toEqual(grid.defaultRowHeight);
         });
 
         it(`should recalculate grid sizes correctly when the column is outside of the viewport`, (async () => {
@@ -95,7 +95,7 @@ describe('IgxGrid - Summaries', () => {
             fixture.detectChanges();
 
             const tFoot = fixture.debugElement.query(By.css('.igx-grid__tfoot')).nativeElement.getBoundingClientRect().height;
-            expect(tFoot).toEqual(5 * grid.defaultRowHeight + 1);
+            expect(tFoot).toEqual(5 * grid.defaultRowHeight);
             expect(fixture.debugElement.query(By.css(SUMMARY_CLASS))).toBeDefined();
         }));
 
@@ -557,14 +557,14 @@ describe('IgxGrid - Summaries', () => {
 
             it('Hiding: should recalculate summary area after column with enabled summary is hidden', fakeAsync(() => {
                 let tFoot = fix.debugElement.query(By.css('.igx-grid__tfoot')).nativeElement.getBoundingClientRect().height;
-                expect(tFoot).toEqual(5 * grid.defaultRowHeight + 1);
+                expect(tFoot).toEqual(5 * grid.defaultRowHeight);
 
                 grid.getColumnByName('UnitsInStock').hidden = true;
                 tick();
                 fix.detectChanges();
 
                 tFoot = fix.debugElement.query(By.css('.igx-grid__tfoot')).nativeElement.getBoundingClientRect().height;
-                expect(tFoot).toEqual(3 * grid.defaultRowHeight + 1);
+                expect(tFoot).toEqual(3 * grid.defaultRowHeight);
                 expect(grid.hasSummarizedColumns).toBe(true);
 
                 let summaryRow = fix.debugElement.query(By.css(SUMMARY_ROW));
@@ -579,7 +579,7 @@ describe('IgxGrid - Summaries', () => {
 
                 expect(grid.hasSummarizedColumns).toBe(true);
                 tFoot = fix.debugElement.query(By.css('.igx-grid__tfoot')).nativeElement.getBoundingClientRect().height;
-                expect(tFoot).toEqual(5 * grid.defaultRowHeight + 1);
+                expect(tFoot).toEqual(5 * grid.defaultRowHeight);
                 summaryRow = fix.debugElement.query(By.css(SUMMARY_ROW));
                 HelperUtils.verifyColumnSummaries(summaryRow, 0, [], []);
                 HelperUtils.verifyColumnSummaries(summaryRow, 1, ['Count'], ['10']);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-toolbar.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-toolbar.spec.ts
@@ -507,7 +507,7 @@ describe('IgxGrid - Grid Toolbar', () => {
         grid.columnHiding = true;
         fixture.detectChanges();
 
-        expect(parseInt(grid.toolbar.columnHidingUI.columnsAreaMaxHeight, 10)).toBe(134);
+        expect(parseFloat(grid.toolbar.columnHidingUI.columnsAreaMaxHeight)).toBe(grid.calcHeight * 0.7);
 
         grid.height = '600px';
         tick(100);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.html
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.html
@@ -1,4 +1,4 @@
-<igx-grid-toolbar role="rowgroup" [style.width.px]="calcWidth" *ngIf="showToolbar" [gridID]="id" [displayDensity]="displayDensity" #toolbar>
+<igx-grid-toolbar role="rowgroup" *ngIf="showToolbar" [gridID]="id" [displayDensity]="displayDensity" #toolbar>
 </igx-grid-toolbar>
 
 <ng-template #defaultPager let-api>
@@ -20,13 +20,13 @@
     </select>
 </ng-template>
 
-<div [style.width.px]='calcWidth' class="igx-grid__grouparea" *ngIf="groupingExpressions.length > 0 || hasGroupableColumns" #groupArea>
+<div class="igx-grid__grouparea" *ngIf="groupingExpressions.length > 0 || hasGroupableColumns" #groupArea>
     <igx-chips-area (onReorder)="chipsOrderChanged($event)" (onMoveEnd)="chipsMovingEnded()">
         <ng-container *ngFor="let expr of chipsGoupingExpressions; let last = last;">
             <igx-chip [id]="expr.fieldName" [attr.title]="getGroupByChipTitle(expr)" [removable]="getColumnByName(expr.fieldName).groupable" [draggable]="getColumnByName(expr.fieldName).groupable" [displayDensity]="displayDensity"
-                (onKeyDown)="onChipKeyDown($event)" (onRemove)="onChipRemoved($event)" (onClick)="getColumnByName(expr.fieldName).groupable ? onChipClicked($event): null" [disabled]='!getColumnByName(expr.fieldName).groupable'>
-                    <span>{{ getGroupByChipTitle(expr) }}</span>
-                    <igx-icon igxSuffix>{{ expr.dir == 1 ? 'arrow_upward' : 'arrow_downward' }}</igx-icon>
+                      (onKeyDown)="onChipKeyDown($event)" (onRemove)="onChipRemoved($event)" (onClick)="getColumnByName(expr.fieldName).groupable ? onChipClicked($event): null" [disabled]='!getColumnByName(expr.fieldName).groupable'>
+                <span>{{ getGroupByChipTitle(expr) }}</span>
+                <igx-icon igxSuffix>{{ expr.dir == 1 ? 'arrow_upward' : 'arrow_downward' }}</igx-icon>
             </igx-chip>
             <span class="igx-grid__grouparea-connector">
                 <igx-icon [style.visibility]="(!last || dropAreaVisible) ? 'visible' : 'hidden'" >arrow_forward</igx-icon>
@@ -38,9 +38,9 @@
     </igx-chips-area>
 </div>
 
-<div style='grid-row:3;'>
-<div class="igx-grid__thead"  role="rowgroup" [style.width.px]='calcWidth + 1' #theadRow style='float:left;overflow:hidden;'>
-    <div class="igx-grid__tr" [style.width.px]='calcWidth + 1' role="row">
+<div class='igx-grid__thead-container'>
+<div class="igx-grid__thead"  role="rowgroup" [style.width.px]='calcWidth + 1' #theadRow>
+    <div class="igx-grid__tr" role="row">
         <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length <= 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-left" [style.left.px]="headerCheckboxWidth"></span>
         <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length > 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-pinned" [style.left.px]="pinnedWidth"></span>
         <ng-container *ngIf="groupingExpressions.length > 0">
@@ -66,11 +66,11 @@
     </div>
     <igx-grid-filtering-row *ngIf="filteringService.isFilterRowVisible" [column]="filteringService.filteredColumn"></igx-grid-filtering-row>
 </div>
-<!-- <div class="igx-grid__header_scroll_holder" style='float: right;height: 100px;' *ngIf='hasVerticalSroll()' [style.width]="'18px'"></div> -->
+<div class="igx-grid__scroll-thumb" *ngIf='hasVerticalSroll()' [style.height.px]='headerHeight' [style.width]="'18px'"></div>
 </div>
 
-<div style='grid-row:4;'>
-<div style='float:left;' class="igx-grid__tbody" role="rowgroup" [style.height.px]='calcHeight' [style.width.px]='calcWidth' #tbody (scroll)='scrollHandler($event)' (wheel)="wheelHandler()">
+<div class='igx-grid__tbody-container'>
+<div class="igx-grid__tbody" role="rowgroup" [style.height.px]='calcHeight' [style.width.px]='calcWidth + 1' #tbody (scroll)='scrollHandler($event)' (wheel)="wheelHandler()">
     <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length <= 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-left"></span>
     <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length > 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-pinned" [style.left.px]="pinnedWidth"></span>
     <ng-template igxGridFor let-rowData [igxGridForOf]="data | gridTransaction:id:pipeTrigger
@@ -100,16 +100,17 @@
     <span *ngIf="hasMovableColumns && draggedColumn" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="right" class="igx-grid__scroll-on-drag-right"></span>
     <div class="igx-grid__row-editing-outlet" igxOverlayOutlet #igxRowEditingOverlayOutlet></div>
 </div>
-    <div style='float:right;' class="igx-grid__vert_scroll" [style.width]="'18px'" [style.height.px]='calcHeight'>
+    <div class="igx-grid__vert_scroll" [style.width]="'18px'" [style.height.px]='calcHeight'>
         <ng-template igxGridFor [igxGridForOf]='[]' #verticalScrollHolder>
         </ng-template>
     </div>
 </div>
 
 
-<div class="igx-grid__tfoot" role="rowgroup" [style.width.px]='calcWidth' #tfoot style='overflow:hidden;'>
-    <igx-grid-summary-row *ngIf="hasSummarizedColumns && rootSummariesEnabled" [gridID]="id" [summaries]="id | igxGridSummaryDataPipe:summaryService.retriggerRootPipe" [indentation]="groupingExpressions.length" [index]="0" class="igx-grid__summaries"  #summaryRow>
+<div class="igx-grid__tfoot" role="rowgroup" [style.height.px]='summariesHeight' #tfoot>
+    <igx-grid-summary-row [style.width.px]='calcWidth' *ngIf="hasSummarizedColumns && rootSummariesEnabled" [gridID]="id" [summaries]="id | igxGridSummaryDataPipe:summaryService.retriggerRootPipe" [indentation]="groupingExpressions.length" [index]="0" class="igx-grid__summaries"  #summaryRow>
     </igx-grid-summary-row>
+    <div class="igx-grid__scroll-thumb" *ngIf='hasVerticalSroll()' [style.height.px]='summariesHeight' [style.width]="'18px'"></div>
 </div>
 
 <div class="igx-grid__scroll" [style.height]="'18px'" #scr [hidden]="unpinnedWidth - totalWidth >= 0">

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.html
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.html
@@ -38,8 +38,9 @@
     </igx-chips-area>
 </div>
 
-<div class="igx-grid__thead" role="rowgroup" [style.width.px]='calcWidth' #theadRow>
-    <div class="igx-grid__tr" [style.width.px]='calcWidth' role="row">
+<div style='grid-row:3;'>
+<div class="igx-grid__thead"  role="rowgroup" [style.width.px]='calcWidth + 1' #theadRow style='float:left;overflow:hidden;'>
+    <div class="igx-grid__tr" [style.width.px]='calcWidth + 1' role="row">
         <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length <= 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-left" [style.left.px]="headerCheckboxWidth"></span>
         <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length > 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-pinned" [style.left.px]="pinnedWidth"></span>
         <ng-container *ngIf="groupingExpressions.length > 0">
@@ -65,8 +66,11 @@
     </div>
     <igx-grid-filtering-row *ngIf="filteringService.isFilterRowVisible" [column]="filteringService.filteredColumn"></igx-grid-filtering-row>
 </div>
+<!-- <div class="igx-grid__header_scroll_holder" style='float: right;height: 100px;' *ngIf='hasVerticalSroll()' [style.width]="'18px'"></div> -->
+</div>
 
-<div class="igx-grid__tbody" role="rowgroup" [style.height.px]='calcHeight' [style.width.px]='calcWidth' #tbody (scroll)='scrollHandler($event)' (wheel)="wheelHandler()">
+<div style='grid-row:4;'>
+<div style='float:left;' class="igx-grid__tbody" role="rowgroup" [style.height.px]='calcHeight' [style.width.px]='calcWidth' #tbody (scroll)='scrollHandler($event)' (wheel)="wheelHandler()">
     <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length <= 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-left"></span>
     <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length > 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-pinned" [style.left.px]="pinnedWidth"></span>
     <ng-template igxGridFor let-rowData [igxGridForOf]="data | gridTransaction:id:pipeTrigger
@@ -76,7 +80,7 @@
     | gridPaging:page:perPage:id:pipeTrigger
     | gridPostGroupBy:groupingExpressions:groupingExpansionState:groupsExpanded:id:groupsRecords:pipeTrigger
     | gridSummary:hasSummarizedColumns:summaryCalculationMode:summaryPosition:id:pipeTrigger:summaryPipeTrigger"
-    let-rowIndex="index" [igxForScrollOrientation]="'vertical'"
+    let-rowIndex="index" [igxForScrollOrientation]="'vertical'"  [igxForScrollContainer]='verticalScroll'
     [igxForContainerSize]='calcHeight' [igxForItemSize]="rowHeight" #verticalScrollContainer (onChunkPreload)="dataLoading($event)">
         <ng-template #record_template>
             <igx-grid-row [gridID]="id" [index]="rowIndex" [rowData]="rowData" #row>
@@ -96,9 +100,14 @@
     <span *ngIf="hasMovableColumns && draggedColumn" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="right" class="igx-grid__scroll-on-drag-right"></span>
     <div class="igx-grid__row-editing-outlet" igxOverlayOutlet #igxRowEditingOverlayOutlet></div>
 </div>
+    <div style='float:right;' class="igx-grid__vert_scroll" [style.width]="'18px'" [style.height.px]='calcHeight'>
+        <ng-template igxGridFor [igxGridForOf]='[]' #verticalScrollHolder>
+        </ng-template>
+    </div>
+</div>
 
 
-<div class="igx-grid__tfoot" role="rowgroup" [style.width.px]='calcWidth' #tfoot>
+<div class="igx-grid__tfoot" role="rowgroup" [style.width.px]='calcWidth' #tfoot style='overflow:hidden;'>
     <igx-grid-summary-row *ngIf="hasSummarizedColumns && rootSummariesEnabled" [gridID]="id" [summaries]="id | igxGridSummaryDataPipe:summaryService.retriggerRootPipe" [indentation]="groupingExpressions.length" [index]="0" class="igx-grid__summaries"  #summaryRow>
     </igx-grid-summary-row>
 </div>

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.html
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.html
@@ -1,4 +1,4 @@
-<igx-grid-toolbar role="rowgroup" *ngIf="showToolbar" [gridID]="id" [displayDensity]="displayDensity" #toolbar>
+<igx-grid-toolbar [style.width.px]="outerWidth" role="rowgroup" *ngIf="showToolbar" [gridID]="id" [displayDensity]="displayDensity" #toolbar>
 </igx-grid-toolbar>
 
 <ng-template #defaultPager let-api>
@@ -20,7 +20,7 @@
     </select>
 </ng-template>
 
-<div class="igx-grid__grouparea" *ngIf="groupingExpressions.length > 0 || hasGroupableColumns" #groupArea>
+<div [style.width.px]='outerWidth' class="igx-grid__grouparea" *ngIf="groupingExpressions.length > 0 || hasGroupableColumns" #groupArea>
     <igx-chips-area (onReorder)="chipsOrderChanged($event)" (onMoveEnd)="chipsMovingEnded()">
         <ng-container *ngFor="let expr of chipsGoupingExpressions; let last = last;">
             <igx-chip [id]="expr.fieldName" [attr.title]="getGroupByChipTitle(expr)" [removable]="getColumnByName(expr.fieldName).groupable" [draggable]="getColumnByName(expr.fieldName).groupable" [displayDensity]="displayDensity"
@@ -64,7 +64,7 @@
         </ng-template>
         <span *ngIf="hasMovableColumns && draggedColumn" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="right" class="igx-grid__scroll-on-drag-right"></span>
     </div>
-    <igx-grid-filtering-row *ngIf="filteringService.isFilterRowVisible" [column]="filteringService.filteredColumn"></igx-grid-filtering-row>
+    <igx-grid-filtering-row [style.width.px]='calcWidth' *ngIf="filteringService.isFilterRowVisible" [column]="filteringService.filteredColumn"></igx-grid-filtering-row>
 </div>
 <div class="igx-grid__scroll-thumb" *ngIf='hasVerticalSroll()' [style.height.px]='headerHeight' [style.width]="'18px'"></div>
 </div>

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -173,7 +173,7 @@ describe('IgxGrid Component Tests', () => {
             tick(200);
             fix.detectChanges();
             expect(fix.componentInstance.isVerticalScrollbarVisible()).toBe(true);
-            expect(fix.componentInstance.isHorizontalScrollbarVisible()).toBe(false);
+            expect(fix.componentInstance.isHorizontalScrollbarVisible()).toBe(true);
             verticalScrollHeight = fix.componentInstance.getVerticalScrollHeight();
             grid.width = '200px';
 
@@ -205,7 +205,8 @@ describe('IgxGrid Component Tests', () => {
 
             gridBodyHeight = parseInt(window.getComputedStyle(grid.nativeElement).height, 10)
                 - parseInt(window.getComputedStyle(gridHeader.nativeElement).height, 10)
-                - parseInt(window.getComputedStyle(gridFooter.nativeElement).height, 10);
+                - parseInt(window.getComputedStyle(gridFooter.nativeElement).height, 10)
+                - parseInt(window.getComputedStyle(gridScroll.nativeElement).height, 10);
 
             // The scrollbar is no longer visible
             //    - parseInt(window.getComputedStyle(gridScroll.nativeElement).height, 10);
@@ -451,7 +452,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(grid.columns[0].width).toEqual('100px');
                 expect(grid.columns[4].width).toEqual('100px');
 
-                const actualGridWidth = grid.nativeElement.clientWidth;
+                const actualGridWidth = grid.tbody.nativeElement.clientWidth;
 
                 const expectedDefWidth = Math.max(Math.floor((actualGridWidth -
                     parseInt(grid.columns[0].width, 10) -
@@ -471,7 +472,7 @@ describe('IgxGrid Component Tests', () => {
                     }
                 });
 
-                expect(fix.componentInstance.isHorizonatScrollbarVisible()).toBe(false);
+                expect(fix.componentInstance.isHorizonatScrollbarVisible()).toBe(true);
                 expect(grid.rowList.length).toBeGreaterThan(0);
             });
 
@@ -3120,8 +3121,8 @@ describe('IgxGrid Component Tests', () => {
             fix.detectChanges();
             const gridHeader = fix.debugElement.query(By.css('.igx-grid__thead'));
             const gridBody = fix.debugElement.query(By.css('.igx-grid__tbody'));
-            expect(parseInt(window.getComputedStyle(gridHeader.nativeElement).width, 10)).toBe(400);
-            expect(parseInt(window.getComputedStyle(gridBody.nativeElement).width, 10)).toBe(400);
+            expect(parseInt(window.getComputedStyle(gridHeader.nativeElement).width, 10)).toBe(401);
+            expect(parseInt(window.getComputedStyle(gridBody.nativeElement).width, 10)).toBe(401);
             expect(parseInt(window.getComputedStyle(gridBody.nativeElement).height, 10)).toBe(510);
         }));
     });

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
@@ -983,7 +983,7 @@ describe('IgxGrid - GroupBy', () => {
 
         let grRows = grid.groupsRowList.toArray();
         for (const grRow of grRows) {
-            expect(grRow.element.nativeElement.clientWidth).toEqual(1200);
+            expect(grRow.element.nativeElement.clientWidth - 1).toEqual(1200);
         }
 
         const headers = fix.debugElement.queryAll(By.css(COLUMN_HEADER_GROUP_CLASS));
@@ -1010,7 +1010,7 @@ describe('IgxGrid - GroupBy', () => {
 
         grRows = grid.groupsRowList.toArray();
         for (const grRow of grRows) {
-            expect(grRow.element.nativeElement.clientWidth).toEqual(1200);
+            expect(grRow.element.nativeElement.clientWidth - 1).toEqual(1200);
         }
     }));
 
@@ -1037,7 +1037,7 @@ describe('IgxGrid - GroupBy', () => {
 
         const grRows = grid.groupsRowList.toArray();
         for (const grRow of grRows) {
-            expect(grRow.element.nativeElement.clientWidth).toEqual(1200);
+            expect(grRow.element.nativeElement.clientWidth - 1).toEqual(1200);
         }
     }));
 
@@ -1061,7 +1061,7 @@ describe('IgxGrid - GroupBy', () => {
         fix.detectChanges();
         const grRows = grid.groupsRowList.toArray();
         for (const grRow of grRows) {
-            expect(grRow.element.nativeElement.clientWidth).toEqual(500);
+            expect(grRow.element.nativeElement.clientWidth - 1).toEqual(500);
         }
     }));
 
@@ -1949,7 +1949,7 @@ describe('IgxGrid - GroupBy', () => {
         const indentation = fix.debugElement.query(By.css('.igx-grid__header-indentation'));
 
         expect(grid.pinnedWidth).toEqual(parseInt(window.getComputedStyle(indentation.nativeElement).width, 10));
-        expect(grid.unpinnedWidth).toEqual(400 - parseInt(window.getComputedStyle(indentation.nativeElement).width, 10));
+        expect(grid.unpinnedWidth).toEqual(400 - parseInt(window.getComputedStyle(indentation.nativeElement).width, 10) - 18);
 
         grid.clearGrouping();
         tick();

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.pinning.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.pinning.spec.ts
@@ -63,7 +63,7 @@ describe('IgxGrid - Column Pinning ', () => {
 
         // verify container widths
         expect(grid.pinnedWidth).toEqual(400);
-        expect(grid.unpinnedWidth).toEqual(400);
+        expect(grid.unpinnedWidth + 18).toEqual(400);
     }));
 
     it('should allow pinning/unpinning via the grid API', fakeAsync(() => {
@@ -96,7 +96,7 @@ describe('IgxGrid - Column Pinning ', () => {
 
         // verify container widths
         expect(grid.pinnedWidth).toEqual(200);
-        expect(grid.unpinnedWidth).toEqual(600);
+        expect(grid.unpinnedWidth + 18).toEqual(600);
 
         // pin back the column.
         grid.pinColumn('CompanyName');
@@ -109,7 +109,7 @@ describe('IgxGrid - Column Pinning ', () => {
 
         // verify container widths
         expect(grid.pinnedWidth).toEqual(400);
-        expect(grid.unpinnedWidth).toEqual(400);
+        expect(grid.unpinnedWidth).toEqual(382);
 
         expect(col.pinned).toBe(true);
         expect(col.visibleIndex).toEqual(1);
@@ -139,7 +139,7 @@ describe('IgxGrid - Column Pinning ', () => {
 
         // verify container widths
         expect(grid.pinnedWidth).toEqual(600);
-        expect(grid.unpinnedWidth).toEqual(200);
+        expect(grid.unpinnedWidth + 18).toEqual(200);
 
         col.pinned = false;
 
@@ -152,7 +152,7 @@ describe('IgxGrid - Column Pinning ', () => {
 
         // verify container widths
         expect(grid.pinnedWidth).toEqual(400);
-        expect(grid.unpinnedWidth).toEqual(400);
+        expect(grid.unpinnedWidth).toEqual(382);
     }));
 
     it('on unpinning should restore the original location(index) of the column', fakeAsync(() => {

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.html
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.html
@@ -1,4 +1,4 @@
-<igx-grid-toolbar role="rowgroup" [style.width.px]="calcWidth" *ngIf="showToolbar" [gridID]="id" [displayDensity]="displayDensity" #toolbar>
+<igx-grid-toolbar role="rowgroup" [style.width.px]='outerWidth' *ngIf="showToolbar" [gridID]="id" [displayDensity]="displayDensity" #toolbar>
 </igx-grid-toolbar>
 
 <ng-template #defaultPager let-api>
@@ -20,7 +20,8 @@
     </select>
 </ng-template>
 
-<div class="igx-grid__thead" role="rowgroup" [style.width.px]='calcWidth' #theadRow>
+<div class='igx-grid__thead-container'>
+    <div class="igx-grid__thead"  role="rowgroup" [style.width.px]='calcWidth + 1' #theadRow>
     <div class="igx-grid__tr" [style.width.px]='calcWidth' role="row">
         <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length <= 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-left" [style.left.px]="headerCheckboxWidth"></span>
         <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length > 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-pinned" [style.left.px]="pinnedWidth"></span>
@@ -42,41 +43,50 @@
     </div>
     <igx-grid-filtering-row *ngIf="filteringService.isFilterRowVisible" [column]="filteringService.filteredColumn"></igx-grid-filtering-row>
 </div>
+<div class="igx-grid__scroll-thumb" *ngIf='hasVerticalSroll()' [style.height.px]='headerHeight' [style.width]="'18px'"></div>
+</div>
 
-<div class="igx-grid__tbody" role="rowgroup" [style.height.px]='calcHeight' [style.width.px]='calcWidth' #tbody (scroll)='scrollHandler($event)' (wheel)="wheelHandler()">
-    <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length <= 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-left"></span>
-    <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length > 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-pinned" [style.left.px]="pinnedWidth"></span>
-    <ng-template igxGridFor let-rowData [igxGridForOf]="data
-	| treeGridTransaction:id:pipeTrigger
-	| treeGridHierarchizing:primaryKey:foreignKey:childDataKey:id:pipeTrigger
-    | treeGridFiltering:filteringExpressionsTree:id:pipeTrigger
-    | treeGridSorting:sortingExpressions:id:pipeTrigger
-    | treeGridFlattening:id:expansionDepth:expansionStates:pipeTrigger
-    | treeGridPaging:page:perPage:id:pipeTrigger
-    | treeGridSummary:hasSummarizedColumns:summaryCalculationMode:summaryPosition:id:pipeTrigger:summaryPipeTrigger"
+<div class='igx-grid__tbody-container'>
+    <div class="igx-grid__tbody" role="rowgroup" [style.height.px]='calcHeight' [style.width.px]='calcWidth' #tbody (scroll)='scrollHandler($event)' (wheel)="wheelHandler()">
+        <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length <= 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-left"></span>
+        <span *ngIf="hasMovableColumns && draggedColumn && pinnedColumns.length > 0" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="left" class="igx-grid__scroll-on-drag-pinned" [style.left.px]="pinnedWidth"></span>
+        <ng-template igxGridFor let-rowData [igxGridForOf]="data
+        | treeGridTransaction:id:pipeTrigger
+        | treeGridHierarchizing:primaryKey:foreignKey:childDataKey:id:pipeTrigger
+        | treeGridFiltering:filteringExpressionsTree:id:pipeTrigger
+        | treeGridSorting:sortingExpressions:id:pipeTrigger
+        | treeGridFlattening:id:expansionDepth:expansionStates:pipeTrigger
+        | treeGridPaging:page:perPage:id:pipeTrigger
+        | treeGridSummary:hasSummarizedColumns:summaryCalculationMode:summaryPosition:id:pipeTrigger:summaryPipeTrigger"
 
-    let-rowIndex="index" [igxForScrollOrientation]="'vertical'"
-    [igxForContainerSize]='calcHeight' [igxForItemSize]="rowHeight" #verticalScrollContainer (onChunkPreload)="dataLoading($event)">
-        <ng-template #record_template>
-            <igx-tree-grid-row [gridID]="id" [index]="rowIndex" [treeRow]="rowData" #row>
-            </igx-tree-grid-row>
+        let-rowIndex="index" [igxForScrollOrientation]="'vertical'"  [igxForScrollContainer]='verticalScroll'
+        [igxForContainerSize]='calcHeight' [igxForItemSize]="rowHeight" #verticalScrollContainer (onChunkPreload)="dataLoading($event)">
+            <ng-template #record_template>
+                <igx-tree-grid-row [gridID]="id" [index]="rowIndex" [treeRow]="rowData" #row>
+                </igx-tree-grid-row>
+            </ng-template>
+            <ng-template #summary_template>
+                <igx-grid-summary-row [gridID]="id" [summaries]="rowData.summaries" [firstCellIndentation]="rowData.cellIndentation" [index]="rowIndex" class="igx-grid__summaries--body" #summaryRow>
+                </igx-grid-summary-row>
+            </ng-template>
+
+            <ng-container *igxTemplateOutlet="isSummaryRow(rowData) ? summary_template : record_template; context: getContext(rowData) "></ng-container>
         </ng-template>
-        <ng-template #summary_template>
-            <igx-grid-summary-row [gridID]="id" [summaries]="rowData.summaries" [firstCellIndentation]="rowData.cellIndentation" [index]="rowIndex" class="igx-grid__summaries--body" #summaryRow>
-            </igx-grid-summary-row>
-        </ng-template>
-
-        <ng-container *igxTemplateOutlet="isSummaryRow(rowData) ? summary_template : record_template; context: getContext(rowData) "></ng-container>
+        <ng-container *ngTemplateOutlet="template"></ng-container>
+        <span *ngIf="hasMovableColumns && draggedColumn" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="right" class="igx-grid__scroll-on-drag-right"></span>
+        <div class="igx-grid__row-editing-outlet" igxOverlayOutlet #igxRowEditingOverlayOutlet></div>
+    </div>
+    <div class="igx-grid__vert_scroll" [style.width]="'18px'" [style.height.px]='calcHeight'>
+    <ng-template igxGridFor [igxGridForOf]='[]' #verticalScrollHolder>
     </ng-template>
-    <ng-container *ngTemplateOutlet="template"></ng-container>
-    <span *ngIf="hasMovableColumns && draggedColumn" [igxColumnMovingDrop]="parentVirtDir" [attr.droppable]="true" id="right" class="igx-grid__scroll-on-drag-right"></span>
-    <div class="igx-grid__row-editing-outlet" igxOverlayOutlet #igxRowEditingOverlayOutlet></div>
+    </div>
 </div>
 
-<div class="igx-grid__tfoot" role="rowgroup" [style.width.px]='calcWidth' #tfoot>
-    <igx-grid-summary-row *ngIf="hasSummarizedColumns && rootSummariesEnabled" [gridID]="id" [firstCellIndentation]="0" [summaries]="id | igxGridSummaryDataPipe:summaryService.retriggerRootPipe" [index]="0" class="igx-grid__summaries"  #summaryRow>
-    </igx-grid-summary-row>
-</div>
+    <div class="igx-grid__tfoot"  [style.width.px]='outerWidth' role="rowgroup" [style.height.px]='summariesHeight' #tfoot>
+        <igx-grid-summary-row [style.width.px]='calcWidth' *ngIf="hasSummarizedColumns && rootSummariesEnabled" [gridID]="id" [summaries]="id | igxGridSummaryDataPipe:summaryService.retriggerRootPipe" [index]="0" class="igx-grid__summaries"  #summaryRow>
+        </igx-grid-summary-row>
+        <div class="igx-grid__scroll-thumb" *ngIf='hasVerticalSroll()' [style.height.px]='summariesHeight' [style.width]="'18px'"></div>
+    </div>
 
 <div class="igx-grid__scroll" [style.height]="'18px'" #scr [hidden]="unpinnedWidth - totalWidth >= 0">
     <div class="igx-grid__scroll-start" [style.width.px]='pinnedWidth' [hidden]="pinnedWidth === 0"></div>

--- a/projects/igniteui-angular/src/lib/test-utils/tree-grid-components.spec.ts
+++ b/projects/igniteui-angular/src/lib/test-utils/tree-grid-components.spec.ts
@@ -52,7 +52,7 @@ export class IgxTreeGridSimpleComponent {
 
 @Component({
     template: `
-    <igx-tree-grid #treeGrid [data]="data" childDataKey="Employees" primaryKey="ID" width="300px" height="400px" columnWidth="100px">
+    <igx-tree-grid #treeGrid [data]="data" childDataKey="Employees" primaryKey="ID" width="318px" height="400px" columnWidth="100px">
         <igx-column [field]="'ID'" dataType="number"></igx-column>
         <igx-column [field]="'Name'" dataType="string"></igx-column>
         <igx-column [field]="'HireDate'" dataType="date"></igx-column>

--- a/src/app/grid-column-moving/grid-column-moving.sample.html
+++ b/src/app/grid-column-moving/grid-column-moving.sample.html
@@ -9,6 +9,7 @@
                 #grid1
                 [data]="data"
                 [allowFiltering]="true"
+                [showToolbar]="true"
                 (onColumnMovingStart)="onColumnMovingStart($event)"
                 (onColumnMoving)="onColumnMoving($event)"
                 (onColumnMovingEnd)="onColumnMovingEnd($event)"

--- a/src/app/grid-column-moving/grid-column-moving.sample.html
+++ b/src/app/grid-column-moving/grid-column-moving.sample.html
@@ -21,14 +21,12 @@
                                                     [movable]="c.movable"
                                                     [groupable]="true"
                                                     [resizable]="c.resizable"
-                                                    [width]="c.width"
+
                                                     [sortable]="true"
                                                     [filterable]="true"
                                                     [editable]="true"
                                                     [hidden]="c.hidden"
                                                     [hasSummary]="true"
-                                                    [minWidth]="c.minWidth"
-                                                    [maxWidth]="c.maxWidth"
                                                     [dataType]="c.type">
                 </igx-column>
             </igx-grid>

--- a/src/app/grid-column-moving/grid-column-moving.sample.ts
+++ b/src/app/grid-column-moving/grid-column-moving.sample.ts
@@ -21,7 +21,7 @@ export class GridColumnMovingSampleComponent implements OnInit {
             { field: 'ID', width: 80, resizable: true, movable: true },
             { field: 'CompanyName', width: 150, resizable: true, movable: true, type: 'string'},
             { field: 'ContactName', width: 150, resizable: true, movable: true, type: 'string' },
-            // { field: 'ContactTitle', width: 150, resizable: true, movable: true, type: 'string' },
+            { field: 'ContactTitle', width: 150, resizable: true, movable: true, type: 'string' },
             // { field: 'Address', width: 150, resizable: true, movable: true, type: 'string' },
             // { field: 'City', width: 150, resizable: true, movable: true, type: 'string' },
             // { field: 'Region', width: 150, resizable: true, movable: true, type: 'string' },

--- a/src/app/grid-column-moving/grid-column-moving.sample.ts
+++ b/src/app/grid-column-moving/grid-column-moving.sample.ts
@@ -21,16 +21,16 @@ export class GridColumnMovingSampleComponent implements OnInit {
             { field: 'ID', width: 80, resizable: true, movable: true },
             { field: 'CompanyName', width: 150, resizable: true, movable: true, type: 'string'},
             { field: 'ContactName', width: 150, resizable: true, movable: true, type: 'string' },
-            { field: 'ContactTitle', width: 150, resizable: true, movable: true, type: 'string' },
-            { field: 'Address', width: 150, resizable: true, movable: true, type: 'string' },
-            { field: 'City', width: 150, resizable: true, movable: true, type: 'string' },
-            { field: 'Region', width: 150, resizable: true, movable: true, type: 'string' },
-            { field: 'PostalCode', width: 150, resizable: true, movable: true, type: 'string' },
-            { field: 'Phone', width: 150, resizable: true, movable: true, type: 'string' },
-            { field: 'Fax', width: 150, resizable: true, movable: true, type: 'string' },
-            { field: 'Employees', width: 150, resizable: true, movable: true, type: 'number' },
-            { field: 'DateCreated', width: 150, resizable: true, movable: true, type: 'date' },
-            { field: 'Contract', width: 150, resizable: true, movable: true, type: 'boolean' }
+            // { field: 'ContactTitle', width: 150, resizable: true, movable: true, type: 'string' },
+            // { field: 'Address', width: 150, resizable: true, movable: true, type: 'string' },
+            // { field: 'City', width: 150, resizable: true, movable: true, type: 'string' },
+            // { field: 'Region', width: 150, resizable: true, movable: true, type: 'string' },
+            // { field: 'PostalCode', width: 150, resizable: true, movable: true, type: 'string' },
+            // { field: 'Phone', width: 150, resizable: true, movable: true, type: 'string' },
+            // { field: 'Fax', width: 150, resizable: true, movable: true, type: 'string' },
+            // { field: 'Employees', width: 150, resizable: true, movable: true, type: 'number' },
+            // { field: 'DateCreated', width: 150, resizable: true, movable: true, type: 'date' },
+            // { field: 'Contract', width: 150, resizable: true, movable: true, type: 'boolean' }
         ];
         this.data = [
             {

--- a/src/app/grid-column-moving/grid-column-moving.sample.ts
+++ b/src/app/grid-column-moving/grid-column-moving.sample.ts
@@ -22,15 +22,15 @@ export class GridColumnMovingSampleComponent implements OnInit {
             { field: 'CompanyName', width: 150, resizable: true, movable: true, type: 'string'},
             { field: 'ContactName', width: 150, resizable: true, movable: true, type: 'string' },
             { field: 'ContactTitle', width: 150, resizable: true, movable: true, type: 'string' },
-            // { field: 'Address', width: 150, resizable: true, movable: true, type: 'string' },
-            // { field: 'City', width: 150, resizable: true, movable: true, type: 'string' },
-            // { field: 'Region', width: 150, resizable: true, movable: true, type: 'string' },
-            // { field: 'PostalCode', width: 150, resizable: true, movable: true, type: 'string' },
-            // { field: 'Phone', width: 150, resizable: true, movable: true, type: 'string' },
-            // { field: 'Fax', width: 150, resizable: true, movable: true, type: 'string' },
-            // { field: 'Employees', width: 150, resizable: true, movable: true, type: 'number' },
-            // { field: 'DateCreated', width: 150, resizable: true, movable: true, type: 'date' },
-            // { field: 'Contract', width: 150, resizable: true, movable: true, type: 'boolean' }
+            { field: 'Address', width: 150, resizable: true, movable: true, type: 'string' },
+            { field: 'City', width: 150, resizable: true, movable: true, type: 'string' },
+            { field: 'Region', width: 150, resizable: true, movable: true, type: 'string' },
+            { field: 'PostalCode', width: 150, resizable: true, movable: true, type: 'string' },
+            { field: 'Phone', width: 150, resizable: true, movable: true, type: 'string' },
+            { field: 'Fax', width: 150, resizable: true, movable: true, type: 'string' },
+            { field: 'Employees', width: 150, resizable: true, movable: true, type: 'number' },
+            { field: 'DateCreated', width: 150, resizable: true, movable: true, type: 'date' },
+            { field: 'Contract', width: 150, resizable: true, movable: true, type: 'boolean' }
         ];
         this.data = [
             {


### PR DESCRIPTION
This allows the right border of the last column to always be visible so that actions like column moving, resizing and selection that add additional visualizations (indicators, borders etc.) to display as expected for the last column elements. 
Removing previous logic that makes the last cell smaller in case vertical scrollbar needs to be displayed.

Closes #3396  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 