### PR TITLE
fix(Grid): fix and test for #3952 - Sort expressions order should be …

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
@@ -163,10 +163,10 @@ export class IgxGridComponent extends IgxGridBaseComponent implements OnInit, Do
         this._groupingExpressions = cloneArray(value);
         this.chipsGoupingExpressions = cloneArray(value);
         if (this._gridAPI.get(this.id)) {
-            this._gridAPI.arrange_sorting_expressions(this.id);
             /* grouping should work in conjunction with sorting
             and without overriding separate sorting expressions */
             this._applyGrouping();
+            this._gridAPI.arrange_sorting_expressions(this.id);
             this.cdr.markForCheck();
         } else {
             // setter called before grid is registered in grid API service

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
@@ -2298,23 +2298,23 @@ describe('IgxGrid - GroupBy', () => {
 
         grid.sort({ fieldName: 'Downloads', dir: SortingDirection.Asc, ignoreCase: false });
         grid.sort({ fieldName: 'ID', dir: SortingDirection.Desc, ignoreCase: false });
-
+        fix.detectChanges();
         expect(grid.sortingExpressions).toEqual([
-            { fieldName: 'Downloads', dir: SortingDirection.Asc, ignoreCase: false },
-            { fieldName: 'ID', dir: SortingDirection.Desc, ignoreCase: false }
+            { fieldName: 'Downloads', dir: SortingDirection.Asc, ignoreCase: false, strategy: DefaultSortingStrategy.instance() },
+            { fieldName: 'ID', dir: SortingDirection.Desc, ignoreCase: false, strategy: DefaultSortingStrategy.instance() }
         ]);
         expect(grid.groupingExpressions).toEqual([]);
 
-        grid.groupBy({ fieldName: 'Released', dir: SortingDirection.Asc, ignoreCase: false });
-        grid.sort({ fieldName: 'Released', dir: SortingDirection.Desc, ignoreCase: false });
-
+        grid.groupBy({ fieldName: 'Released', dir: SortingDirection.Asc, ignoreCase: false, strategy: DefaultSortingStrategy.instance() });
+        grid.sort({ fieldName: 'Released', dir: SortingDirection.Desc, ignoreCase: false, strategy: DefaultSortingStrategy.instance() });
+        fix.detectChanges();
         expect(grid.sortingExpressions).toEqual([
-            { fieldName: 'Released', dir: SortingDirection.Desc, ignoreCase: false },
+            { fieldName: 'Released', dir: SortingDirection.Desc, ignoreCase: false, strategy: DefaultSortingStrategy.instance() },
             { fieldName: 'Downloads', dir: SortingDirection.Asc, ignoreCase: false, strategy: DefaultSortingStrategy.instance() },
             { fieldName: 'ID', dir: SortingDirection.Desc, ignoreCase: false, strategy: DefaultSortingStrategy.instance() }
         ]);
         expect(grid.groupingExpressions).toEqual([{
-            fieldName: 'Released', dir: SortingDirection.Desc, ignoreCase: false
+            fieldName: 'Released', dir: SortingDirection.Desc, ignoreCase: false, strategy: DefaultSortingStrategy.instance()
         }]);
     });
 
@@ -2419,6 +2419,46 @@ describe('IgxGrid - GroupBy', () => {
          const chips = fix.nativeElement.querySelectorAll('igx-chip');
         expect(chips[0].getAttribute('title')).toEqual('ProductName');
         expect(chips[1].getAttribute('title')).toEqual('Released');
+    });
+
+    it('should order sorting expressions correctly when setting groupingExpressions runtime.', () => {
+        const fix = TestBed.createComponent(DefaultGridComponent);
+        fix.detectChanges();
+
+        const sExprs: ISortingExpression[] = [
+            { fieldName: 'Released', dir: SortingDirection.Desc, ignoreCase: true }
+        ];
+        const grid = fix.componentInstance.instance;
+        grid.sortingExpressions = sExprs;
+
+        fix.detectChanges();
+        let dataRows = grid.dataRowList.toArray();
+        expect(dataRows.length).toEqual(8);
+        // verify data records order
+        const expectedDataRecsOrder = [true, true, true, true, false, false, false, null];
+        dataRows.forEach((row, index) => {
+            expect(row.rowData.Released).toEqual(expectedDataRecsOrder[index]);
+        });
+
+        const grExprs: ISortingExpression[] = [
+            { fieldName: 'ProductName', dir: SortingDirection.Desc, ignoreCase: true }
+        ];
+        grid.groupingExpressions = grExprs;
+        fix.detectChanges();
+
+        // check sorting expressions order - grouping should be applied first
+        expect(grid.sortingExpressions.length).toBe(2);
+        expect(grid.sortingExpressions[0]).toBe(grExprs[0]);
+        expect(grid.sortingExpressions[1]).toBe(sExprs[0]);
+
+        dataRows = grid.dataRowList.toArray();
+        const expectedReleaseRecsOrder = [true, false, true, false, false, null, true, true];
+        const expectedProductNameOrder = ['NetAdvantage', 'NetAdvantage', 'Ignite UI for JavaScript', 'Ignite UI for JavaScript',
+         'Ignite UI for Angular', 'Ignite UI for Angular', '', null];
+        dataRows.forEach((row, index) => {
+            expect(row.rowData.Released).toEqual(expectedReleaseRecsOrder[index]);
+            expect(row.rowData.ProductName).toEqual(expectedProductNameOrder[index]);
+        });
     });
 
     function sendInput(element, text, fix) {


### PR DESCRIPTION
…correct when setting groupingExpressions runtime.

Closes #3952   

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 