### PR TITLE
Postion component wrapper on exact pixel location 7.1.x

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/toggle/toggle.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/toggle/toggle.directive.spec.ts
@@ -266,8 +266,8 @@ describe('IgxToggle', () => {
 
         let toggle = fixture.debugElement.query(By.css('#toggle1'));
         let toggleRect = toggle.nativeElement.getBoundingClientRect();
-        expect(toggleRect.right).toBe(button.getBoundingClientRect().right);
-        expect(toggleRect.top).toBe(button.getBoundingClientRect().bottom);
+        expect(Math.round(toggleRect.right)).toBe(Math.round(button.getBoundingClientRect().right));
+        expect(Math.round(toggleRect.top)).toBe(Math.round(button.getBoundingClientRect().bottom));
 
         button = fixture.componentInstance.button2.nativeElement;
         button.click();
@@ -275,8 +275,8 @@ describe('IgxToggle', () => {
 
         toggle = fixture.debugElement.query(By.css('#toggle2'));
         toggleRect = toggle.nativeElement.getBoundingClientRect();
-        expect(toggleRect.right).toBe(button.getBoundingClientRect().right);
-        expect(toggleRect.top).toBe(button.getBoundingClientRect().bottom);
+        expect(Math.round(toggleRect.right)).toBe(Math.round(button.getBoundingClientRect().right));
+        expect(Math.round(toggleRect.top)).toBe(Math.round(button.getBoundingClientRect().bottom));
 
         button = fixture.componentInstance.button3.nativeElement;
         button.click();
@@ -285,8 +285,8 @@ describe('IgxToggle', () => {
 
         toggle = fixture.debugElement.query(By.css('#toggle3'));
         toggleRect = toggle.nativeElement.getBoundingClientRect();
-        expect(toggleRect.right).toBe(button.getBoundingClientRect().right);
-        expect(toggleRect.top).toBe(button.getBoundingClientRect().bottom);
+        expect(Math.round(toggleRect.right)).toBe(Math.round(button.getBoundingClientRect().right));
+        expect(Math.round(toggleRect.top)).toBe(Math.round(button.getBoundingClientRect().bottom));
     }));
 
     it('fix for #3636 - All toggles should scroll correctly', fakeAsync(() => {
@@ -305,20 +305,20 @@ describe('IgxToggle', () => {
         let toggle = fixture.debugElement.query(By.css('#toggle1'));
         let toggleRect = toggle.nativeElement.getBoundingClientRect();
         button = fixture.componentInstance.button1.nativeElement;
-        expect(toggleRect.right).toBe(button.getBoundingClientRect().right);
-        expect(toggleRect.top).toBe(button.getBoundingClientRect().bottom);
+        expect(Math.round(toggleRect.right)).toBe(Math.round(button.getBoundingClientRect().right));
+        expect(Math.round(toggleRect.top)).toBe(Math.round(button.getBoundingClientRect().bottom));
 
         toggle = fixture.debugElement.query(By.css('#toggle2'));
         toggleRect = toggle.nativeElement.getBoundingClientRect();
         button = fixture.componentInstance.button2.nativeElement;
-        expect(toggleRect.right).toBe(button.getBoundingClientRect().right);
-        expect(toggleRect.top).toBe(button.getBoundingClientRect().bottom);
+        expect(Math.round(toggleRect.right)).toBe(Math.round(button.getBoundingClientRect().right));
+        expect(Math.round(toggleRect.top)).toBe(Math.round(button.getBoundingClientRect().bottom));
 
         toggle = fixture.debugElement.query(By.css('#toggle3'));
         toggleRect = toggle.nativeElement.getBoundingClientRect();
         button = fixture.componentInstance.button3.nativeElement;
-        expect(toggleRect.right).toBe(button.getBoundingClientRect().right);
-        expect(toggleRect.top).toBe(button.getBoundingClientRect().bottom);
+        expect(Math.round(toggleRect.right)).toBe(Math.round(button.getBoundingClientRect().right));
+        expect(Math.round(toggleRect.top)).toBe(Math.round(button.getBoundingClientRect().bottom));
 
         document.documentElement.scrollTop += 100;
         document.dispatchEvent(new Event('scroll'));
@@ -327,20 +327,20 @@ describe('IgxToggle', () => {
         toggle = fixture.debugElement.query(By.css('#toggle1'));
         toggleRect = toggle.nativeElement.getBoundingClientRect();
         button = fixture.componentInstance.button1.nativeElement;
-        expect(toggleRect.right).toBe(button.getBoundingClientRect().right);
-        expect(toggleRect.top).toBe(button.getBoundingClientRect().bottom);
+        expect(Math.round(toggleRect.right)).toBe(Math.round(button.getBoundingClientRect().right));
+        expect(Math.round(toggleRect.top)).toBe(Math.round(button.getBoundingClientRect().bottom));
 
         toggle = fixture.debugElement.query(By.css('#toggle2'));
         toggleRect = toggle.nativeElement.getBoundingClientRect();
         button = fixture.componentInstance.button2.nativeElement;
-        expect(toggleRect.right).toBe(button.getBoundingClientRect().right);
-        expect(toggleRect.top).toBe(button.getBoundingClientRect().bottom);
+        expect(Math.round(toggleRect.right)).toBe(Math.round(button.getBoundingClientRect().right));
+        expect(Math.round(toggleRect.top)).toBe(Math.round(button.getBoundingClientRect().bottom));
 
         toggle = fixture.debugElement.query(By.css('#toggle3'));
         toggleRect = toggle.nativeElement.getBoundingClientRect();
         button = fixture.componentInstance.button3.nativeElement;
-        expect(toggleRect.right).toBe(button.getBoundingClientRect().right);
-        expect(toggleRect.top).toBe(button.getBoundingClientRect().bottom);
+        expect(Math.round(toggleRect.right)).toBe(Math.round(button.getBoundingClientRect().right));
+        expect(Math.round(toggleRect.top)).toBe(Math.round(button.getBoundingClientRect().bottom));
     }));
 
     describe('overlay settings', () => {

--- a/projects/igniteui-angular/src/lib/directives/tooltip/tooltip.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/tooltip/tooltip.directive.spec.ts
@@ -79,7 +79,7 @@ describe('IgxTooltip', () => {
             verifyTooltipVisibility(tooltipNativeElement, tooltipTarget, false);
         }));
 
-        it('verify tooltip default position', fakeAsync(() => {
+        fit('verify tooltip default position', fakeAsync(() => {
             hoverElement(button);
             flush();
             verifyTooltipPosition(tooltipNativeElement, button, true);
@@ -424,7 +424,7 @@ describe('IgxTooltip', () => {
             buttonTwo = fix.debugElement.query(By.css('.buttonTwo'));
         }));
 
-        it('Same tooltip shows on different targets depending on which target is hovered', fakeAsync(() => {
+        fit('Same tooltip shows on different targets depending on which target is hovered', fakeAsync(() => {
             hoverElement(buttonOne);
             flush();
 
@@ -526,7 +526,7 @@ function verifyTooltipPosition(tooltipNativeElement, actualTarget, shouldBeAlign
     if (shouldBeAligned) {
         // Verify that tooltip and target are horizontally aligned with approximately same center
         expect(horizontalOffset >= 0).toBe(true, 'tooltip and target are horizontally MISaligned');
-        expect(horizontalOffset <= 0.1).toBe(true, 'tooltip and target are horizontally MISaligned');
+        expect(horizontalOffset <= 0.5).toBe(true, 'tooltip and target are horizontally MISaligned');
         // Verify that tooltip is vertically aligned beneath the target
         expect(verticalOffset >= 0).toBe(true, 'tooltip and target are vertically MISaligned');
         expect(verticalOffset <= 6).toBe(true, 'tooltip and target are vertically MISaligned');

--- a/projects/igniteui-angular/src/lib/directives/tooltip/tooltip.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/tooltip/tooltip.directive.spec.ts
@@ -79,7 +79,7 @@ describe('IgxTooltip', () => {
             verifyTooltipVisibility(tooltipNativeElement, tooltipTarget, false);
         }));
 
-        fit('verify tooltip default position', fakeAsync(() => {
+        it('verify tooltip default position', fakeAsync(() => {
             hoverElement(button);
             flush();
             verifyTooltipPosition(tooltipNativeElement, button, true);
@@ -424,7 +424,7 @@ describe('IgxTooltip', () => {
             buttonTwo = fix.debugElement.query(By.css('.buttonTwo'));
         }));
 
-        fit('Same tooltip shows on different targets depending on which target is hovered', fakeAsync(() => {
+        it('Same tooltip shows on different targets depending on which target is hovered', fakeAsync(() => {
             hoverElement(buttonOne);
             flush();
 

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -1830,12 +1830,13 @@ describe('igxOverlay', () => {
                 const componentEl_2 = overlayWrapper_2.children[0].children[0];
                 const componentRect_1 = componentEl_1.getBoundingClientRect();
                 const componentRect_2 = componentEl_2.getBoundingClientRect();
-                expect(componentRect_1.left).toEqual(buttonRect.right); // Will be positioned on the right of the button
-                expect(componentRect_1.left).toEqual(componentRect_2.left); // Are on the same spot
+                // Will be positioned on the right of the button
+                expect(Math.round(componentRect_1.left)).toEqual(Math.round(buttonRect.right));
+                expect(Math.round(componentRect_1.left)).toEqual(Math.round(componentRect_2.left)); // Are on the same spot
                 // expect(componentRect_1.top).toEqual(buttonRect.top - componentEl_1.clientHeight); // Will be positioned on top of button
-                expect(componentRect_1.top).toEqual(componentRect_2.top); // Will have the same top
-                expect(componentRect_1.width).toEqual(componentRect_2.width); // Will have the same width
-                expect(componentRect_1.height).toEqual(componentRect_2.height); // Will have the same height
+                expect(Math.round(componentRect_1.top)).toEqual(Math.round(componentRect_2.top)); // Will have the same top
+                expect(Math.round(componentRect_1.width)).toEqual(Math.round(componentRect_2.width)); // Will have the same width
+                expect(Math.round(componentRect_1.height)).toEqual(Math.round(componentRect_2.height)); // Will have the same height
             }));
 
         it(`Should persist the component's open state when scrolling, when scrolling and noOP scroll strategy is used

--- a/projects/igniteui-angular/src/lib/services/overlay/position/connected-positioning-strategy.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/position/connected-positioning-strategy.ts
@@ -27,8 +27,10 @@ export class ConnectedPositioningStrategy implements IPositionStrategy {
 
     //  TODO: extract transform setting in util function
     let transformString = '';
-    transformString += `translateX(${startPoint.x + this.settings.horizontalDirection * size.width}px) `;
-    transformString += `translateY(${startPoint.y + this.settings.verticalDirection * size.height}px)`;
+    const xLocation = Math.round(startPoint.x + this.settings.horizontalDirection * size.width);
+    const yLocation = Math.round(startPoint.y + this.settings.verticalDirection * size.height);
+    transformString += `translateX(${xLocation}px) `;
+    transformString += `translateY(${yLocation}px)`;
     contentElement.style.transform = transformString.trim();
   }
 }

--- a/projects/igniteui-angular/src/lib/services/overlay/position/elastic-position-strategy.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/position/elastic-position-strategy.ts
@@ -11,7 +11,7 @@ export class ElasticPositionStrategy extends BaseFitPositionStrategy implements 
                 if (extend > innerRect.width - minSize.width) {
                     extend = innerRect.width - minSize.width;
                 }
-                const translateX = `translateX(${innerRect.left + extend}px)`;
+                const translateX = `translateX(${Math.round(innerRect.left + extend)}px)`;
                 element.style.transform = element.style.transform.replace(/translateX\([.-\d]+px\)/g, translateX);
                 break;
             }
@@ -36,7 +36,7 @@ export class ElasticPositionStrategy extends BaseFitPositionStrategy implements 
                 if (extend > innerRect.height - minSize.height) {
                     extend = innerRect.height - minSize.height;
                 }
-                const translateY = `translateY(${innerRect.top + extend}px)`;
+                const translateY = `translateY(${Math.round(innerRect.top + extend)}px)`;
                 element.style.transform = element.style.transform.replace(/translateY\([.-\d]+px\)/g, translateY);
                 break;
             }


### PR DESCRIPTION
Up to now position strategies have calculated position where we should draw the shown element as fractional numbers, e.g. 158.56376px. Positioning like this lead to the bellow mentioned issue. What we are doing now is before set position we are rounding it to a whole number.

Closes #3820

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 