### PR TITLE
refactor: move DOCUMENT imports from platform-browser to common

### DIFF
--- a/projects/igniteui-angular/src/lib/core/touch.ts
+++ b/projects/igniteui-angular/src/lib/core/touch.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, NgZone } from '@angular/core';
-import { DOCUMENT, ɵgetDOM as getDOM } from '@angular/platform-browser';
+import { ɵgetDOM as getDOM } from '@angular/platform-browser';
+import { DOCUMENT } from '@angular/common';
 
 const EVENT_SUFFIX = 'precise';
 


### PR DESCRIPTION
upgrade to angular 8 does not work because DOCUMENT does not imports from platform-browser any more
 
### Additional information (check all that apply):
 - [x] Bug fix 
 