### PR TITLE
Adding 16px to the default typography scale for the body-1 rule

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/typography/_base.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/typography/_base.scss
@@ -156,7 +156,7 @@
             $line-height: rem(28px),
             $text-transform: none,
             $margin-top: rem(28px),
-            $margin-bottom: 0,
+            $margin-bottom: rem(16),
         ),
         body-2: igx-type-style(
             $font-size: rem(14px),


### PR DESCRIPTION
Related to #4156  

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 