### PR TITLE
Fix - Expansion Panel - Do not play collapse animation if panel is already collapsed - 7.0.x

### DIFF
--- a/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel.component.ts
+++ b/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel.component.ts
@@ -197,6 +197,9 @@ export class IgxExpansionPanelComponent implements IgxExpansionPanelBase {
      * ```
      */
     collapse(evt?: Event) {
+        if (this.collapsed) { // If expansion panel is already collapsed, do nothing
+            return;
+        }
         this.playCloseAnimation(
             () => {
                 this.onCollapsed.emit({ event: evt, panel: this });

--- a/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel.spec.ts
+++ b/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel.spec.ts
@@ -725,6 +725,15 @@ describe('igxExpansionPanel', () => {
             fixture.detectChanges();
             expect(headerButton.children[1].classList).toContain(IconPositionClass.NONE);
         });
+
+        it('Should not call animate method when `collapse` is called on a collapsed panel', () => {
+            const fixture = TestBed.createComponent(IgxExpansionPanelSampleComponent);
+            fixture.detectChanges();
+            const panel = fixture.componentInstance.panel;
+            const animationSpy = spyOn<any>(panel, 'playCloseAnimation');
+            panel.collapse();
+            expect(animationSpy).not.toHaveBeenCalled();
+        });
     });
 
     describe('Aria tests', () => {


### PR DESCRIPTION
Closes #3669 

This prevents an error being thrown when calling `expansionPanel.collapse` or `banner.close` when the component is already collapsed.

### Additional information (check all that apply):
 - [x] Bug fix

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 