### PR TITLE
fix(hgrid): rowDraggable is applied only to row islands where set #4789

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid/row-drag.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/row-drag.directive.spec.ts
@@ -954,8 +954,8 @@ export class IgxGridFeaturesRowDragComponent extends DataParent {
     <igx-hierarchical-grid #hierarchicalDragGrid [data]="data"
      [autoGenerate]="true" [height]="'500px'" [width]="'1500px'"
       primaryKey="ID" [expandChildren]='true' [rowDraggable]="true">
-        <igx-row-island [key]="'childData'" [expandChildren]='true' [autoGenerate]="true" #rowIsland>
-            <igx-row-island [key]="'childData2'" [autoGenerate]="true" #rowIsland2 >
+        <igx-row-island [key]="'childData'" [expandChildren]='true' [autoGenerate]="true" [rowDraggable]="true" #rowIsland>
+            <igx-row-island [key]="'childData2'" [autoGenerate]="true" [rowDraggable]="true" #rowIsland2 >
             </igx-row-island>
         </igx-row-island>
     </igx-hierarchical-grid>
@@ -1034,13 +1034,6 @@ export class IgxTreeGridTestComponent {
         args.cancel = true;
         this.dropGrid.addRow(args.dragData.rowData);
     }
-}
-
-function getWindowScrollLeft() {
-    return window.scrollX ? window.scrollX : (window.pageXOffset ? window.pageXOffset : 0);
-}
-function getWindowScrollTop() {
-    return window.scrollY ? window.scrollY : (window.pageYOffset ? window.pageYOffset : 0);
 }
 
 /**

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
@@ -68,19 +68,6 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseCompone
     implements IGridDataBindable, AfterViewInit, AfterContentInit, OnInit, OnDestroy {
 
     /**
-     * @inheritdoc
-     */
-    public get rowDraggable(): boolean {
-        return this.parent ? this.parent.rowDraggable : this._rowDrag;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public set rowDraggable(val: boolean) {
-        this._rowDrag = val;
-    }
-    /**
      * Sets the value of the `id` attribute. If not provided it will be automatically generated.
      * ```html
      * <igx-hierarchical-grid [id]="'igx-hgrid-1'" [data]="Data" [autoGenerate]="true"></igx-hierarchical-grid>


### PR DESCRIPTION
Closes #4789

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 