### PR TITLE
fix(grid): remove empty css property warnings in prod builds

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
@@ -361,7 +361,6 @@
         cell-selected-text-color: $cell-selected-text-color,
 
         edit-mode-color: $edit-mode-color,
-        edit-mode-row-border-color: $edit-mode-color,
         edited-row-indicator: $edited-row-indicator,
         cell-edited-value-color: $cell-edited-value-color,
 


### PR DESCRIPTION
Closes #3775 

### Additional information (check all that apply):
 - [x] Warning fix

### Checklist:
 - [x] All relevant tags have been applied to this PR
 