### PR TITLE
fix(hgrid): Set summary indentation to 0 for leaf childs #4108

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.html
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.html
@@ -103,7 +103,14 @@
 
 
 <div class="igx-grid__tfoot" role="rowgroup" [style.height.px]='summariesHeight' #tfoot>
-    <igx-grid-summary-row [style.width.px]='calcWidth' [style.height.px]='summariesHeight' *ngIf="hasSummarizedColumns && rootSummariesEnabled" [gridID]="id" [summaries]="id | igxGridSummaryDataPipe:summaryService.retriggerRootPipe" [indentation]="1" [index]="0" class="igx-grid__summaries"  #summaryRow>
+    <igx-grid-summary-row [style.width.px]='calcWidth' [style.height.px]='summariesHeight'
+        *ngIf="hasSummarizedColumns && rootSummariesEnabled"
+        [gridID]="id"
+        [summaries]="id | igxGridSummaryDataPipe:summaryService.retriggerRootPipe"
+        [indentation]="hasExpandableChildren ? 1 : 0"
+        [index]="0"
+        class="igx-grid__summaries"
+        #summaryRow>
     </igx-grid-summary-row>
     <div class="igx-grid__tfoot-thumb" [hidden]='!hasVerticalSroll()' [style.height.px]='summariesHeight' [style.width.px]="scrollWidth"></div>
 </div>

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.integration.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.integration.spec.ts
@@ -410,6 +410,7 @@ describe('IgxHierarchicalGrid Integration', () => {
     });
 
     describe('Summaries', () => {
+        const INDENT_LEVEL_CLASS = 'igx-grid__row-indentation--level-1';
         it('should allow defining summaries for child grid and child should be sized correctly.', () => {
             hierarchicalGrid.dataRowList.toArray()[0].nativeElement.children[0].click();
             fixture.detectChanges();
@@ -425,6 +426,9 @@ describe('IgxHierarchicalGrid Integration', () => {
             expect(summaryRow.children[0].offsetWidth).toEqual(expander.nativeElement.offsetWidth);
             expect(summaryRow.children[1].tagName.toLowerCase()).toEqual('igx-display-container');
 
+            // there should be indentation of the summaries
+            expect(summaryRow.children[0].className.indexOf(INDENT_LEVEL_CLASS) !== -1).toBe(true);
+
             const gridHeight = childGrid.nativeElement.offsetHeight;
             const childElems: HTMLElement[] = Array.from(childGrid.nativeElement.children);
             const elementsHeight = childElems.map(elem => elem.offsetHeight).reduce((total, height) => {
@@ -433,6 +437,17 @@ describe('IgxHierarchicalGrid Integration', () => {
 
             // Expect the combined height of all elements (header, body, footer etc) to equal the calculated height of the grid.
             expect(elementsHeight).toEqual(gridHeight);
+
+            childGrid.dataRowList.toArray()[0].nativeElement.children[0].click();
+            fixture.detectChanges();
+
+            const childGridDebugElement = childGrids[0].query(By.css('igx-hierarchical-grid'));
+            const grandChild = childGridDebugElement.query(By.css('igx-hierarchical-grid')).componentInstance;
+            const grandChildSummaryRow = grandChild.summariesRowList.first.nativeElement;
+
+            expect(grandChildSummaryRow.children.length).toEqual(1);
+            // there should be no indentation of the summaries of the leaf grid
+            expect(grandChildSummaryRow.children[0].className.indexOf(INDENT_LEVEL_CLASS) === -1).toBe(true);
         });
 
         it('should render summaries for column inside a column group.', () => {


### PR DESCRIPTION
Closes #4108 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 