### PR TITLE
Hide only top elementя on outside click

### DIFF
--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -732,7 +732,6 @@ describe('igxOverlay', () => {
             const fix = TestBed.createComponent(EmptyPageComponent);
             const button = fix.componentInstance.buttonElement;
             const overlay = fix.componentInstance.overlay;
-            const div = fix.componentInstance.divElement;
             fix.detectChanges();
 
             const overlaySettings: OverlaySettings = {
@@ -744,6 +743,7 @@ describe('igxOverlay', () => {
             overlaySettings.positionStrategy.settings.target = button.nativeElement;
 
             overlay.show(SimpleDynamicComponent, overlaySettings);
+            overlaySettings.positionStrategy.settings.horizontalStartPoint = HorizontalAlignment.Right;
             overlay.show(SimpleDynamicComponent, overlaySettings);
             fix.detectChanges();
             tick();
@@ -754,7 +754,7 @@ describe('igxOverlay', () => {
             expect(overlayDiv.children[0].localName).toEqual('div');
             expect(overlayDiv.children[1].localName).toEqual('div');
 
-            div.nativeElement.click();
+            (<any>overlay)._overlayInfos[0].elementRef.nativeElement.click();
             fix.detectChanges();
             tick();
 
@@ -3417,7 +3417,6 @@ export class SimpleDynamicWithDirectiveComponent {
 @Component({
     template: `
         <button #button (click)=\'click($event)\' class='button'>Show Overlay</button>
-        <div #div style='position: absolute; width:100px; height: 100px; background-color: blue; left: 300px;'></div>
     `
 })
 export class EmptyPageComponent {

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -727,6 +727,42 @@ describe('igxOverlay', () => {
             expect(overlayInstance.onOpening.emit).toHaveBeenCalledTimes(2);
             expect(overlayInstance.onOpened.emit).toHaveBeenCalledTimes(1);
         }));
+
+        it('fix for #3673 - Should not close dropdown in dropdown', fakeAsync(() => {
+            const fix = TestBed.createComponent(EmptyPageComponent);
+            const button = fix.componentInstance.buttonElement;
+            const overlay = fix.componentInstance.overlay;
+            const div = fix.componentInstance.divElement;
+            fix.detectChanges();
+
+            const overlaySettings: OverlaySettings = {
+                positionStrategy: new ConnectedPositioningStrategy(),
+                modal: false,
+                closeOnOutsideClick: true
+            };
+
+            overlaySettings.positionStrategy.settings.target = button.nativeElement;
+
+            overlay.show(SimpleDynamicComponent, overlaySettings);
+            overlay.show(SimpleDynamicComponent, overlaySettings);
+            fix.detectChanges();
+            tick();
+
+            let overlayDiv: Element = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
+            expect(overlayDiv).toBeDefined();
+            expect(overlayDiv.children.length).toEqual(2);
+            expect(overlayDiv.children[0].localName).toEqual('div');
+            expect(overlayDiv.children[1].localName).toEqual('div');
+
+            div.nativeElement.click();
+            fix.detectChanges();
+            tick();
+
+            overlayDiv = document.getElementsByClassName(CLASS_OVERLAY_MAIN)[0];
+            expect(overlayDiv).toBeDefined();
+            expect(overlayDiv.children.length).toEqual(1);
+            expect(overlayDiv.children[0].localName).toEqual('div');
+        }));
     });
 
     describe('Unit Tests - Scroll Strategies: ', () => {
@@ -3379,12 +3415,16 @@ export class SimpleDynamicWithDirectiveComponent {
 }
 
 @Component({
-    template: `<button #button (click)=\'click($event)\' class='button'>Show Overlay</button>`
+    template: `
+        <button #button (click)=\'click($event)\' class='button'>Show Overlay</button>
+        <div #div style='position: absolute; width:100px; height: 100px; background-color: blue; left: 300px;'></div>
+    `
 })
 export class EmptyPageComponent {
     constructor(@Inject(IgxOverlayService) public overlay: IgxOverlayService) { }
 
     @ViewChild('button') buttonElement: ElementRef;
+    @ViewChild('div') divElement: ElementRef;
 
     click(event) {
         this.overlay.show(SimpleDynamicComponent);

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
@@ -520,6 +520,12 @@ export class IgxOverlayService implements OnDestroy {
     }
 
     private documentClicked = (ev: Event) => {
+        //  if we get to modal overlay just return - we should not close anything under it
+        //  if we get to non-modal overlay do the next:
+        //   1. Check it has close on outside click. If not go on to next overlay;
+        //   2. If true check if click is on the element. If it is on the element we have closed
+        //  already all previous non-modal with close on outside click elements, so we return. If
+        //  not close the overlay and check next
         for (let i = this._overlayInfos.length; i--;) {
             const info = this._overlayInfos[i];
             if (info.settings.modal) {
@@ -528,7 +534,8 @@ export class IgxOverlayService implements OnDestroy {
             if (info.settings.closeOnOutsideClick) {
                 if (!info.elementRef.nativeElement.contains(ev.target)) {
                     this.hide(info.id);
-                    // TODO: should we return here too and not closing all no-modal overlays?
+                } else {
+                    return;
                 }
             }
         }


### PR DESCRIPTION
On click we are checking now all shown overlays from top to bottom:
- if currently top overlay is modal we do not close it and do not close anything else;
- if currently top overlay is not modal, and has close on outside click set to false we do not close it and proceed to next one;
- if currently top overlay is not modal, and has close on outside click set to true, and the click is on the element we do not close it and do not close anything else;
- if currently top overlay is not modal, and has close on outside click set to true, and the click is outside the element we close it and proceed with next one;

Closes #3673 

### Additional information (check all that apply):
 - [x] Bug fix

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 