### PR TITLE
fix(grid): add warning to `rowEditable` in grid w/o primaryKey, #3770

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -591,11 +591,14 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
     /**
     * Sets whether rows can be edited.
     * ```html
-    * <igx-grid #grid [showToolbar]="true" [rowEditable]="true" [columnHiding]="true"></igx-grid>
+    * <igx-grid #grid [showToolbar]="true" [rowEditable]="true" [primaryKey]="'ProductID'" [columnHiding]="true"></igx-grid>
     * ```
     * @memberof IgxGridBaseComponent
     */
     set rowEditable(val: boolean) {
+        if (val && (this.primaryKey === undefined || this.primaryKey === null)) {
+            console.warn('The grid must have a `primaryKey` specified when using `rowEditable`!');
+        }
         this._rowEditable = val;
         if (this.gridAPI.grid) {
             this.refreshGridState();

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1342,6 +1342,36 @@ describe('IgxGrid Component Tests', () => {
         }));
 
         describe('Row Editing - General tests', () => {
+            it('Should throw a warning when [rowEditable] is set on a grid w/o [primaryKey]', fakeAsync(() => {
+                const fix = TestBed.createComponent(IgxGridRowEditingComponent);
+                fix.detectChanges();
+                const grid = fix.componentInstance.grid;
+                grid.primaryKey = null;
+                grid.rowEditable = false;
+                tick();
+                fix.detectChanges();
+
+                spyOn(console, 'warn');
+                grid.rowEditable = true;
+                tick();
+                fix.detectChanges();
+                expect(console.warn).toHaveBeenCalledWith('The grid must have a `primaryKey` specified when using `rowEditable`!');
+                expect(console.warn).toHaveBeenCalledTimes(1);
+                // Throws warinig but still sets the property correctly
+                expect(grid.rowEditable).toBeTruthy();
+
+                tick();
+                fix.detectChanges();
+                grid.primaryKey = 'ProductID';
+                grid.rowEditable = false;
+                tick();
+                fix.detectChanges();
+                grid.rowEditable = true;
+                tick();
+                fix.detectChanges();
+                expect(console.warn).toHaveBeenCalledTimes(1);
+                expect(grid.rowEditable).toBeTruthy();
+            }));
             it('Should be able to enter edit mode on dblclick, enter and f2', fakeAsync(() => {
                 const fix = TestBed.createComponent(IgxGridRowEditingComponent);
                 fix.detectChanges();

--- a/projects/igniteui-angular/src/lib/grids/grid/row-drag.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/row-drag.directive.spec.ts
@@ -863,6 +863,7 @@ describe('IgxGrid - Row Drag Tests', () => {
         <igx-grid #grid
             [width]='width'
             [height]='height'
+            primaryKey="ID"
             [data]="data"
             [autoGenerate]="true" (onColumnInit)="columnsCreated($event)" (onGroupingDone)="onGroupingDoneHandler($event)"
             [rowEditable]="true" [rowDraggable]="enableRowDraggable"
@@ -916,7 +917,7 @@ export class IgxGridRowDraggableComponent extends DataParent {
             [width]="'800px'"
             [height]="'300px'"
             [data]="data"
-            [primaryKey]="'ID'"
+            primaryKey="ID"
             [autoGenerate]="true" (onGroupingDone)="onGroupingDoneHandler($event)"
             [rowEditable]="true" [rowDraggable]="true"
             >


### PR DESCRIPTION
Closes #3770

PR adds a warning to the `rowEditable` setter that is logged only when `rowEditable` is set to `true` and there is no `primaryKey`

### Additional information (check all that apply):
 - [ ] Bug fix
 - [x] New functionality
 - [x] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 