### PR TITLE
Remove calls to closeOnOutsideClick property

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/toggle/toggle.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/toggle/toggle.directive.ts
@@ -415,8 +415,8 @@ export class IgxToggleActionDirective implements OnInit {
      */
     @HostListener('click')
     public onClick() {
-        if (this.closeOnOutsideClick !== undefined) {
-            this._overlayDefaults.closeOnOutsideClick = this.closeOnOutsideClick;
+        if (this._closeOnOutsideClick !== undefined) {
+            this._overlayDefaults.closeOnOutsideClick = this._closeOnOutsideClick;
         }
         if (this.outlet) {
             this._overlayDefaults.outlet = this.outlet;


### PR DESCRIPTION
In onClick handler we were calling deprecated `closeOnOutsideClick` property. This was logging a deprecation message. Now we are calling directly the inner field and bypassing the property.

Closes #4126

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 