### PR TITLE
fix(igxFor): Fixing chunksize calculations so that vertical space is always filled for last chunk.

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.spec.ts
@@ -108,7 +108,7 @@ describe('IgxForOf directive -', () => {
             }
         });
 
-        it('should always fill available space for last chunk size calculation', () => {
+        it('should always fill available space for last chunk size calculation - horizontal virtualization', () => {
             fix.componentInstance.width = '1900px';
             fix.componentInstance.cols = [
                 { field: '1', width: 100 },
@@ -263,6 +263,46 @@ describe('IgxForOf directive -', () => {
             await wait();
             rowsRendered = displayContainer.querySelectorAll('div');
             expect(rowsRendered.length).not.toBe(0);
+        });
+
+        it('should always fill available space for last chunk size calculation - vertical virtualization', () => {
+            fix.componentInstance.height = '1900px';
+            const virtualContainer = fix.componentInstance.parentVirtDir;
+            virtualContainer.igxForSizePropName = 'height';
+            fix.componentInstance.data = [
+                { '1': '1', height: '100px' },
+                {  '1': '2', height: '1800px' },
+                {  '1': '3', height: '200px' },
+                {  '1': '4', height: '200px' },
+                {  '1': '5', height: '300px' },
+                {  '1': '6', height: '100px' },
+                {  '1': '7', height: '100px' },
+                {  '1': '8', height: '100px' },
+                {  '1': '9', height: '150px' },
+                {  '1': '10', height: '150px' }
+            ];
+            fix.componentRef.hostView.detectChanges();
+            fix.detectChanges();
+            let chunkSize = (virtualContainer as any)._calcMaxChunkSize();
+            expect(chunkSize).toEqual(9);
+
+            fix.componentInstance.height = '1900px';
+            fix.componentInstance.data = [
+                {  '1': '1', height: '1800px' },
+                {  '1': '2', height: '100px' },
+                {  '1': '3', height: '200px' },
+                {  '1': '4', height: '200px' },
+                {  '1': '5', height: '300px' },
+                {  '1': '6', height: '100px' },
+                {  '1': '7', height: '100px' },
+                {  '1': '8', height: '100px' },
+                {  '1': '9', height: '150px' },
+                {  '1': '10', height: '150px' }
+            ];
+            fix.componentRef.hostView.detectChanges();
+            fix.detectChanges();
+            chunkSize = (virtualContainer as any)._calcMaxChunkSize();
+            expect(chunkSize).toEqual(10);
         });
     });
 
@@ -1187,7 +1227,7 @@ export class EmptyVirtualComponent {
                 [igxForScrollOrientation]="'vertical'"
                 [igxForContainerSize]='height'
                 [igxForItemSize]='"50px"'>
-                <div [style.display]="'flex'" [style.height]="'50px'">
+                <div [style.display]="'flex'" [style.height]="rowData.height || '50px'">
                     <div [style.min-width]=cols[0].width>{{rowData['1']}}</div>
                     <div [style.min-width]=cols[1].width>{{rowData['2']}}</div>
                     <div [style.min-width]=cols[2].width>{{rowData['3']}}</div>

--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
@@ -1004,9 +1004,11 @@ export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestr
                 if (i === this.igxForOf.length - 1) {
                     // reached end without exceeding
                     // include prev items until size is filled or first item is reached.
-                    let prevIndex = this.igxForOf.indexOf(arr[0]) - 1;
+                    let curItem = dimension === 'height' ? arr[0].value : arr[0];
+                    let prevIndex = this.igxForOf.indexOf(curItem) - 1;
                     while (prevIndex >= 0 && sum <= availableSize) {
-                        prevIndex = this.igxForOf.indexOf(arr[0]) - 1;
+                        curItem = dimension === 'height' ? arr[0].value : arr[0];
+                        prevIndex = this.igxForOf.indexOf(curItem) - 1;
                         const prevItem = this.igxForOf[prevIndex];
                         const prevSize = dimension === 'height' ?
                             this.heightCache[prevIndex] :


### PR DESCRIPTION
Should fix scenarios when expanding/collapsing in TreeGrid/HierarchicalGrid results in white space when items with large size are added to the view.