### PR TITLE
fix(igxHierarchicalGrid): There is no possible way to get row island column reference specific to grid through template.

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-header.component.html
+++ b/projects/igniteui-angular/src/lib/grids/grid-header.component.html
@@ -3,7 +3,7 @@
 </ng-template>
 
 <span class="igx-grid__th-title">
-    <ng-container *ngTemplateOutlet="column.headerTemplate ? column.headerTemplate : defaultColumn; context: { $implicit: column }">
+    <ng-container *ngTemplateOutlet="column.headerTemplate ? column.headerTemplate : defaultColumn; context: { $implicit: column, column: column}">
     </ng-container>
 </span>
 <div class="igx-grid__th-icons" *ngIf="!column.columnGroup">

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.integration.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.integration.spec.ts
@@ -9,12 +9,13 @@ import { IgxRowIslandComponent } from './row-island.component';
 import { wait, UIInteractions } from '../../test-utils/ui-interactions.spec';
 import { SortingDirection } from '../../data-operations/sorting-expression.interface';
 import { DefaultSortingStrategy } from '../../data-operations/sorting-strategy';
-import { IgxGridGroupByRowComponent, IgxColumnMovingDragDirective } from '../grid';
+import { IgxGridGroupByRowComponent, IgxColumnMovingDragDirective, IgxColumnComponent } from '../grid';
 import { IgxHierarchicalRowComponent } from './hierarchical-row.component';
 import { IgxChildGridRowComponent } from './child-grid-row.component';
 import { IgxStringFilteringOperand } from '../../data-operations/filtering-condition';
 import { take } from 'rxjs/operators';
 import { IgxHierarchicalTransactionServiceFactory } from './hierarchical-grid-base.component';
+import { IgxIconModule } from '../../icon';
 
 describe('IgxHierarchicalGrid Integration', () => {
     configureTestSuite();
@@ -27,7 +28,7 @@ describe('IgxHierarchicalGrid Integration', () => {
                 IgxHierarchicalGridTestCustomToolbarComponent
             ],
             imports: [
-                NoopAnimationsModule, IgxHierarchicalGridModule]
+                NoopAnimationsModule, IgxHierarchicalGridModule, IgxIconModule]
         }).compileComponents();
     }));
 
@@ -667,7 +668,7 @@ describe('IgxHierarchicalGrid Integration', () => {
             // Check visible columns and headers are rendered correctly
             let childHeaders = childGrids[0].queryAll(By.css('igx-grid-header'));
             expect(childGrid.pinnedColumns.length).toEqual(0);
-            expect(childHeaders[0].children[0].nativeElement.innerText.trim()).toEqual('ID');
+            expect(childHeaders[0].children[0].nativeElement.children[0].children[0].innerText.trim()).toEqual('ID');
             expect(childHeaders[1].children[0].nativeElement.innerText.trim()).toEqual('ChildLevels');
             expect(childHeaders[2].children[0].nativeElement.innerText.trim()).toEqual('ProductName');
 
@@ -695,7 +696,7 @@ describe('IgxHierarchicalGrid Integration', () => {
             expect(childGrid.pinnedColumns.length).toEqual(3);
             expect(childHeaders[0].children[0].nativeElement.innerText.trim()).toEqual('ChildLevels');
             expect(childHeaders[1].children[0].nativeElement.innerText.trim()).toEqual('ProductName');
-            expect(childHeaders[2].children[0].nativeElement.innerText.trim()).toEqual('ID');
+            expect(childHeaders[2].children[0].nativeElement.children[0].children[0].innerText.trim()).toEqual('ID');
         });
 
         it('should read from custom templates per level', () => {
@@ -756,6 +757,31 @@ describe('IgxHierarchicalGrid Integration', () => {
             expect(mainHeaders[2].children[0].innerText.trim()).toEqual('ProductName');
         }));
     });
+
+    describe('Pinning', () => {
+        it('should be possible by templating the header and getting column reference for child grid', (async() => {
+            hierarchicalGrid = fixture.componentInstance.hgrid;
+            hierarchicalGrid.dataRowList.toArray()[0].nativeElement.children[0].click();
+            fixture.detectChanges();
+
+            const childGrids =  fixture.debugElement.queryAll(By.css('igx-child-grid-row'));
+            const childGrid = childGrids[0].query(By.css('igx-hierarchical-grid')).componentInstance;
+            let headers = childGrid.nativeElement.querySelectorAll('igx-grid-header-group');
+            const firstHeaderIcon = headers[0].querySelector('igx-icon');
+
+            expect(headers[0].classList.contains('igx-grid__th--pinned')).toBeFalsy();
+            expect(childGrid.columnList.toArray()[0].pinned).toBeFalsy();
+            expect(firstHeaderIcon).toBeTruthy();
+
+            firstHeaderIcon.click();
+            await wait();
+            fixture.detectChanges();
+
+            headers = childGrid.nativeElement.querySelectorAll('igx-grid-header-group');
+            expect(childGrid.columnList.toArray()[0].pinned).toBeTruthy();
+            expect(headers[0].classList.contains('igx-grid__th--pinned')).toBeTruthy();
+        }));
+    });
 });
 
 @Component({
@@ -769,7 +795,14 @@ describe('IgxHierarchicalGrid Integration', () => {
         </igx-column-group>
         <igx-row-island [key]="'childData'" #rowIsland [allowFiltering]="true" [rowEditable]="true"
             [primaryKey]="'ID'" [showToolbar]="true" [columnHiding]="true" [columnPinning]="true">
-            <igx-column field="ID" [groupable]='true' [hasSummary]='true' [movable]='true'></igx-column>
+            <igx-column field="ID" [groupable]='true' [hasSummary]='true' [movable]='true'>
+                <ng-template igxHeader let-columnRef="column">
+                    <div>
+                        <span>ID</span>
+                        <igx-icon fontSet="material" (click)="pinColumn(columnRef)">lock</igx-icon>
+                    </div>
+                </ng-template>
+            </igx-column>
             <igx-column-group header="Information">
                     <igx-column field="ChildLevels" [groupable]='true' [sortable]='true' [editable]="true"></igx-column>
                     <igx-column field="ProductName" [groupable]='true'></igx-column>
@@ -809,6 +842,10 @@ export class IgxHierarchicalGridTestBaseComponent {
             'Col2': i, 'Col3': i, childData: children, childData2: children });
         }
         return prods;
+    }
+
+    pinColumn(column: IgxColumnComponent) {
+        column.pinned ? column.unpin() : column.pin();
     }
 }
 


### PR DESCRIPTION
Closes #3998

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 