### PR TITLE
fix(igxOverlay): add NgModuleRef param to attach, #3988

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,8 +101,10 @@ All notable changes for each version of this project will be documented in this 
     - **Behavioral Change** - The UI now hides the columns whose `disableHiding` property is set to true instead of simply disabling them.
 - `igxButton` - **New Button Style** - Include [outlined](https://material.io/design/components/buttons.html#outlined-button) button style to support the latest material spec.
 - `igxOverlay`:
-    - `igxOverlay.attach(component, settings?)` method added. Use this method to obtain an unique Id of the created overlay where the provided component will be shown. Then call `igxOverlay.show(id, settings?)` method to show the component in overlay.
-    - `igxOverlay.show(component, settings)` is **depricated**. Use `igxOverlay.attach(component, settings?)` method to obtain an Id, and then call `igxOverlay.show(id, settings)` method to show a component in the overlay.
+    - `igxOverlay.attach()` method added. Use this method to obtain an unique Id of the created overlay where the provided component will be shown. Then call `igxOverlay.show(id, settings?)` method to show the component in overlay. The new `attach` method has two overloads:
+      - `attach(component: ElementRef, settings?: OverlaySettings): string` - this overload will create overlay where provided `component` will be shown.
+      - `attach(component: Type<any>, settings?: OverlaySettings, moduleRef?: NgModuleRef<any>): string` - with this overload `IgxOverlay` will create `ComponentRef` according to provided `component`. Then `IgxOverlay` will create overlay where `ComponentRef` will be shown. If `moduleRef` is provided `IgxOverlay` will use `moduleRef's` `ComponentFactoryResolver` and `Injector` when creating the `ComponentRef`.
+    - `igxOverlay.show(component, settings)` is **depricated**. Use `igxOverlay.attach()` method to obtain an Id, and then call `igxOverlay.show(id, settings)` method to show a component in the overlay.
 
 - `igx-date-picker`
     - **Feature** Added editable `mode` to enable the input field value editing and spinning of the date parts. Example:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,9 +102,9 @@ All notable changes for each version of this project will be documented in this 
 - `igxButton` - **New Button Style** - Include [outlined](https://material.io/design/components/buttons.html#outlined-button) button style to support the latest material spec.
 - `igxOverlay`:
     - `igxOverlay.attach()` method added. Use this method to obtain an unique Id of the created overlay where the provided component will be shown. Then call `igxOverlay.show(id, settings?)` method to show the component in overlay. The new `attach` method has two overloads:
-      - `attach(component: ElementRef, settings?: OverlaySettings): string` - this overload will create overlay where provided `component` will be shown.
-      - `attach(component: Type<any>, settings?: OverlaySettings, moduleRef?: NgModuleRef<any>): string` - with this overload `IgxOverlay` will create `ComponentRef` according to provided `component`. Then `IgxOverlay` will create overlay where `ComponentRef` will be shown. If `moduleRef` is provided `IgxOverlay` will use `moduleRef's` `ComponentFactoryResolver` and `Injector` when creating the `ComponentRef`.
-    - `igxOverlay.show(component, settings)` is **depricated**. Use `igxOverlay.attach()` method to obtain an Id, and then call `igxOverlay.show(id, settings)` method to show a component in the overlay.
+      - `attach(element: ElementRef, settings?: OverlaySettings): string` - this overload will create overlay where provided `element` will be shown.
+      - `attach(component: Type<any>, settings?: OverlaySettings, moduleRef?: NgModuleRef<any>): string` - Creates a `ComponentRef` from the provided `component` class to show in an overlay. If `moduleRef` is provided the service will use the module's `ComponentFactoryResolver` and `Injector` when creating the `ComponentRef` instead of the root ones.
+    - `igxOverlay.show(component, settings)` is **deprecated**. Use `igxOverlay.attach()` method to obtain an Id, and then call `igxOverlay.show(id, settings)` method to show a component in the overlay.
 
 - `igx-date-picker`
     - **Feature** Added editable `mode` to enable the input field value editing and spinning of the date parts. Example:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,7 +102,7 @@ All notable changes for each version of this project will be documented in this 
 - `igxButton` - **New Button Style** - Include [outlined](https://material.io/design/components/buttons.html#outlined-button) button style to support the latest material spec.
 - `igxOverlay`:
     - `igxOverlay.attach()` method added. Use this method to obtain an unique Id of the created overlay where the provided component will be shown. Then call `igxOverlay.show(id, settings?)` method to show the component in overlay. The new `attach` method has two overloads:
-      - `attach(element: ElementRef, settings?: OverlaySettings): string` - this overload will create overlay where provided `element` will be shown.
+      - `attach(element: ElementRef, settings?: OverlaySettings): string` - This overload will create overlay where provided `element` will be shown.
       - `attach(component: Type<any>, settings?: OverlaySettings, moduleRef?: NgModuleRef<any>): string` - Creates a `ComponentRef` from the provided `component` class to show in an overlay. If `moduleRef` is provided the service will use the module's `ComponentFactoryResolver` and `Injector` when creating the `ComponentRef` instead of the root ones.
     - `igxOverlay.show(component, settings)` is **deprecated**. Use `igxOverlay.attach()` method to obtain an Id, and then call `igxOverlay.show(id, settings)` method to show a component in the overlay.
 

--- a/projects/igniteui-angular/src/lib/services/overlay/README.md
+++ b/projects/igniteui-angular/src/lib/services/overlay/README.md
@@ -90,7 +90,7 @@ this.overlay.show(component, overlaySettings);
 
 | Name            | Description                                                                     | Parameters      |
 |-----------------|---------------------------------------------------------------------------------|-----------------|
-|attach           | Generates Id. Provide this Id when call `show(id, settings?)` method |component, overlaySettings? |
+|attach           | Generates Id. Provide this Id when call `show(id, settings?)` method |element, overlaySettings? |
 |attach           | Generates Id. Provide this Id when call `show(id, settings?)` method |component, overlaySettings?, moduleRef? |
 |show             | Shows the provided component on the overlay                                  |id, overlaySettings?|
 |hide             | Remove the provided native element of for the component with provided id        |id               |

--- a/projects/igniteui-angular/src/lib/services/overlay/README.md
+++ b/projects/igniteui-angular/src/lib/services/overlay/README.md
@@ -90,7 +90,8 @@ this.overlay.show(component, overlaySettings);
 
 | Name            | Description                                                                     | Parameters      |
 |-----------------|---------------------------------------------------------------------------------|-----------------|
-|register         | Generates Id. Provide this Id when call `show(id, settings?)` method |component, overlaySettings? |
+|attach           | Generates Id. Provide this Id when call `show(id, settings?)` method |component, overlaySettings? |
+|attach           | Generates Id. Provide this Id when call `show(id, settings?)` method |component, overlaySettings?, moduleRef? |
 |show             | Shows the provided component on the overlay                                  |id, overlaySettings?|
 |hide             | Remove the provided native element of for the component with provided id        |id               |
 |hideAll          | Remove the all native elements and hides the overlay                            |-                |

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
@@ -21,7 +21,8 @@ import {
     Injectable,
     Injector,
     Type,
-    OnDestroy
+    OnDestroy,
+    NgModuleRef
 } from '@angular/core';
 import { AnimationBuilder, AnimationReferenceMetadata, AnimationMetadataType, AnimationAnimateRefMetadata } from '@angular/animations';
 import { fromEvent, Subject } from 'rxjs';
@@ -111,13 +112,22 @@ export class IgxOverlayService implements OnDestroy {
 
     /**
      * Generates Id. Provide this Id when call `show(id, settings?)` method
-     * @param component ElementRef or Component Type to show in overlay
+     * @param component ElementRef to show in overlay
      * @param settings Display settings for the overlay, such as positioning and scroll/close behavior.
      * @returns Id of the created overlay. Valid until `onClosed` is emitted.
      */
-    attach(component: ElementRef | Type<{}>, settings?: OverlaySettings): string {
+    attach(component: ElementRef , settings?: OverlaySettings): string;
+    /**
+     * Generates Id. Provide this Id when call `show(id, settings?)` method
+     * @param component Component Type to show in overlay
+     * @param settings Display settings for the overlay, such as positioning and scroll/close behavior.
+     * @param moduleRef Optional reference to the NgModule that can resolve the component's factory
+     * @returns Id of the created overlay. Valid until `onClosed` is emitted.
+     */
+    attach(component: Type<any>, settings?: OverlaySettings, moduleRef?: NgModuleRef<any>): string;
+    attach(component: ElementRef | Type<any>, settings?: OverlaySettings, moduleRef?: NgModuleRef<any>): string {
         let info: OverlayInfo;
-        info = this.getOverlayInfo(component);
+        info = this.getOverlayInfo(component, moduleRef);
 
         //  if there is no info most probably wrong type component was provided and we just go out
         if (!info) {
@@ -148,8 +158,8 @@ export class IgxOverlayService implements OnDestroy {
      * @deprecated Use `attach(component)` to obtain an Id. Then `show(id, settings?)` with provided Id.
      */
     // tslint:disable-next-line:unified-signatures
-    show(component: ElementRef | Type<{}>, settings?: OverlaySettings): string;
-    show(compOrId: string | ElementRef | Type<{}>, settings?: OverlaySettings): string {
+    show(component: ElementRef | Type<any>, settings?: OverlaySettings): string;
+    show(compOrId: string | ElementRef | Type<any>, settings?: OverlaySettings): string {
         let info: OverlayInfo;
         let id: string;
         if (typeof compOrId === 'string') {
@@ -318,20 +328,22 @@ export class IgxOverlayService implements OnDestroy {
         }
     }
 
-    private getOverlayInfo(component: any): OverlayInfo {
+    private getOverlayInfo(component: any, moduleRef?: NgModuleRef<any>): OverlayInfo {
         const info: OverlayInfo = {};
         if (component instanceof ElementRef) {
             info.elementRef = <ElementRef>component;
         } else {
             let dynamicFactory: ComponentFactory<{}>;
+            const factoryResolver = moduleRef ? moduleRef.componentFactoryResolver : this._factoryResolver;
             try {
-                dynamicFactory = this._factoryResolver.resolveComponentFactory(component);
+                dynamicFactory = factoryResolver.resolveComponentFactory(component);
             } catch (error) {
                 console.error(error);
                 return null;
             }
 
-            const dynamicComponent: ComponentRef<{}> = dynamicFactory.create(this._injector);
+            const injector = moduleRef ? moduleRef.injector : this._injector;
+            const dynamicComponent: ComponentRef<{}> = dynamicFactory.create(injector);
             this._appRef.attachView(dynamicComponent.hostView);
 
             // If the element is newly created from a Component, it is wrapped in 'ng-component' tag - we do not want that.

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
@@ -116,7 +116,7 @@ export class IgxOverlayService implements OnDestroy {
      * @param settings Display settings for the overlay, such as positioning and scroll/close behavior.
      * @returns Id of the created overlay. Valid until `onClosed` is emitted.
      */
-    attach(component: ElementRef , settings?: OverlaySettings): string;
+    attach(element: ElementRef , settings?: OverlaySettings): string;
     /**
      * Generates Id. Provide this Id when call `show(id, settings?)` method
      * @param component Component Type to show in overlay


### PR DESCRIPTION
Attach method accepts now NgModuleRef. If attach is called with NgModuleRef overlay service will use NgModuleRef's ComponentFactoryResolver and Injector.

Closes #3988 
  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [x] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [x] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 