### PR TITLE
calculateGridSizes should not get called in ngAfterContentInit - igxHierarchicalGrid

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
@@ -402,7 +402,7 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseCompone
      * @hidden
      */
     ngAfterContentInit() {
-        this.updateColumnList();
+        this.updateColumnList(false);
         super.ngAfterContentInit();
     }
 
@@ -411,7 +411,7 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseCompone
         super.onColumnsChanged(change);
     }
 
-    private updateColumnList() {
+    private updateColumnList(recalcColSizes = true) {
         const childLayouts = this.parent ? this.childLayoutList : this.allLayoutList;
         const nestedColumns = childLayouts.map((layout) => {
             if (!layout.rootGrid && !this.parent) {
@@ -427,7 +427,7 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseCompone
                 return colsArray.indexOf(item) === -1;
             });
             this.columnList.reset(topCols);
-            if (this.columnList.length !== colLength) {
+            if (recalcColSizes && this.columnList.length !== colLength) {
                 this.calculateGridSizes();
             }
         }


### PR DESCRIPTION
Closes #4491  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 