### PR TITLE
Fixing #1861 and #1858 7.1.x

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -3594,9 +3594,6 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
         if (!this.nativeElement.parentNode || !this.nativeElement.parentNode.clientHeight) {
             const viewPortHeight = document.documentElement.clientHeight;
             this._height = this.rowBasedHeight <= viewPortHeight ? null : viewPortHeight.toString();
-        } else {
-            const parentHeight = this.nativeElement.parentNode.getBoundingClientRect().height;
-            this._height = this.rowBasedHeight <= parentHeight ? null : this._height;
         }
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -3674,7 +3674,7 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
      */
     private get defaultTargetBodyHeight(): number {
         const allItems = this.totalItemCount || this.dataLength;
-        return this.rowHeight * Math.min(this._defaultTargetRecordNumber,
+        return (this.rowHeight + 1) * Math.min(this._defaultTargetRecordNumber,
             this.paging ? Math.min(allItems, this.perPage) : allItems);
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
@@ -457,8 +457,9 @@ describe('IgxGrid - Summaries', () => {
             let grid: IgxGridComponent;
             beforeEach(() => {
                 fix = TestBed.createComponent(SummaryColumnComponent);
-                fix.detectChanges();
                 grid = fix.componentInstance.grid;
+                grid.height = null;
+                fix.detectChanges();
             });
 
             it('Filtering: should calculate summaries only over filteredData', () => {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -705,7 +705,7 @@ describe('IgxGrid Component Tests', () => {
                 const defaultHeight = fix.debugElement.query(By.css(TBODY_CLASS)).styles.height;
                 const defaultHeightNum = parseInt(defaultHeight, 10);
                 expect(defaultHeight).not.toBeNull();
-                expect(defaultHeightNum).toBe(320);
+                expect(defaultHeightNum).toBe(330);
                 expect(fix.componentInstance.isVerticalScrollbarVisible()).toBeTruthy();
                 expect(fix.componentInstance.grid.rowList.length).toEqual(11);
         }));
@@ -3270,7 +3270,7 @@ describe('IgxGrid Component Tests', () => {
             fix.detectChanges();
             const grid = fix.componentInstance.grid3;
             const tab = fix.componentInstance.tabs;
-            expect(grid.calcHeight).toBe(500);
+            expect(grid.calcHeight).toBe(510);
             tab.tabs.toArray()[2].select();
             await wait(100);
             fix.detectChanges();
@@ -3332,7 +3332,7 @@ describe('IgxGrid Component Tests', () => {
 
             const grid = fix.componentInstance.grid5;
             const tab = fix.componentInstance.tabs;
-            expect(grid.calcHeight).toBe(200);
+            expect(grid.calcHeight).toBe(204);
             tab.tabs.toArray()[4].select();
             await wait(100);
             fix.detectChanges();
@@ -3342,7 +3342,7 @@ describe('IgxGrid Component Tests', () => {
             const gridBody = fix.debugElement.query(By.css(TBODY_CLASS));
             const paging = fix.debugElement.query(By.css('.igx-paginator'));
             expect(headers.length).toBe(4);
-            expect(parseInt(window.getComputedStyle(gridBody.nativeElement).height, 10)).toBe(200);
+            expect(parseInt(window.getComputedStyle(gridBody.nativeElement).height, 10)).toBe(204);
             expect(parseInt(window.getComputedStyle(paging.nativeElement).height, 10)).toBe(47);
         });
     });

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -269,7 +269,6 @@ describe('IgxGrid Component Tests', () => {
         it('should render empty message', fakeAsync(() => {
             const fixture = TestBed.createComponent(IgxGridTestComponent);
             fixture.componentInstance.data = [];
-            fixture.componentInstance.height = null;
             fixture.detectChanges();
 
             const grid = fixture.componentInstance.grid;

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -143,8 +143,9 @@ describe('IgxGrid Component Tests', () => {
             }
         });
 
-        it('height/width should be calculated depending on number of records', fakeAsync(() => {
+        it('height/width should be calculated depending on number of records when height = null', fakeAsync(() => {
             const fix = TestBed.createComponent(IgxGridTestComponent);
+            fix.componentInstance.height = null;
             fix.detectChanges();
 
             const grid = fix.componentInstance.grid;
@@ -268,6 +269,7 @@ describe('IgxGrid Component Tests', () => {
         it('should render empty message', fakeAsync(() => {
             const fixture = TestBed.createComponent(IgxGridTestComponent);
             fixture.componentInstance.data = [];
+            fixture.componentInstance.height = null;
             fixture.detectChanges();
 
             const grid = fixture.componentInstance.grid;
@@ -3344,7 +3346,7 @@ describe('IgxGrid Component Tests', () => {
 
 @Component({
     template: `<div style="width: 800px; height: 600px;">
-        <igx-grid #grid [data]="data" [autoGenerate]="autoGenerate" (onColumnInit)="columnCreated($event)">
+        <igx-grid #grid [data]="data" [autoGenerate]="autoGenerate" (onColumnInit)="columnCreated($event)" [height]="height">
             <igx-column *ngFor="let column of columns;" [field]="column.field" [hasSummary]="column.hasSummary"
                 [header]="column.field" [width]="column.width">
             </igx-column>
@@ -3360,7 +3362,7 @@ export class IgxGridTestComponent {
     @ViewChild('grid') public grid: IgxGridComponent;
 
     public autoGenerate = false;
-
+    public height = '100%';
     public columnEventCount = 0;
 
     public columnCreated(column: IgxColumnComponent) {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -331,7 +331,8 @@ describe('IgxGrid Component Tests', () => {
                     IgxGridDefaultRenderingComponent,
                     IgxGridColumnPercentageWidthComponent,
                     IgxGridWrappedInContComponent,
-                    IgxGridFormattingComponent
+                    IgxGridFormattingComponent,
+                    IgxGridFixedContainerHeightComponent
                 ],
                 imports: [
                     NoopAnimationsModule, IgxGridModule.forRoot()]
@@ -706,7 +707,32 @@ describe('IgxGrid Component Tests', () => {
                 expect(defaultHeightNum).toBe(320);
                 expect(fix.componentInstance.isVerticalScrollbarVisible()).toBeTruthy();
                 expect(fix.componentInstance.grid.rowList.length).toEqual(11);
-            }));
+        }));
+
+        fit(`should render grid with correct height when parent container\'s height is set
+            and the total row height is smaller than parent height #1861`, fakeAsync(() => {
+                const fix = TestBed.createComponent(IgxGridFixedContainerHeightComponent);
+                fix.componentInstance.grid.height = '100%';
+                fix.componentInstance.paging = true;
+                fix.componentInstance.data = fix.componentInstance.data.slice(0, 5);
+
+                tick();
+                fix.detectChanges();
+                const domGrid = fix.debugElement.query(By.css('igx-grid')).nativeElement;
+                expect(parseInt(window.getComputedStyle(domGrid).height, 10)).toBe(300);
+        }));
+
+        it(`should render grid with correct height when height is in percent and the
+            sum height of all rows is lower than parent height #1858`, fakeAsync(() => {
+                const fix = TestBed.createComponent(IgxGridFixedContainerHeightComponent);
+                fix.componentInstance.grid.height = '100%';
+                fix.componentInstance.data = fix.componentInstance.data.slice(0, 3);
+
+                tick();
+                fix.detectChanges();
+                const domGrid = fix.debugElement.query(By.css('igx-grid')).nativeElement;
+                expect(parseInt(window.getComputedStyle(domGrid).height, 10)).toBe(300);
+        }));
 
         it('should render correct columns if after scrolling right container size changes so that all columns become visible.',
         async () => {
@@ -3507,6 +3533,20 @@ export class IgxGridWrappedInContComponent extends IgxGridTestComponent {
     public density = DisplayDensity.comfortable;
     public outerWidth = 800;
     public outerHeight: number;
+}
+
+@Component({
+    template:
+        `<div style="height:300px">
+            <igx-grid #grid [data]="data" [displayDensity]="density" [autoGenerate]="true"
+                [paging]="paging" [perPage]="pageSize">
+            </igx-grid>
+        </div>`
+})
+export class IgxGridFixedContainerHeightComponent extends IgxGridWrappedInContComponent {
+    public paging = false;
+    public pageSize = 5;
+    public density = DisplayDensity.comfortable;
 }
 
 @Component({

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -762,6 +762,7 @@ describe('IgxGrid Component Tests', () => {
 
         it('Should render date and number values based on default formatting', () => {
             const fixture = TestBed.createComponent(IgxGridFormattingComponent);
+            fixture.componentInstance.grid.height = null;
             fixture.detectChanges();
             const grid = fixture.componentInstance.grid;
             const rows = grid.rowList.toArray();

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -709,7 +709,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(fix.componentInstance.grid.rowList.length).toEqual(11);
         }));
 
-        fit(`should render grid with correct height when parent container\'s height is set
+        it(`should render grid with correct height when parent container\'s height is set
             and the total row height is smaller than parent height #1861`, fakeAsync(() => {
                 const fix = TestBed.createComponent(IgxGridFixedContainerHeightComponent);
                 fix.componentInstance.grid.height = '100%';

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.crud.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.crud.spec.ts
@@ -46,7 +46,8 @@ describe('IgxGrid - CRUD operations', () => {
         expect(grid.rowList.length).toEqual(grid.data.length);
     });
 
-    it('should support adding rows by manipulating the `data` @Input of the grid', () => {
+    it('should support adding rows by manipulating the `data` @Input of the grid', fakeAsync(() => {
+        fix.componentInstance.instance.height = null;
         // Add to the data array without changing the reference
         // with manual detection
         for (let i = 0; i < 10; i++) {
@@ -55,6 +56,8 @@ describe('IgxGrid - CRUD operations', () => {
 
         grid.cdr.markForCheck();
         fix.detectChanges();
+
+        tick(1000);
 
         expect(grid.data.length).toEqual(fix.componentInstance.data.length);
         expect(grid.rowList.length).toEqual(fix.componentInstance.data.length);
@@ -70,7 +73,7 @@ describe('IgxGrid - CRUD operations', () => {
 
         expect(grid.data.length).toEqual(fix.componentInstance.data.length);
         expect(grid.rowList.length).toEqual(fix.componentInstance.data.length);
-    });
+    }));
 
     it('should support deleting rows through the grid API', () => {
         grid.deleteRow(1);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.search.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.search.spec.ts
@@ -961,6 +961,7 @@ describe('IgxGrid - search API', () => {
         });
 
         it('Should be able to navigate through highlights with grouping enabled', async () => {
+            grid.height = null;
             grid.groupBy({
                 fieldName: 'JobTitle',
                 dir: SortingDirection.Asc,
@@ -1108,6 +1109,7 @@ describe('IgxGrid - search API', () => {
         });
 
         it('Should be able to properly handle perPage changes with gouping and paging', async () => {
+            grid.height = null;
             grid.groupBy({
                 fieldName: 'JobTitle',
                 dir: SortingDirection.Asc,
@@ -1153,6 +1155,7 @@ describe('IgxGrid - search API', () => {
         });
 
         it('Should be able to properly handle navigating through collapsed rows', async () => {
+            grid.height = null;
             grid.groupBy({
                 fieldName: 'JobTitle',
                 dir: SortingDirection.Asc,

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.spec.ts
@@ -76,7 +76,7 @@ describe('IgxTreeGrid Component Tests', () => {
                 expect(grid.rowList.length).toEqual(6);
         }));
 
-        it(`should render 11 records if height is 100% and parent container\'s height is unset and
+        it(`should render 12 records if height is 100% and parent container\'s height is unset and
             display density is changed`, fakeAsync(() => {
                 grid.height = '100%';
                 fix.componentInstance.density = DisplayDensity.compact;
@@ -85,10 +85,9 @@ describe('IgxTreeGrid Component Tests', () => {
                 const defaultHeight = fix.debugElement.query(By.css('.igx-grid__tbody')).styles.height;
                 const defaultHeightNum = parseInt(defaultHeight, 10);
                 expect(defaultHeight).not.toBeNull();
-                expect(defaultHeightNum).toBeGreaterThan(300);
-                expect(defaultHeightNum).toBeLessThan(330);
+                expect(defaultHeightNum).toBe(330);
                 expect(fix.componentInstance.isVerticalScrollbarVisible()).toBeTruthy();
-                expect(grid.rowList.length).toEqual(11);
+                expect(grid.rowList.length).toEqual(12);
         }));
 
         it('should display horizontal scroll bar when column width is set in %', async() => {


### PR DESCRIPTION
#1861 
#1858

### Description
The grid now won't set height=null internally in some conditions. The default height=100% will be set to the grid as it is by [specification](https://github.com/IgniteUI/igniteui-angular/wiki/igxGrid-Specification#height). The developer should explicitly set height=null if he wants the grid to render all rows without a vertical scrollbar.

### Additional information (check all that apply):
 - [X] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [X] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 