### PR TITLE
fix(circular-bar): Remove id attr and  #text template reference variable 

### DIFF
--- a/projects/igniteui-angular/src/lib/progressbar/templates/circular-bar.component.html
+++ b/projects/igniteui-angular/src/lib/progressbar/templates/circular-bar.component.html
@@ -4,13 +4,12 @@
     role="progressbar"
     aria-valuemin="0"
     [attr.aria-valuemax]="max"
-    [attr.aria-valuenow]="value"
->
+    [attr.aria-valuenow]="value">
     <circle class="igx-circular-bar__inner" cx="50" cy="50" r="46" />
     <circle #circle class="igx-circular-bar__outer" cx="50" cy="50" r="46" />
-    <text #text [class.igx-circular-bar__text--hidden]="!textVisibility" id="myTimer" text-anchor="middle" x="50" y="60">
-            <ng-container *ngTemplateOutlet="textTemplate ? textTemplate.template : defaultTextTemplate; context: context">
-            </ng-container>
+    <text [class.igx-circular-bar__text--hidden]="!textVisibility" text-anchor="middle" x="50" y="60">
+        <ng-container *ngTemplateOutlet="textTemplate ? textTemplate.template : defaultTextTemplate; context: context">
+        </ng-container>
     </text>
 
     <ng-template #defaultTextTemplate>


### PR DESCRIPTION
Remove id attr and #text template reference variable because it is not use anywhere in the progress bar implementation.

Closes #4410
### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 