### PR TITLE
refactor(input-group): fix visual glitches in safari and firefox

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/input/_input-group-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/input/_input-group-theme.scss
@@ -532,6 +532,7 @@
     }
 
     %form-group-label--float {
+        overflow: visible;
         transform: translateY(-50%) scale(.75);
     }
 
@@ -577,7 +578,7 @@
         box-shadow: none;
 
         &::-webkit-input-placeholder {
-            padding: 4px 0;
+            line-height: normal;
         }
 
         &::placeholder {
@@ -593,6 +594,7 @@
     }
 
     %form-group-input--compact {
+        font-size: rem(map-get($base-scale-size, 'compact') - 1px, map-get($base-scale-size, 'compact'));
         height: rem(32px, map-get($base-scale-size, 'compact'));
         padding: 0 0 rem(8px, map-get($base-scale-size, 'compact'));
         border-top: rem(8px, map-get($base-scale-size, 'compact')) solid rgba(0, 0, 0, 0);
@@ -719,6 +721,7 @@
 
     %form-group-prefix--compact,
     %form-group-suffix--compact {
+        font-size: rem(map-get($base-scale-size, 'compact') - 1px, map-get($base-scale-size, 'compact'));
         height: rem(32px, map-get($base-scale-size, 'compact'));
     }
 


### PR DESCRIPTION
The text in the input would appear cut-off in Safari. This can happen
when the font-family's font height is slightly larger than the input
height. Substract a pixel from the font-size in compact mode of the
input to allow a bit of leeway.

Closes #4496

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 