### PR TITLE
fix(grid): Enabling grid prefixes for IE 11 #3716

### DIFF
--- a/src/styles/igniteui-theme.scss
+++ b/src/styles/igniteui-theme.scss
@@ -8,6 +8,7 @@
 
 @include igx-core();
 
+/* autoprefixer grid: on */
 .default-theme {
     $igx-background-color: #fff;
     $igx-foreground-color: text-contrast($igx-background-color);


### PR DESCRIPTION
Closes #3716  
Closes #3717 

[Autoprefixer](https://github.com/postcss/autoprefixer#does-autoprefixer-polyfill-grid-layout-for-ie) plugin is used to translate modern CSS Grid syntax into IE 11 syntax, it will enable -ms- prefixes for Grid Layout. In order to enable it in our Dev samples I use the second approach `/* autoprefixer grid: autoplace */`, instead of enabling the grid prefixes with `grid: "autoplace"`

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [x] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 