### PR TITLE
Fix buttons with icons to have consistent height:

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/button/_button-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/button/_button-theme.scss
@@ -401,6 +401,8 @@
         compact: rem(40px)
     );
 
+    $icon-in-button-size: rem(18px);
+
     %igx-button-display {
         position: relative;
         display: inline-flex;
@@ -409,7 +411,7 @@
         min-width: $button-width;
         padding: map-get($button-padding, 'comfortable');
         min-height: map-get($button-size, 'comfortable');
-        border: $button-border;
+        border: none;
         cursor: pointer;
         user-select: none;
         outline-style: none;
@@ -419,6 +421,12 @@
         transition: $button-transition;
         font-family: inherit;
         margin: 0;
+
+        %igx-icon-display {
+            width: $icon-in-button-size;
+            height: $icon-in-button-size;
+            font-size: $icon-in-button-size;
+        }
     }
 
     %igx-button-display--cosy {
@@ -449,6 +457,7 @@
     }
 
     %igx-button--outlined {
+        border: $button-border;
         border-color: --var($theme, 'outlined-outline-color');
         background: --var($theme, 'outlined-background');
         color: --var($theme, 'outlined-text-color');

--- a/src/app/button/button.sample.css
+++ b/src/app/button/button.sample.css
@@ -11,6 +11,17 @@
     justify-content: flex-start;
 }
 
+.igx-button--flat .igx-icon,
+.igx-button--raised .igx-icon,
+.igx-button--outlined .igx-icon {
+    margin-right: 8px;
+}
+
 .density-chooser {
     margin-bottom: 16px;
 }
+
+.sample-wrap {
+    flex-wrap: wrap;
+}
+

--- a/src/app/button/button.sample.html
+++ b/src/app/button/button.sample.html
@@ -149,15 +149,33 @@
                 <div class="density-chooser">
                     <igx-buttongroup [values]="displayDensities" (onSelect)="selectDensity($event)"></igx-buttongroup>
                 </div>
-                <div class="button-sample">
+                <div class="button-sample sample-wrap">
                     <div class="button-sample">
                         <button igxButton="flat" igxRipple [displayDensity]="density">Flat</button>
+                    </div>
+                    <div class="button-sample">
+                        <button igxButton="flat" igxRipple [displayDensity]="density">
+                            <igx-icon>face</igx-icon>
+                            Flat
+                        </button>
                     </div>
                     <div class="button-sample">
                         <button igxButton="raised" igxRipple [displayDensity]="density">Raised</button>
                     </div>
                     <div class="button-sample">
+                        <button igxButton="raised" igxRipple [displayDensity]="density">
+                            <igx-icon>face</igx-icon>
+                            Flat
+                        </button>
+                    </div>
+                    <div class="button-sample">
                         <button igxButton="outlined" igxRipple [displayDensity]="density">Outlined</button>
+                    </div>
+                    <div class="button-sample">
+                        <button igxButton="outlined" igxRipple [displayDensity]="density">
+                            <igx-icon>face</igx-icon>
+                            Flat
+                        </button>
                     </div>
                     <div class="button-sample">
                         <button igxRipple igxButton="fab" [displayDensity]="density">
@@ -168,4 +186,3 @@
             </article>
         </section>
     </div>
-    


### PR DESCRIPTION
1. set border only for outline buttons to make the height consistent
2. Make the icon size inside a button to correspond to a material spec

Closes #4604 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 