### PR TITLE
Replace the igxFilterPipe with a separate ESF specific pipe

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/filter/filter.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/filter/filter.directive.ts
@@ -139,11 +139,6 @@ export class IgxFilterPipe implements PipeTransform {
             items = options.items;
         }
 
-        const selectAll = items[0];
-        if (selectAll.isSpecial) {
-            items = items.slice(1, items.length);
-        }
-
         result = items.filter((item: any) => {
             const match = options.matchFn(options.formatter(options.get_value(item, options.key)), options.inputValue);
 
@@ -159,10 +154,6 @@ export class IgxFilterPipe implements PipeTransform {
 
             return match;
         });
-
-        if (result.length > 0 && selectAll.isSpecial) {
-            result.unshift(selectAll);
-        }
 
         return result;
     }

--- a/projects/igniteui-angular/src/lib/grids/filtering/excel-style/excel-style-search.component.html
+++ b/projects/igniteui-angular/src/lib/grids/filtering/excel-style/excel-style-search.component.html
@@ -22,7 +22,7 @@
         <igx-list [style.height.px]="250">
             <div [style.overflow]="'hidden'" [style.position]="'relative'">
                 <igx-list-item
-                    *igxFor="let item of data | igxFilter: filterOptions; scrollOrientation : 'vertical'; containerSize: '250px'; itemSize: '48px'">
+                    *igxFor="let item of data | excelStyleSearchFilter: searchValue; scrollOrientation : 'vertical'; containerSize: '250px'; itemSize: '48px'">
                     <igx-checkbox
                     [value]="item"
                     tabindex="-1"

--- a/projects/igniteui-angular/src/lib/grids/filtering/excel-style/excel-style-search.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/filtering/excel-style/excel-style-search.component.ts
@@ -8,6 +8,7 @@ import { IgxColumnComponent } from '../../column.component';
 import { IgxFilterOptions } from '../../../directives/filter/filter.directive';
 import { IChangeCheckboxEventArgs } from '../../../checkbox/checkbox.component';
 import { IgxInputDirective } from '../../../directives/input/input.directive';
+import { FilterListItem } from './grid.excel-style-filtering.component';
 
 /**
  * @hidden
@@ -23,7 +24,7 @@ export class IgxExcelStyleSearchComponent {
     public searchValue: any;
 
     @Input()
-    public data: any[];
+    public data: FilterListItem[];
 
     @Input()
     public column: IgxColumnComponent;
@@ -32,13 +33,6 @@ export class IgxExcelStyleSearchComponent {
     public searchInput: IgxInputDirective;
 
     constructor() {}
-
-    get filterOptions() {
-        const fo = new IgxFilterOptions();
-        fo.key = 'value';
-        fo.inputValue = this.searchValue;
-        return fo;
-    }
 
     public clearInput() {
         this.searchValue = null;

--- a/projects/igniteui-angular/src/lib/grids/filtering/excel-style/excel-style-search.pipe.ts
+++ b/projects/igniteui-angular/src/lib/grids/filtering/excel-style/excel-style-search.pipe.ts
@@ -1,0 +1,27 @@
+import { Pipe, PipeTransform } from '@angular/core';
+import { FilterListItem } from './grid.excel-style-filtering.component';
+
+/**
+ * @hidden
+ */
+@Pipe({
+    name: 'excelStyleSearchFilter'
+})
+export class IgxExcelStyleSearchFilterPipe implements PipeTransform {
+    transform(items: FilterListItem[], searchText: string): any[] {
+        if (!items || !items.length) {
+            return [];
+        }
+
+        if (!searchText) {
+            return items;
+        }
+
+        searchText = searchText.toLowerCase();
+        const result = items.filter((it, i) => (i === 0 && it.isSpecial) ||
+            (it.value || it.value === 0) &&
+            it.value.toString().toLowerCase().indexOf(searchText) > -1);
+
+        return result.length > 1 ? result : [];
+    }
+}

--- a/projects/igniteui-angular/src/lib/grids/filtering/excel-style/grid.excel-style-filtering.module.ts
+++ b/projects/igniteui-angular/src/lib/grids/filtering/excel-style/grid.excel-style-filtering.module.ts
@@ -28,6 +28,7 @@ import { IgxCheckboxModule } from '../../../checkbox/checkbox.component';
 import { IgxFilterModule } from '../../../directives/filter/filter.directive';
 import { IgxToggleModule } from '../../../directives/toggle/toggle.directive';
 import { IgxListModule } from '../../../list/list.component';
+import { IgxExcelStyleSearchFilterPipe } from './excel-style-search.pipe';
 
 /**
  * @hidden
@@ -44,7 +45,8 @@ import { IgxListModule } from '../../../list/list.component';
         IgxExcelStyleSortingTemplateDirective,
         IgxExcelStyleHidingTemplateDirective,
         IgxExcelStyleMovingTemplateDirective,
-        IgxExcelStylePinningTemplateDirective
+        IgxExcelStylePinningTemplateDirective,
+        IgxExcelStyleSearchFilterPipe
     ],
     exports: [
         IgxGridExcelStyleFilteringComponent,


### PR DESCRIPTION
Closes #4862

### Description
The reason for this change is that the igxFilterPipe is impure and is evaluated on each change detection (triggered by click or other events) even if the filtering options are not changed. The new pipe is pure and is called only when the search text is changed.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 