### PR TITLE
fix(excelExporter): Set empty column header when exporting #3763

### DIFF
--- a/projects/igniteui-angular/src/lib/services/excel/excel-exporter-grid.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/excel/excel-exporter-grid.spec.ts
@@ -1,4 +1,5 @@
 import { async, TestBed } from '@angular/core/testing';
+import { Component, ViewChild } from '@angular/core';
 import { IgxGridModule } from '../../grids/grid';
 import { IgxGridComponent } from '../../grids/grid/grid.component';
 import { IColumnExportingEventArgs, IRowExportingEventArgs } from '../exporter-common/base-export-service';
@@ -32,7 +33,8 @@ describe('Excel Exporter', () => {
                 ReorderedColumnsComponent,
                 GridIDNameJobTitleComponent,
                 IgxTreeGridPrimaryForeignKeyComponent,
-                ProductsComponent
+                ProductsComponent,
+                GridWithEmtpyColumnsComponent
             ],
             imports: [IgxGridModule.forRoot(), IgxTreeGridModule]
         }).compileComponents();
@@ -418,6 +420,22 @@ describe('Excel Exporter', () => {
             // Verify the exported data with formatting
             await exportAndVerify(grid, options, actualData.simpleGridNameJobTitleWithFormatting);
         });
+
+        it('should export columns without header', async () => {
+            const fix = TestBed.createComponent(GridWithEmtpyColumnsComponent);
+            fix.detectChanges();
+
+            const grid = fix.componentInstance.grid;
+            // Verify the data without formatting
+            await exportAndVerify(grid, options, actualData.gridWithEmptyColums);
+
+            exporter.onColumnExport.subscribe((value: IColumnExportingEventArgs) => {
+                if (value.columnIndex === 0 || value.columnIndex === 2) {
+                    value.cancel = true;
+                }
+            });
+            await exportAndVerify(grid, options, actualData.simpleGridData);
+        });
     });
 
     describe('', () => {
@@ -602,3 +620,24 @@ describe('Excel Exporter', () => {
         await wrapper.verifyDataFilesContent(expectedData);
     }
 });
+
+@Component({
+    template: `
+    <igx-grid #grid1 [data]="data">
+        <igx-column>
+            <ng-template igxCell>
+                <button>SimpleBtn</button>
+            </ng-template>
+        </igx-column>
+        <igx-column header="" field="ID"></igx-column>
+        <igx-column header="  " field=""></igx-column>
+        <igx-column header="Name" field="Name"></igx-column>
+        <igx-column header="JobTitle" field="JobTitle"></igx-column>
+    </igx-grid>`
+})
+
+export class GridWithEmtpyColumnsComponent {
+    public data = SampleTestData.personJobDataFull();
+
+    @ViewChild('grid1') public grid: IgxGridComponent;
+}

--- a/projects/igniteui-angular/src/lib/services/excel/test-data.service.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/excel/test-data.service.spec.ts
@@ -853,5 +853,22 @@ export class FileContentData {
 
         return this.createData();
     }
+
+    get gridWithEmptyColums() {
+        this._sharedStringsData =
+            `count="25" uniqueCount="23"><si><t>Column1</t></si><si><t>ID</t></si><si><t>Column2</t></si><si><t>Name</t></si><si><t>JobTitle</t></si><si><t>Casey Houston</t></si><si><t>Vice President</t></si><si><t>Gilberto Todd</t></si><si><t>Director</t></si><si><t>Tanya Bennett</t></si><si><t>Jack Simon</t></si><si><t>Software Developer</t></si><si><t>Celia Martinez</t></si><si><t>Senior Software Developer</t></si><si><t>Erma Walsh</t></si><si><t>CEO</t></si><si><t>Debra Morton</t></si><si><t>Associate Software Developer</t></si><si><t>Erika Wells</t></si><si><t>Software Development Team Lead</t></si><si><t>Leslie Hansen</t></si><si><t>Eduardo Ramirez</t></si><si><t>Manager</t></si>`;
+
+        this._tableData = `ref="A1:E11" totalsRowShown="0">
+        <autoFilter ref="A1:E11"/><tableColumns count="5"><tableColumn id="1" name="Column1"/><tableColumn id="2" name="ID"/><tableColumn id="3" name="Column2"/><tableColumn id="4" name="Name"/><tableColumn id="5" name="JobTitle"/></tableColumns>`;
+
+        this._worksheetData = `
+        <dimension ref="A1:E11"/>
+<sheetViews><sheetView tabSelected="1" workbookViewId="0"></sheetView></sheetViews>
+<sheetFormatPr defaultRowHeight="15"  x14ac:dyDescent="0.25"/>
+<cols><col min="1" max="1" width="50" customWidth="1"/><col min="2" max="2" width="50" customWidth="1"/><col min="3" max="3" width="50" customWidth="1"/><col min="4" max="4" width="50" customWidth="1"/><col min="5" max="5" width="50" customWidth="1"/></cols>
+<sheetData><row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c><c r="C1" t="s"><v>2</v></c><c r="D1" t="s"><v>3</v></c><c r="E1" t="s"><v>4</v></c></row><row r="2"><c r="A2" s="1"/><c r="B2" s="1"><v>1</v></c><c r="C2" s="1"/><c r="D2" t="s"><v>5</v></c><c r="E2" t="s"><v>6</v></c></row><row r="3"><c r="A3" s="1"/><c r="B3" s="1"><v>2</v></c><c r="C3" s="1"/><c r="D3" t="s"><v>7</v></c><c r="E3" t="s"><v>8</v></c></row><row r="4"><c r="A4" s="1"/><c r="B4" s="1"><v>3</v></c><c r="C4" s="1"/><c r="D4" t="s"><v>9</v></c><c r="E4" t="s"><v>8</v></c></row><row r="5"><c r="A5" s="1"/><c r="B5" s="1"><v>4</v></c><c r="C5" s="1"/><c r="D5" t="s"><v>10</v></c><c r="E5" t="s"><v>11</v></c></row><row r="6"><c r="A6" s="1"/><c r="B6" s="1"><v>5</v></c><c r="C6" s="1"/><c r="D6" t="s"><v>12</v></c><c r="E6" t="s"><v>13</v></c></row><row r="7"><c r="A7" s="1"/><c r="B7" s="1"><v>6</v></c><c r="C7" s="1"/><c r="D7" t="s"><v>14</v></c><c r="E7" t="s"><v>15</v></c></row><row r="8"><c r="A8" s="1"/><c r="B8" s="1"><v>7</v></c><c r="C8" s="1"/><c r="D8" t="s"><v>16</v></c><c r="E8" t="s"><v>17</v></c></row><row r="9"><c r="A9" s="1"/><c r="B9" s="1"><v>8</v></c><c r="C9" s="1"/><c r="D9" t="s"><v>18</v></c><c r="E9" t="s"><v>19</v></c></row><row r="10"><c r="A10" s="1"/><c r="B10" s="1"><v>9</v></c><c r="C10" s="1"/><c r="D10" t="s"><v>20</v></c><c r="E10" t="s"><v>17</v></c></row><row r="11"><c r="A11" s="1"/><c r="B11" s="1"><v>10</v></c><c r="C11" s="1"/><c r="D11" t="s"><v>21</v></c><c r="E11" t="s"><v>22</v></c></row></sheetData>`;
+
+        return this.createData();
+    }
     /* tslint:enable max-line-length */
 }

