### PR TITLE
Change content div position to relative in flex wrapper

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/overlay/_overlay-component.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/overlay/_overlay-component.scss
@@ -38,6 +38,11 @@
         @extend %overlay-content !optional;
         @extend %overlay-content--elastic !optional;
     }
+
+    @include e(content, $m: relative) {
+        @extend %overlay-content !optional;
+        @extend %overlay-content--relative !optional;
+    }
 }
 
 @include b(igx-toggle) {

--- a/projects/igniteui-angular/src/lib/core/styles/components/overlay/_overlay-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/overlay/_overlay-theme.scss
@@ -80,11 +80,15 @@
         pointer-events: initial;
     }
 
-    %igx-toggle--hidden {
-        display: none !important;
-    }
-
     %overlay-content--elastic {
         overflow: auto;
+    }
+
+    %overlay-content--relative {
+        position: relative;
+    }
+
+    %igx-toggle--hidden {
+        display: none !important;
     }
 }

--- a/projects/igniteui-angular/src/lib/services/overlay/position/global-position-strategy.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/position/global-position-strategy.ts
@@ -25,6 +25,7 @@ export class GlobalPositionStrategy implements IPositionStrategy {
     }
 
     position(contentElement: HTMLElement, size?: Size, document?: Document, initialCall?: boolean): void {
+        contentElement.classList.add('igx-overlay__content--relative');
         contentElement.parentElement.classList.add('igx-overlay__wrapper--flex');
         switch (this.settings.horizontalDirection) {
             case HorizontalAlignment.Left:


### PR DESCRIPTION
When position strategy is global we are using flex container to position the content. In this case, in order to position content correctly even in IE, we should set content div's position to relative.

Closes #4220   

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 