### PR TITLE
fix(combo): do not run filter + emit if search input value is unchanged

### DIFF
--- a/projects/igniteui-angular/src/lib/combo/combo.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.ts
@@ -112,7 +112,7 @@ const noop = () => { };
     }]
 })
 export class IgxComboComponent extends DisplayDensityBase implements IgxComboBase, AfterViewInit, ControlValueAccessor, OnInit,
- OnDestroy, EditorProvider {
+    OnDestroy, EditorProvider {
     /**
      * @hidden @internal
      */
@@ -128,6 +128,7 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
     protected _sortingExpressions: ISortingExpression[] = [];
     protected _groupKey = '';
     protected _displayKey: string;
+    protected _prevInputValue = '';
     private _dataType = '';
     private destroy$ = new Subject<any>();
     private _data = [];
@@ -1034,6 +1035,12 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
     public handleInputChange(event?: string) {
         let cdrFlag = false;
         const vContainer = this.dropdown.verticalScrollContainer;
+        if (event !== undefined && this._prevInputValue === event) {
+            // Nothing has changed
+            return;
+        } else {
+            this._prevInputValue = event !== undefined ? event : '';
+        }
         if (event !== undefined) {
             // Do not scroll if not scrollable
             if (vContainer.isScrollable()) {


### PR DESCRIPTION
Closes #4303 

Focusing the search input in IE causes Angular's `ngValueChanged` event to be fired (not fired in other browsers). When no change is made to the search value, the `handleSearchInput` method will no longer run.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 