### PR TITLE
fix(Grid): Hide grouped columns after columns have been generated in ngAfterContentInit.

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
@@ -829,11 +829,10 @@ export class IgxGridComponent extends IgxGridBaseComponent implements OnInit, Do
         if (this.groupTemplate) {
             this._groupRowTemplate = this.groupTemplate.template;
         }
-
+        super.ngAfterContentInit();
         if (this.hideGroupedColumns && this.columnList && this.groupingExpressions) {
             this._setGroupColsVisibility(this.hideGroupedColumns);
         }
-        super.ngAfterContentInit();
     }
 
     public ngOnInit() {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
@@ -2271,6 +2271,22 @@ describe('IgxGrid - GroupBy', () => {
             expect(grid.getColumnByName('ProductName').hidden).toBe(true);
         }));
 
+    it(`should hide the grouped columns when hideGroupedColumns option is enabled,
+    there are initially set groupingExpressions and columns are autogenareted`,
+    fakeAsync(() => {
+        const fix = TestBed.createComponent(DefaultGridComponent);
+        const grid = fix.componentInstance.instance;
+        grid.hideGroupedColumns = true;
+        grid.groupingExpressions = [
+            { fieldName: 'Released', dir: SortingDirection.Asc }
+        ];
+        fix.detectChanges();
+        expect(grid.getColumnByName('Released').hidden).toBe(true);
+        const groupRows = grid.groupsRowList.toArray();
+
+        expect(groupRows.length).toEqual(3);
+    }));
+
     it('should update grouping expression when sorting a column first then grouping by it and changing sorting for it again', () => {
         const fix = TestBed.createComponent(DefaultGridComponent);
         const grid = fix.componentInstance.instance;


### PR DESCRIPTION

Closes #3951 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 