### PR TITLE
fix(HierarchicalGrid):  Making sure correct  pinned width is set when child grid width in % and there is expander.

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
@@ -284,7 +284,6 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseCompone
     private childGridTemplates: Map<any, any> = new Map();
     private scrollTop = 0;
     private scrollLeft = 0;
-    private _viewInitPased = false;
 
     constructor(
         public selectionService: IgxGridSelectionService,

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
@@ -27,7 +27,7 @@ import { IgxHierarchicalGridAPIService } from './hierarchical-grid-api.service';
 import { IgxRowIslandComponent } from './row-island.component';
 import { IgxChildGridRowComponent } from './child-grid-row.component';
 import { IgxFilteringService } from '../filtering/grid-filtering.service';
-import { IDisplayDensityOptions, DisplayDensityToken } from '../../core/displayDensity';
+import { IDisplayDensityOptions, DisplayDensityToken, DisplayDensity } from '../../core/displayDensity';
 import { IGridDataBindable, } from '../grid/index';
 import { DOCUMENT } from '@angular/common';
 import { IgxHierarchicalSelectionAPIService } from './selection';
@@ -284,6 +284,7 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseCompone
     private childGridTemplates: Map<any, any> = new Map();
     private scrollTop = 0;
     private scrollLeft = 0;
+    private _viewInitPased = false;
 
     constructor(
         public selectionService: IgxGridSelectionService,
@@ -440,7 +441,22 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseCompone
      * @memberof IgxHierarchicalGridComponent
      */
     public getPinnedWidth(takeHidden = false) {
-        return super.getPinnedWidth(takeHidden) + this.headerHierarchyExpander.nativeElement.clientWidth;
+        let width = super.getPinnedWidth(takeHidden);
+        if (this.hasExpandableChildren) {
+            width += this.headerHierarchyExpander.nativeElement.clientWidth || this.getDefaultExpanderWidth();
+        }
+        return width;
+    }
+
+     private getDefaultExpanderWidth(): number {
+        switch (this.displayDensity) {
+            case DisplayDensity.cosy:
+                return 57;
+            case DisplayDensity.compact:
+                return 49;
+            default:
+                return 72;
+        }
     }
 
     /**


### PR DESCRIPTION
Closes #4449 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 