### PR TITLE
mrl-nav bug fixing

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
@@ -406,6 +406,17 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         return '.igx-grid__mrl-block';
     }
 
+    protected performHorizontalScrollToCell(rowIndex, visibleColumnIndex, isSummary = false) {
+        const col = this.grid.columns.find(x => !x.columnGroup && x.visibleIndex === visibleColumnIndex);
+        const unpinnedIndex = this.getColumnUnpinnedIndex(col.parent.visibleIndex);
+        this.grid.parentVirtDir.onChunkLoad
+            .pipe(first())
+            .subscribe(() => {
+                this._focusCell(this.getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummary));
+            });
+        this.horizontalScroll(rowIndex).scrollTo(unpinnedIndex);
+    }
+
     protected _focusCell(cellElem) {
         const gridBoundingClientRect = this.grid.tbody.nativeElement.getBoundingClientRect();
         const diffTop = cellElem.getBoundingClientRect().top - gridBoundingClientRect.top;

--- a/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
@@ -351,8 +351,8 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
     }
 
     public onKeydownEnd(rowIndex, isSummary = false, cellRowStart?) {
-        const layouts = this.grid.columns.filter(c => c.columnLayout && !c.hidden).length;
-        const lastLayout = this.grid.columns.filter(c => c.columnLayout && !c.hidden)[layouts - 1];
+        const layouts = this.grid.columns.filter(c => c.columnLayout && !c.hidden).sort((a, b) => a.visibleIndex - b.visibleIndex);
+        const lastLayout = layouts[layouts.length - 1];
         const lastLayoutChildren = lastLayout.children;
         const layoutSize =  lastLayout.getInitialChildColumnSizes(lastLayoutChildren).length;
         const currentRowStart =  cellRowStart || this.grid.multiRowLayoutRowSize;

--- a/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
@@ -57,6 +57,10 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
     public onKeydownArrowLeft(element, rowIndex, visibleColumnIndex, isSummary = false, cell?) {
         this.focusPrevCellFromLayout(cell);
     }
+    public get gridOrderedColumns(): IgxColumnComponent[] {
+        return [...this.grid.pinnedColumns, ...this.grid.unpinnedColumns].filter(c => !c.columnGroup)
+        .sort((a, b) => a.visibleIndex - b.visibleIndex);
+    }
 
     public performTab(currentRowEl, rowIndex, visibleColumnIndex, isSummaryRow = false, cell?) {
         const nextElementColumn = cell.grid.columns.find(x => !x.columnGroup && x.visibleIndex === cell.column.visibleIndex + 1);
@@ -68,12 +72,20 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
                 .pipe(first())
                 .subscribe(() => {
                     nextCell = cell.row.cells.find(currCell => currCell.column === nextElementColumn);
+                    if (this.grid.rowEditable && this.isRowInEditMode(rowIndex)) {
+                        this.moveNextEditable(nextCell.nativeElement, rowIndex, visibleColumnIndex);
+                        return;
+                    }
                     this._focusCell(nextCell.nativeElement);
                 });
                 const hScroll = this.horizontalScroll(cell.rowIndex);
                 const scrIndex = hScroll.igxForOf.indexOf(nextElementColumn.parent);
                 hScroll.scrollTo(scrIndex);
             } else {
+                if (this.grid.rowEditable && this.isRowInEditMode(rowIndex)) {
+                    this.moveNextEditable(nextCell.nativeElement, rowIndex, visibleColumnIndex);
+                    return;
+                }
                 this._focusCell(nextCell.nativeElement);
             }
         } else {
@@ -97,12 +109,20 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
                 .pipe(first())
                 .subscribe(() => {
                     nextCell = cell.row.cells.find(currCell => currCell.column === prevElementColumn);
+                    if (this.grid.rowEditable && this.isRowInEditMode(rowIndex)) {
+                        this.movePreviousEditable(rowIndex, visibleColumnIndex);
+                        return;
+                    }
                     this._focusCell(nextCell.nativeElement);
                 });
                 const hScroll = this.horizontalScroll(cell.rowIndex);
                 const scrIndex = hScroll.igxForOf.indexOf(prevElementColumn.parent);
                 hScroll.scrollTo(scrIndex);
             } else {
+                if (this.grid.rowEditable && this.isRowInEditMode(rowIndex)) {
+                    this.movePreviousEditable(rowIndex, visibleColumnIndex);
+                    return;
+                }
                 this._focusCell(nextCell.nativeElement);
             }
         } else {

--- a/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
@@ -107,6 +107,10 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
             }
         } else {
             // end of layout reached
+            if (this.isRowInEditMode(rowIndex)) {
+                this.grid.rowEditTabs.last.element.nativeElement.focus();
+                return;
+            }
             let lastVisibleIndex = 0;
             cell.grid.unpinnedColumns.forEach((col) => {
                 lastVisibleIndex = Math.max(lastVisibleIndex, col.visibleIndex);

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -555,7 +555,7 @@ export class IgxGridNavigationService {
             }
         }
     }
-    private performHorizontalScrollToCell(rowIndex, visibleColumnIndex, isSummary = false) {
+    protected performHorizontalScrollToCell(rowIndex, visibleColumnIndex, isSummary = false) {
         const unpinnedIndex = this.getColumnUnpinnedIndex(visibleColumnIndex);
         this.grid.parentVirtDir.onChunkLoad
             .pipe(first())

--- a/projects/igniteui-angular/src/lib/grids/grid.rowEdit.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid.rowEdit.directive.ts
@@ -68,12 +68,13 @@ export class IgxRowEditTabStopDirective {
         const horizontalScroll = this.grid.parentVirtDir.getHorizontalScroll();
         const targetIndex = event.shiftKey ? this.grid.lastEditableColumnIndex : this.grid.firstEditableColumnIndex;
         const targetCell = this.grid.rowInEditMode.cells.find(e => e.visibleColumnIndex === targetIndex);
+        const scrollIndex = this.grid.hasColumnLayouts ? targetCell.column.parent.visibleIndex : targetIndex;
         if (!targetCell ||
-            !this.navigationService.isColumnFullyVisible(targetIndex)
-            || !this.navigationService.isColumnLeftFullyVisible(targetIndex)) {
+            !this.navigationService.isColumnFullyVisible(scrollIndex)
+            || !this.navigationService.isColumnLeftFullyVisible(scrollIndex)) {
             this.focusNextCell(this.grid.rowInEditMode.index, targetIndex);
             horizontalScroll.scrollLeft =
-            this.grid.rowInEditMode.virtDirRow.getColumnScrollLeft(this.navigationService.getColumnUnpinnedIndex(targetIndex));
+            this.grid.rowInEditMode.virtDirRow.getColumnScrollLeft(this.navigationService.getColumnUnpinnedIndex(scrollIndex));
         } else {
             targetCell.nativeElement.focus();
         }

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
@@ -2076,6 +2076,66 @@ describe('IgxGrid Multi Row Layout - Keyboard navigation', () => {
         targetCell = grid.getCellByColumn(0, 'ID');
         expect(targetCell.focused).toBe(true);
     });
+
+    it('tab navigation should should skip non-editable cells when navigating in row edit mode. ', async () => {
+        const fix = TestBed.createComponent(ColumnLayoutTestComponent);
+        fix.componentInstance.colGroups = [
+            {
+                group: 'group1',
+                columns: [
+                    { field: 'CompanyName', rowStart: 1, colStart: 1, colEnd: 3, width: '300px', editable: true },
+                    { field: 'ContactName', rowStart: 2, colStart: 1, editable: false  },
+                    { field: 'ContactTitle', rowStart: 2, colStart: 2, editable: true  },
+                    { field: 'Address', rowStart: 3, colStart: 1, colEnd: 3, editable: true  }
+                ]
+            },
+            {
+                group: 'group2',
+                columns: [
+                    { field: 'City', rowStart: 1, colStart: 1, colEnd: 3, rowEnd: 3, width: '400px', editable: true  },
+                    { field: 'Region', rowStart: 3, colStart: 1, editable: true  },
+                    { field: 'PostalCode', rowStart: 3, colStart: 2, editable: true  }
+                ]
+            },
+            {
+                group: 'group3',
+                columns: [
+                    { field: 'Phone', rowStart: 1, colStart: 1, width: '200px', editable: true  },
+                    { field: 'Fax', rowStart: 2, colStart: 1, editable: true  },
+                    { field: 'ID', rowStart: 3, colStart: 1, editable: true  }
+                ]
+            }
+        ];
+        const grid = fix.componentInstance.grid;
+        grid.primaryKey = 'ID';
+        grid.rowEditable = true;
+        fix.detectChanges();
+
+        let cell = grid.getCellByColumn(0, 'CompanyName');
+        cell.nativeElement.focus();
+        fix.detectChanges();
+        cell.onKeydownEnterEditMode();
+        await wait(DEBOUNCETIME);
+        fix.detectChanges();
+        const order = ['CompanyName', 'City', 'Phone', 'ContactTitle'];
+        // tab through cols and check order is correct - ContactName should be skipped.
+        for (let i = 1; i < order.length; i++) {
+            UIInteractions.triggerKeyDownEvtUponElem('Tab', cell.nativeElement, true);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+            cell = grid.getCellByColumn(0, order[i]);
+            expect(cell.editMode).toBe(true);
+        }
+
+        // shift+tab through  cols and check order is correct - ContactName should be skipped.
+        for (let j = order.length - 2; j >= 0; j--) {
+            cell.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+            cell = grid.getCellByColumn(0, order[j]);
+            expect(cell.editMode).toBe(true);
+        }
+    });
 });
 
 @Component({

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
@@ -2013,6 +2013,69 @@ describe('IgxGrid Multi Row Layout - Keyboard navigation', () => {
             expect(document.activeElement).toEqual(thirdCell.nativeElement);
         });
     });
+
+    it('shift+tab navigation should go through edit row buttons when navigating in row edit mode. ', async () => {
+        const fix = TestBed.createComponent(ColumnLayoutTestComponent);
+        fix.componentInstance.colGroups = [
+            {
+                group: 'group1',
+                columns: [
+                    { field: 'CompanyName', rowStart: 1, colStart: 1, colEnd: 3, width: '300px', editable: true },
+                    { field: 'ContactName', rowStart: 2, colStart: 1, editable: true  },
+                    { field: 'ContactTitle', rowStart: 2, colStart: 2, editable: true  },
+                    { field: 'Address', rowStart: 3, colStart: 1, colEnd: 3, editable: true  }
+                ]
+            },
+            {
+                group: 'group2',
+                columns: [
+                    { field: 'City', rowStart: 1, colStart: 1, colEnd: 3, rowEnd: 3, width: '400px', editable: true  },
+                    { field: 'Region', rowStart: 3, colStart: 1, editable: true  },
+                    { field: 'PostalCode', rowStart: 3, colStart: 2, editable: true  }
+                ]
+            },
+            {
+                group: 'group3',
+                columns: [
+                    { field: 'Phone', rowStart: 1, colStart: 1, width: '200px', editable: true  },
+                    { field: 'Fax', rowStart: 2, colStart: 1, editable: true  },
+                    { field: 'ID', rowStart: 3, colStart: 1, editable: true  }
+                ]
+            }
+        ];
+        const grid = fix.componentInstance.grid;
+        grid.primaryKey = 'ID';
+        grid.rowEditable = true;
+        fix.detectChanges();
+
+        let targetCell = grid.getCellByColumn(0, 'CompanyName');
+        targetCell.nativeElement.focus();
+        fix.detectChanges();
+        targetCell.onKeydownEnterEditMode();
+        fix.detectChanges();
+        await wait(100);
+
+        const rowEditingBannerElement = fix.debugElement.query(By.css('.igx-banner__row')).nativeElement;
+        const doneButtonElement = rowEditingBannerElement.lastElementChild;
+        const cancelButtonElement = rowEditingBannerElement.firstElementChild;
+
+        // shift+tab into Done button
+        targetCell.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+        fix.detectChanges();
+        expect(document.activeElement).toEqual(doneButtonElement);
+
+        // shift+ tab into Cancel
+        doneButtonElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+        fix.detectChanges();
+
+        // shift+ tab into last cell
+        cancelButtonElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+        await wait(100);
+        fix.detectChanges();
+
+        targetCell = grid.getCellByColumn(0, 'ID');
+        expect(targetCell.focused).toBe(true);
+    });
 });
 
 @Component({
@@ -2021,7 +2084,7 @@ describe('IgxGrid Multi Row Layout - Keyboard navigation', () => {
         <igx-column-layout *ngFor='let group of colGroups' [hidden]='group.hidden' [pinned]='group.pinned' [field]='group.group'>
             <igx-column *ngFor='let col of group.columns'
             [rowStart]="col.rowStart" [colStart]="col.colStart" [width]='col.width'
-            [colEnd]="col.colEnd" [rowEnd]="col.rowEnd" [field]='col.field'></igx-column>
+            [colEnd]="col.colEnd" [rowEnd]="col.rowEnd" [field]='col.field' [editable]='col.editable'></igx-column>
         </igx-column-layout>
     </igx-grid>
     `

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
@@ -841,6 +841,55 @@ describe('IgxGrid Multi Row Layout - Keyboard navigation', () => {
          }
      }));
 
+     it('Shift+Tab Navigation should scroll last cell fully in view.',  async() => {
+        const fix = TestBed.createComponent(ColumnLayoutTestComponent);
+        fix.componentInstance.colGroups = [{
+            group: 'group1',
+            // row span 3
+            columns: [
+                { field: 'ID', rowStart: 1, colStart: 1, rowEnd: 4 }
+            ]
+        }, {
+            group: 'group3',
+            columns: [
+                 // row span 2
+                { field: 'Address', rowStart: 1, colStart: 1, rowEnd: 3 },
+                { field: 'PostalCode', rowStart: 3, colStart: 1 }
+            ]
+        }, {
+            group: 'group2',
+            columns: [
+                 // col span 2
+                { field: 'ContactName', rowStart: 1, colStart: 1, colEnd: 3 },
+                { field: 'Phone', rowStart: 2, colStart: 1 },
+                { field: 'City', rowStart: 2, colStart: 2 },
+                // col span 2
+                { field: 'ContactTitle', rowStart: 3, colStart: 1, colEnd: 3 }
+            ]
+        }];
+        const grid =  fix.componentInstance.grid;
+        setupGridScrollDetection(fix, grid);
+        grid.columnWidth = '300px';
+        grid.width = '300px';
+        fix.detectChanges();
+
+        // focus 1st in 2nd row
+        const cell = grid.getCellByColumn(1, 'ID');
+        cell.nativeElement.dispatchEvent(new Event('focus'));
+        await wait();
+        fix.detectChanges();
+
+        // shift + tab
+        cell.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+        await wait(100);
+        fix.detectChanges();
+        const lastCell = grid.getCellByColumn(0, 'ContactTitle');
+        expect(lastCell.focused).toBe(true);
+        expect(grid.parentVirtDir.getHorizontalScroll().scrollLeft).toBe(600);
+        const diff = lastCell.nativeElement.getBoundingClientRect().left - grid.tbody.nativeElement.getBoundingClientRect().left;
+        expect(diff).toBe(0);
+     });
+
     it('should navigate to unpinned area when the column layout is bigger than the display container', (async () => {
         const fix = TestBed.createComponent(ColumnLayoutTestComponent);
         fix.componentInstance.colGroups = [{


### PR DESCRIPTION
Following bugs have been resolved: 
1) When navigation with shift+tab and prev cell is not in horizontal virtual view, prev cell is not scrolled in view.
2) When navigating with Shift + Tab when in edit mode of 1st cell focus  goes to previous row.
3) Edit mode is exited when navigating trough a non editable cell
4) When the last column layout is pinned and press Ctr+End or Pres arrow key and error is returned