--- a/projects/igniteui-angular/src/lib/services/exporter-common/base-export-service.ts
+++ b/projects/igniteui-angular/src/lib/services/exporter-common/base-export-service.ts
@@ -170,10 +170,12 @@ export abstract class IgxBaseExporter {
         }
 
         let skippedPinnedColumnsCount = 0;
+        let columnsWithoutHeaderCount = 1;
         this._columnList.forEach((column, index) => {
             if (!column.skip) {
                 const columnExportArgs = {
-                    header: column.header,
+                    header: ExportUtilities.isNullOrWhitespaces(column.header) ?
+                        'Column' + columnsWithoutHeaderCount++ : column.header,
                     field: column.field,
                     columnIndex: index,
                     cancel: false,

--- a/projects/igniteui-angular/src/lib/services/exporter-common/export-utilities.ts
+++ b/projects/igniteui-angular/src/lib/services/exporter-common/export-utilities.ts
@@ -60,4 +60,7 @@ export class ExportUtilities {
         return value !== undefined && value !== null;
     }
 
+    public static isNullOrWhitespaces(value: string): boolean {
+        return value === undefined || value === null || !value.trim();
+    }
 }


### PR DESCRIPTION
Set 'Column[N]' header to columns without header set when exporting(frequent case for template columns)
Closes #3763

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 