### PR TITLE
Fixing #1861 and #1858

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -3419,9 +3419,6 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
         if (!this.nativeElement.parentNode || !this.nativeElement.parentNode.clientHeight) {
             const viewPortHeight = document.documentElement.clientHeight;
             this._height = this.rowBasedHeight <= viewPortHeight ? null : viewPortHeight.toString();
-        } else {
-            const parentHeight = this.nativeElement.parentNode.getBoundingClientRect().height;
-            this._height = this.rowBasedHeight <= parentHeight ? null : this._height;
         }
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
@@ -174,6 +174,7 @@ describe('IgxGrid - Summaries', () => {
     });
     it('should recalculate summary functions onRowAdded', () => {
         const fixture = TestBed.createComponent(SummaryColumnComponent);
+        fixture.componentInstance.grid1.height = null;
         fixture.detectChanges();
 
         const grid = fixture.componentInstance.grid1;
@@ -204,6 +205,7 @@ describe('IgxGrid - Summaries', () => {
     });
     it('should recalculate summary functions onRowDeleted', () => {
         const fixture = TestBed.createComponent(SummaryColumnComponent);
+        fixture.componentInstance.grid1.height = null;
         fixture.detectChanges();
 
         const grid = fixture.componentInstance.grid1;
@@ -232,6 +234,7 @@ describe('IgxGrid - Summaries', () => {
     });
     it('should recalculate summary functions on updateRow', () => {
         const fixture = TestBed.createComponent(SummaryColumnComponent);
+        fixture.componentInstance.grid1.height = null;
         fixture.detectChanges();
 
         const grid = fixture.componentInstance.grid1;

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -687,7 +687,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(fix.componentInstance.grid.rowList.length).toEqual(11);
         }));
 
-        fit(`should render grid with correct height when parent container\'s height is set
+        it(`should render grid with correct height when parent container\'s height is set
             and the total row height is smaller than parent height #1861`, fakeAsync(() => {
                 const fix = TestBed.createComponent(IgxGridFixedContainerHeightComponent);
                 fix.componentInstance.grid.height = '100%';

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -269,7 +269,6 @@ describe('IgxGrid Component Tests', () => {
         it('should render empty message', fakeAsync(() => {
             const fixture = TestBed.createComponent(IgxGridTestComponent);
             fixture.componentInstance.data = [];
-            fixture.componentInstance.height = null;
             fixture.detectChanges();
 
             const grid = fixture.componentInstance.grid;

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -309,7 +309,8 @@ describe('IgxGrid Component Tests', () => {
                     IgxGridDefaultRenderingComponent,
                     IgxGridColumnPercentageWidthComponent,
                     IgxGridWrappedInContComponent,
-                    IgxGridFormattingComponent
+                    IgxGridFormattingComponent,
+                    IgxGridFixedContainerHeightComponent
                 ],
                 imports: [
                     NoopAnimationsModule, IgxGridModule.forRoot()]
@@ -684,7 +685,32 @@ describe('IgxGrid Component Tests', () => {
                 expect(defaultHeightNum).toBe(320);
                 expect(fix.componentInstance.isVerticalScrollbarVisible()).toBeTruthy();
                 expect(fix.componentInstance.grid.rowList.length).toEqual(11);
-            }));
+        }));
+
+        fit(`should render grid with correct height when parent container\'s height is set
+            and the total row height is smaller than parent height #1861`, fakeAsync(() => {
+                const fix = TestBed.createComponent(IgxGridFixedContainerHeightComponent);
+                fix.componentInstance.grid.height = '100%';
+                fix.componentInstance.paging = true;
+                fix.componentInstance.data = fix.componentInstance.data.slice(0, 5);
+
+                tick();
+                fix.detectChanges();
+                const domGrid = fix.debugElement.query(By.css('igx-grid')).nativeElement;
+                expect(parseInt(window.getComputedStyle(domGrid).height, 10)).toBe(300);
+        }));
+
+        it(`should render grid with correct height when height is in percent and the
+            sum height of all rows is lower than parent height #1858`, fakeAsync(() => {
+                const fix = TestBed.createComponent(IgxGridFixedContainerHeightComponent);
+                fix.componentInstance.grid.height = '100%';
+                fix.componentInstance.data = fix.componentInstance.data.slice(0, 3);
+
+                tick();
+                fix.detectChanges();
+                const domGrid = fix.debugElement.query(By.css('igx-grid')).nativeElement;
+                expect(parseInt(window.getComputedStyle(domGrid).height, 10)).toBe(300);
+        }));
 
         it('should render correct columns if after scrolling right container size changes so that all columns become visible.',
         async () => {
@@ -3469,6 +3495,20 @@ export class IgxGridWrappedInContComponent extends IgxGridTestComponent {
     public density = DisplayDensity.comfortable;
     public outerWidth = 800;
     public outerHeight: number;
+}
+
+@Component({
+    template:
+        `<div style="height:300px">
+            <igx-grid #grid [data]="data" [displayDensity]="density" [autoGenerate]="true"
+                [paging]="paging" [perPage]="pageSize">
+            </igx-grid>
+        </div>`
+})
+export class IgxGridFixedContainerHeightComponent extends IgxGridWrappedInContComponent {
+    public paging = false;
+    public pageSize = 5;
+    public density = DisplayDensity.comfortable;
 }
 
 @Component({

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -762,6 +762,7 @@ describe('IgxGrid Component Tests', () => {
 
         it('Should render date and number values based on default formatting', () => {
             const fixture = TestBed.createComponent(IgxGridFormattingComponent);
+            fixture.componentInstance.grid.height = null;
             fixture.detectChanges();
             const grid = fixture.componentInstance.grid;
             const rows = grid.rowList.toArray();

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -142,8 +142,9 @@ describe('IgxGrid Component Tests', () => {
             }
         });
 
-        it('height/width should be calculated depending on number of records', fakeAsync(() => {
+        it('height/width should be calculated depending on number of records when height = null', fakeAsync(() => {
             const fix = TestBed.createComponent(IgxGridTestComponent);
+            fix.componentInstance.height = null;
             fix.detectChanges();
 
             const grid = fix.componentInstance.grid;
@@ -267,6 +268,7 @@ describe('IgxGrid Component Tests', () => {
         it('should render empty message', fakeAsync(() => {
             const fixture = TestBed.createComponent(IgxGridTestComponent);
             fixture.componentInstance.data = [];
+            fixture.componentInstance.height = null;
             fixture.detectChanges();
 
             const grid = fixture.componentInstance.grid;
@@ -3306,7 +3308,7 @@ describe('IgxGrid Component Tests', () => {
 
 @Component({
     template: `<div style="width: 800px; height: 600px;">
-        <igx-grid #grid [data]="data" [autoGenerate]="autoGenerate" (onColumnInit)="columnCreated($event)">
+        <igx-grid #grid [data]="data" [autoGenerate]="autoGenerate" (onColumnInit)="columnCreated($event)" [height]="height">
             <igx-column *ngFor="let column of columns;" [field]="column.field" [hasSummary]="column.hasSummary"
                 [header]="column.field" [width]="column.width">
             </igx-column>
@@ -3322,7 +3324,7 @@ export class IgxGridTestComponent {
     @ViewChild('grid') public grid: IgxGridComponent;
 
     public autoGenerate = false;
-
+    public height = '100%';
     public columnEventCount = 0;
 
     public columnCreated(column: IgxColumnComponent) {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.crud.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.crud.spec.ts
@@ -46,7 +46,8 @@ describe('IgxGrid - CRUD operations', () => {
         expect(grid.rowList.length).toEqual(grid.data.length);
     });
 
-    it('should support adding rows by manipulating the `data` @Input of the grid', () => {
+    it('should support adding rows by manipulating the `data` @Input of the grid', fakeAsync(() => {
+        fix.componentInstance.instance.height = null;
         // Add to the data array without changing the reference
         // with manual detection
         for (let i = 0; i < 10; i++) {
@@ -55,6 +56,8 @@ describe('IgxGrid - CRUD operations', () => {
 
         grid.cdr.markForCheck();
         fix.detectChanges();
+
+        tick(1000);
 
         expect(grid.data.length).toEqual(fix.componentInstance.data.length);
         expect(grid.rowList.length).toEqual(fix.componentInstance.data.length);
@@ -70,7 +73,7 @@ describe('IgxGrid - CRUD operations', () => {
 
         expect(grid.data.length).toEqual(fix.componentInstance.data.length);
         expect(grid.rowList.length).toEqual(fix.componentInstance.data.length);
-    });
+    }));
 
     it('should support deleting rows through the grid API', () => {
         grid.deleteRow(1);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.search.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.search.spec.ts
@@ -842,6 +842,7 @@ describe('IgxGrid - search API', () => {
         });
 
         it('Should be able to navigate through highlights with grouping enabled', async () => {
+            grid.height = null;
             grid.groupBy({
                 fieldName: 'JobTitle',
                 dir: SortingDirection.Asc,
@@ -989,6 +990,7 @@ describe('IgxGrid - search API', () => {
         });
 
         it('Should be able to properly handle perPage changes with gouping and paging', async () => {
+            grid.height = null;
             grid.groupBy({
                 fieldName: 'JobTitle',
                 dir: SortingDirection.Asc,
@@ -1034,6 +1036,7 @@ describe('IgxGrid - search API', () => {
         });
 
         it('Should be able to properly handle navigating through collapsed rows', async () => {
+            grid.height = null;
             grid.groupBy({
                 fieldName: 'JobTitle',
                 dir: SortingDirection.Asc,


### PR DESCRIPTION
#1861 
#1858

### Description
The grid now won't set height=null internally in some conditions. The default height=100% will be set to the grid as it is by [specification](https://github.com/IgniteUI/igniteui-angular/wiki/igxGrid-Specification#height). The developer should explicitly set height=null if he wants the grid to render all rows without a vertical scrollbar.

### Additional information (check all that apply):
 - [X] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [X] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 