### PR TITLE
Hide only top element on outside click

### DIFF
--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -727,6 +727,42 @@ describe('igxOverlay', () => {
             expect(overlayInstance.onOpening.emit).toHaveBeenCalledTimes(2);
             expect(overlayInstance.onOpened.emit).toHaveBeenCalledTimes(1);
         }));
+
+        it('fix for #3673 - Should not close dropdown in dropdown', fakeAsync(() => {
+            const fix = TestBed.createComponent(EmptyPageComponent);
+            const button = fix.componentInstance.buttonElement;
+            const overlay = fix.componentInstance.overlay;
+            const div = fix.componentInstance.divElement;
+            fix.detectChanges();
+
+            const overlaySettings: OverlaySettings = {
+                positionStrategy: new ConnectedPositioningStrategy(),
+                modal: false,
+                closeOnOutsideClick: true
+            };
+
+            overlaySettings.positionStrategy.settings.target = button.nativeElement;
+
+            overlay.show(SimpleDynamicComponent, overlaySettings);
+            overlay.show(SimpleDynamicComponent, overlaySettings);
+            fix.detectChanges();
+            tick();
+
+            let overlayDiv: Element = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
+            expect(overlayDiv).toBeDefined();
+            expect(overlayDiv.children.length).toEqual(2);
+            expect(overlayDiv.children[0].localName).toEqual('div');
+            expect(overlayDiv.children[1].localName).toEqual('div');
+
+            div.nativeElement.click();
+            fix.detectChanges();
+            tick();
+
+            overlayDiv = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
+            expect(overlayDiv).toBeDefined();
+            expect(overlayDiv.children.length).toEqual(1);
+            expect(overlayDiv.children[0].localName).toEqual('div');
+        }));
     });
 
     describe('Unit Tests - Scroll Strategies: ', () => {
@@ -3379,12 +3415,16 @@ export class SimpleDynamicWithDirectiveComponent {
 }
 
 @Component({
-    template: `<button #button (click)=\'click($event)\' class='button'>Show Overlay</button>`
+    template: `
+        <button #button (click)=\'click($event)\' class='button'>Show Overlay</button>
+        <div #div style='position: absolute; width:100px; height: 100px; background-color: blue; left: 300px;'></div>
+    `
 })
 export class EmptyPageComponent {
     constructor(@Inject(IgxOverlayService) public overlay: IgxOverlayService) { }
 
     @ViewChild('button') buttonElement: ElementRef;
+    @ViewChild('div') divElement: ElementRef;
 
     click(event) {
         this.overlay.show(SimpleDynamicComponent);


### PR DESCRIPTION
When two elements are shown in overlay with closeOnOutsideClick = true and
modal = false only top element should be closed on outside click

Closes #3673 

### Additional information (check all that apply):
 - [x] Bug fix

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 