### PR TITLE
fix(selection): do not clear selection on `add_items` with empty array

### DIFF
--- a/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
@@ -1060,6 +1060,27 @@ describe('igxCombo', () => {
                 cancel: false
             });
         }));
+
+        it(`Should properly handle 'selectItems([]) call'`, fakeAsync(() => {
+            const fix = TestBed.createComponent(IgxComboSampleComponent);
+            fix.detectChanges();
+            const combo = fix.componentInstance.combo;
+            combo.selectItems([], false);
+            expect(combo.selectedItems()).toEqual([]);
+            combo.selectItems([], true);
+            expect(combo.selectedItems()).toEqual([]);
+            const selectedItems = combo.data.slice(0, 3);
+            combo.selectItems(combo.data.slice(0, 3), true);
+            expect(combo.selectedItems()).toEqual(selectedItems);
+            combo.selectItems([], false);
+            expect(combo.selectedItems()).toEqual(selectedItems);
+            selectedItems.push(combo.data[3]);
+            combo.selectItems([combo.data[3]], false);
+            expect(combo.selectedItems()).toEqual(combo.data.slice(0, 4));
+            combo.selectItems([], true);
+            expect(combo.selectedItems()).toEqual([]);
+        }));
+
         it('Should properly select/deselect ALL items', fakeAsync(() => {
             const fix = TestBed.createComponent(IgxComboSampleComponent);
             fix.detectChanges();

--- a/projects/igniteui-angular/src/lib/core/selection.ts
+++ b/projects/igniteui-angular/src/lib/core/selection.ts
@@ -88,6 +88,8 @@ export class IgxSelectionAPIService {
         let selection: Set<any>;
         if (clearSelection) {
             selection = this.get_empty();
+        } else if (itemIDs && itemIDs.length === 0) {
+            selection = new Set(this.get(componentID));
         }
         itemIDs.forEach((item) => selection = this.add_item(componentID, item, selection));
         return selection;


### PR DESCRIPTION
Closes #4106

When `add_items` is called with an empty Array, the result would be undefined, even if the selection was not empty.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 