### PR TITLE
MRL Custom Navigation + basic refactoring and custom nav sample

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/column.component.ts
@@ -1214,7 +1214,7 @@ export class IgxColumnComponent implements AfterContentInit {
         return columnSizes;
     }
 
-    protected getFilledChildColumnSizes(children: QueryList<IgxColumnComponent>): Array<string> {
+    public getFilledChildColumnSizes(children: QueryList<IgxColumnComponent>): Array<string> {
         const columnSizes = this.getInitialChildColumnSizes(children);
 
         // fill the gaps if there are any

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -4862,32 +4862,15 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
         }
         if (visibleColIndex === -1 || (this.navigation.isColumnFullyVisible(visibleColIndex)
             && this.navigation.isColumnLeftFullyVisible(visibleColIndex))) {
-            if (this.navigation.shouldPerformVerticalScroll(rowIndex)) {
-                this.verticalScrollContainer.scrollTo(rowIndex);
-                this.verticalScrollContainer.onChunkLoad
-                .pipe(first()).subscribe(() => {
-                    this.executeCallback(rowIndex, visibleColIndex, cb);
-                });
+            if (this.navigation.shouldPerformVerticalScroll(rowIndex, visibleColIndex)) {
+                this.navigation.performVerticalScrollToCell(rowIndex, visibleColIndex,
+                     () => { this.executeCallback(rowIndex, visibleColIndex, cb); } );
             } else {
                 this.executeCallback(rowIndex, visibleColIndex, cb);
             }
         } else {
-            const unpinnedIndex = this.navigation.getColumnUnpinnedIndex(visibleColIndex);
-            this.parentVirtDir.onChunkLoad
-                .pipe(first())
-                .subscribe(() => {
-                if (this.navigation.shouldPerformVerticalScroll(rowIndex)) {
-                    this.verticalScrollContainer.scrollTo(rowIndex);
-                    this.verticalScrollContainer.onChunkLoad
-                    .pipe(first()).subscribe(() => {
-                        this.executeCallback(rowIndex, visibleColIndex, cb);
-                    });
-                } else {
-                    this.executeCallback(rowIndex, visibleColIndex, cb);
-                }
-
-            });
-            this.navigation.horizontalScroll(rowIndex).scrollTo(unpinnedIndex);
+            this.navigation.performHorizontalScrollToCell(rowIndex, visibleColIndex, false,
+                 () => { this.executeCallback(rowIndex, visibleColIndex, cb); });
         }
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
@@ -117,7 +117,7 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
             if (dir === 'next') {
                 super.navigateDown(currentRowEl, {row: row.index, column: 0});
             } else {
-                let lastVisibleIndex = 0;
+                 let lastVisibleIndex = 0;
                 this.grid.unpinnedColumns.forEach((col) => {
                     lastVisibleIndex = Math.max(lastVisibleIndex, col.visibleIndex);
                 });
@@ -224,7 +224,6 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         const currentColEnd = selectedNode.layout.colEnd || selectedNode.layout.colStart + 1;
         const currentRowStart = selectedNode.layout.rowStart;
         const rowIndex = selectedNode.row;
-        let element = cellElement.parentElement;
         // check if next element is from the same layout
         let nextElementColumn = columnLayout.children.find(c => c.colStart === currentColEnd &&
             c.rowStart <= currentRowStart &&
@@ -240,19 +239,12 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
             nextElementColumn = columnLayout.children.find(c => c.colStart === 1 &&
                 c.rowStart <= currentRowStart &&
                 (currentRowStart < c.rowEnd || currentRowStart < c.rowStart + c.gridRowSpan));
-            element = element.nextElementSibling;
         }
-        const columnIndex = columnLayout.children.toArray().indexOf(nextElementColumn);
-        let nextElement = element.children[columnIndex];
-
         const cb = () => {
-            nextElement = element.children[columnIndex];
+            const nextElement = nextElementColumn.cells.find((c) => c.rowIndex === rowIndex).nativeElement;
             nextElement.focus({ preventScroll: true });
         };
-        if (element.classList.contains('igx-grid__td--pinned-last')) {
-            nextElement = element.nextElementSibling.children[0].children[columnIndex];
-            nextElement.focus({ preventScroll: true });
-        } else if (!this.isColumnFullyVisible(nextElementColumn.visibleIndex)) {
+        if (!this.isColumnFullyVisible(nextElementColumn.visibleIndex)) {
             this.grid.nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, nextElementColumn.visibleIndex, false, cb);
         } else {
@@ -272,7 +264,6 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         .find(c => (c.colEnd === currentColStart || c.colStart + c.gridColumnSpan === currentColStart ) &&
             c.rowStart <= currentRowStart &&
             (currentRowStart < c.rowEnd || currentRowStart < c.rowStart + c.gridRowSpan));
-        let element = cellElement.parentElement;
         if (!prevElementColumn) {
             // no prev column in current layout, seacrh for prev layout
             columnLayout = this.grid.columns.find(c => c.columnLayout && !c.hidden && c.visibleIndex === columnLayout.visibleIndex - 1);
@@ -286,14 +277,10 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
             .find(c => (c.colEnd === layoutSize + 1 || c.colStart + c.gridColumnSpan === layoutSize + 1) &&
                 c.rowStart <= currentRowStart &&
                 (currentRowStart < c.rowEnd || currentRowStart < c.rowStart + c.gridRowSpan));
-            element = element.previousElementSibling;
         }
 
-        const columnIndex = columnLayout.children.toArray().indexOf(prevElementColumn);
-        let prevElement = element.children[columnIndex];
-
         const cb = () => {
-            prevElement = element.children[columnIndex];
+            const prevElement = prevElementColumn.cells.find((c) => c.rowIndex === rowIndex).nativeElement;
             prevElement.focus({ preventScroll: true });
         };
         if (!this.isColumnLeftFullyVisible(prevElementColumn.visibleIndex)) {
@@ -321,7 +308,7 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         if (!rowElement) { return; }
         rowElement = rowElement.nativeElement;
 
-        if (!this.isColumnFullyVisible(nextElementColumn.parent.visibleIndex)) {
+        if (!this.isColumnFullyVisible(nextElementColumn.visibleIndex)) {
             this.grid.nativeElement.focus({ preventScroll: true });
             const cb = () => {
                 const allBlocks = rowElement.querySelectorAll(this.getColumnLayoutSelector());
@@ -352,7 +339,7 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         if (!rowElement) { return; }
         rowElement = rowElement.nativeElement;
 
-        if (!this.isColumnLeftFullyVisible(nextElementColumn.parent.visibleIndex)) {
+        if (!this.isColumnLeftFullyVisible(nextElementColumn.visibleIndex)) {
             this.grid.nativeElement.focus({ preventScroll: true });
            const cb = () => {
                 const allBlocks = rowElement.querySelectorAll(this.getColumnLayoutSelector());

--- a/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
@@ -242,7 +242,7 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         }
         const cb = () => {
             const nextElement = nextElementColumn.cells.find((c) => c.rowIndex === rowIndex).nativeElement;
-            nextElement.focus({ preventScroll: true });
+           this._focusCell(nextElement);
         };
         if (!this.isColumnFullyVisible(nextElementColumn.visibleIndex)) {
             this.grid.nativeElement.focus({ preventScroll: true });
@@ -281,7 +281,7 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
 
         const cb = () => {
             const prevElement = prevElementColumn.cells.find((c) => c.rowIndex === rowIndex).nativeElement;
-            prevElement.focus({ preventScroll: true });
+            this._focusCell(prevElement);
         };
         if (!this.isColumnLeftFullyVisible(prevElementColumn.visibleIndex)) {
             this.grid.nativeElement.focus({ preventScroll: true });
@@ -372,7 +372,7 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
                 leftScroll += parseInt(c.calcWidth, 10);
             }
         });
-        rightScroll = leftScroll + parseInt(targetCol.width, 10);
+        rightScroll = leftScroll + parseInt(targetCol.calcWidth, 10);
         return {leftScroll, rightScroll};
     }
 
@@ -442,9 +442,9 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
                     this._focusCell(this.getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummary));
                 }
         });
-        const nextScroll = !(this.displayContainerScrollLeft <= scrollPos.leftScroll) &&
-        this.displayContainerWidth >= scrollPos.rightScroll - this.displayContainerScrollLeft ?
-        scrollPos.leftScroll : scrollPos.rightScroll - this.displayContainerWidth;
+        const isPrevItem =  hScroll.getHorizontalScroll().scrollLeft > scrollPos.leftScroll;
+        const containerSize = parseInt(hScroll.igxForContainerSize, 10);
+        const nextScroll = isPrevItem ? scrollPos.leftScroll : scrollPos.rightScroll - containerSize;
         hScroll.getHorizontalScroll().scrollLeft = nextScroll;
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
@@ -365,14 +365,17 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         const parent = targetCol.parent;
         const parentVIndex = forOfDir.igxForOf.indexOf(parent);
         let leftScroll = forOfDir.getColumnScrollLeft(parentVIndex), rightScroll = 0;
-        parent.children.forEach((c) => {
-            const rowEnd = c.rowEnd !== undefined ? c.rowEnd : c.rowStart + 1;
-            const targetRowEnd = targetCol.rowEnd !== undefined ? targetCol.rowEnd : targetCol.rowStart + 1;
-            if (c.rowStart >= targetCol.rowStart && rowEnd >= targetRowEnd && c.visibleIndex < targetCol.visibleIndex) {
-                leftScroll += parseInt(c.calcWidth, 10);
-            }
-        });
-        rightScroll = leftScroll + parseInt(targetCol.calcWidth, 10);
+        // caculate offset from parent based on target column colStart and colEnd and the resolved child column sizes.
+        const childSizes = parent.getFilledChildColumnSizes(parent.children);
+        const colStart = targetCol.colStart || 1;
+        const colEnd = targetCol.colEnd || colStart + 1;
+        for (let i = 1; i < colStart; i++) {
+            leftScroll += parseInt(childSizes[i - 1], 10);
+        }
+        rightScroll += leftScroll;
+        for (let j = colStart; j < colEnd; j++) {
+            rightScroll +=  parseInt(childSizes[j - 1], 10);
+        }
         return {leftScroll, rightScroll};
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
@@ -172,7 +172,7 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         };
         if (this.shouldPerformVerticalScroll(rowIndex, upperElementColumn.visibleIndex)) {
             this.grid.nativeElement.focus({ preventScroll: true });
-                this.performVerticalScroll(rowIndex, upperElementColumn.visibleIndex, cb);
+                this.performVerticalScrollToCell(rowIndex, upperElementColumn.visibleIndex, cb);
         } else {
             cb();
         }
@@ -212,7 +212,7 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         };
         if (this.shouldPerformVerticalScroll(rowIndex, nextElementColumn.visibleIndex)) {
             this.grid.nativeElement.focus({ preventScroll: true });
-                this.performVerticalScroll(rowIndex, nextElementColumn.visibleIndex, cb);
+                this.performVerticalScrollToCell(rowIndex, nextElementColumn.visibleIndex, cb);
         } else {
             cb();
         }
@@ -400,7 +400,7 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         return  parseInt(this.grid.verticalScrollContainer.dc.instance._viewContainer.element.nativeElement.style.top, 10);
     }
 
-    public performVerticalScroll(rowIndex: number, visibleColumnIndex: number, cb?) {
+    public performVerticalScrollToCell(rowIndex: number, visibleColumnIndex: number, cb?) {
         const containerHeight = this.grid.calcHeight ? Math.ceil(this.grid.calcHeight) : 0;
         const scrollTop = Math.abs(this.grid.verticalScrollContainer.getVerticalScroll().scrollTop);
         const scrollPos = this.getVerticalScrollPositions(rowIndex, visibleColumnIndex);

--- a/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
@@ -19,15 +19,26 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
     }
 
     public isColumnFullyVisible(visibleColumnIndex: number) {
+        const column = this.grid.columnList.filter(c => !c.columnGroup).find((col) => col.visibleIndex === visibleColumnIndex);
         const forOfDir =  this.grid.headerContainer;
         const horizontalScroll = forOfDir.getHorizontalScroll();
-        const column = this.grid.columnList.filter(c => !c.columnGroup).find((col) => col.visibleIndex === visibleColumnIndex);
         if (!horizontalScroll.clientWidth || (column && column.pinned)) {
             return true;
         } else if (column) {
-            return this.displayContainerWidth >= forOfDir.getColumnScrollLeft(column.parent.visibleIndex) - this.displayContainerScrollLeft;
+            if (this.isParentColumnFullyVisible(column)) { return true; }
+            const scrollPos = this.getChildColumnScrollPositions(visibleColumnIndex);
+            return this.displayContainerWidth >= scrollPos.rightScroll - this.displayContainerScrollLeft &&
+            this.displayContainerScrollLeft <= scrollPos.leftScroll;
         }
         return false;
+    }
+    private isParentColumnFullyVisible(parent: IgxColumnComponent): boolean {
+        const forOfDir = this.grid.dataRowList.length > 0 ? this.grid.dataRowList.first.virtDirRow : this.grid.headerContainer;
+        const horizontalScroll = forOfDir.getHorizontalScroll();
+        if (!horizontalScroll.clientWidth || parent.pinned) { return true; }
+        const index = forOfDir.igxForOf.indexOf(parent);
+        return this.displayContainerWidth >= forOfDir.getColumnScrollLeft(index + 1) - this.displayContainerScrollLeft &&
+            this.displayContainerScrollLeft <= forOfDir.getColumnScrollLeft(index);
     }
 
     public isColumnLeftFullyVisible(visibleColumnIndex: number) {
@@ -37,7 +48,9 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         if (!horizontalScroll.clientWidth || column.pinned) {
             return true;
         }
-        return this.displayContainerScrollLeft <= forOfDir.getColumnScrollLeft(column.parent.visibleIndex);
+        if (this.isParentColumnFullyVisible(column)) { return true; }
+        const scrollPos = this.getChildColumnScrollPositions(visibleColumnIndex);
+        return this.displayContainerScrollLeft <= scrollPos.leftScroll;
     }
 
     public onKeydownArrowRight(element, selectedNode: ISelectionNode) {
@@ -63,11 +76,10 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
     protected _moveFocusToCell(currentRowEl, nextElementColumn, row, selectedNode, dir) {
         if (nextElementColumn) {
             let nextCell = row.cells.find(currCell => currCell.column === nextElementColumn);
-            if (!nextCell) {
+            const isVisible = this.isColumnFullyVisible(nextElementColumn.visibleIndex);
+            if (!nextCell || !isVisible) {
                 this.grid.nativeElement.focus({ preventScroll: true });
-                this.grid.parentVirtDir.onChunkLoad
-                .pipe(first())
-                .subscribe(() => {
+                const cb = () => {
                     nextCell = row.cells.find(currCell => currCell.column === nextElementColumn);
                     if (this.grid.rowEditable && this.isRowInEditMode(row.index)) {
                         if (dir === 'next') {
@@ -78,10 +90,8 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
                         return;
                     }
                     this._focusCell(nextCell.nativeElement);
-                });
-                const hScroll = this.horizontalScroll(row.index);
-                const scrIndex = hScroll.igxForOf.indexOf(nextElementColumn.parent);
-                hScroll.scrollTo(scrIndex);
+                };
+                this.performHorizontalScrollToCell(row.index, nextElementColumn.visibleIndex, false, cb);
             } else {
                 if (this.grid.rowEditable && this.isRowInEditMode(row.index)) {
                     if (dir === 'next') {
@@ -131,57 +141,41 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         const currentColStart = selectedNode.layout ? selectedNode.layout.colStart : 1;
         const parentIndex = selectedNode.column;
         const columnLayout = this.grid.columns.find( x => x.columnLayout && x.visibleIndex === parentIndex);
-        let element;
-        if (!isGroupRow) {
-            const cell = this.grid.getRowByIndex(selectedNode.row).cells
-            .find(x => x.visibleColumnIndex === selectedNode.layout.columnVisibleIndex);
-            element = cell.nativeElement.parentElement;
-        }
-
-        // element up is from the same layout
+        let movePrev;
+        // check if element up is from the same layout
         let upperElementColumn = columnLayout.children.find(c =>
             (c.rowEnd === currentRowStart || c.rowStart + c.gridRowSpan === currentRowStart)  &&
             c.colStart <= currentColStart &&
             (currentColStart < c.colEnd || currentColStart < c.colStart + c.gridColumnSpan));
-
-        const columnIndex = columnLayout.children.toArray().indexOf(upperElementColumn);
-        const upperElement = element ? element.children[columnIndex] : null;
-
-        if (!upperElement) {
+        if (isGroupRow || !upperElementColumn) {
+            // no prev row in current row layout, go to next row last rowstart
             const layoutRowEnd = this.grid.multiRowLayoutRowSize + 1;
             upperElementColumn = columnLayout.children.find(c =>
                 (c.rowEnd === layoutRowEnd || c.rowStart + c.gridRowSpan === layoutRowEnd) &&
                 c.colStart <= currentColStart &&
                 (currentColStart < c.colEnd || currentColStart < c.colStart + c.gridColumnSpan));
-
-            const prevIndex = selectedNode.row - 1;
-            let prevRow;
-            const containerTopOffset = parseInt(this.verticalDisplayContainerElement.style.top, 10);
-            if (prevIndex >= 0 && (!rowElement.previousElementSibling ||
-                rowElement.previousElementSibling.offsetTop < Math.abs(containerTopOffset))) {
-                this.grid.nativeElement.focus({ preventScroll: true });
-                this.grid.verticalScrollContainer.onChunkLoad
-                    .pipe(first())
-                    .subscribe(() => {
-                        prevRow = this.grid.getRowByIndex(prevIndex);
-                        if (prevRow && prevRow.cells) {
-                            this._focusCell(upperElementColumn.cells.find((c) => c.rowIndex === prevRow.index).nativeElement);
-                        } else if (prevRow) {
-                            prevRow.nativeElement.focus({ preventScroll: true });
-                        }
-                    });
-                this.grid.verticalScrollContainer.scrollTo(prevIndex);
-            } else {
-                prevRow = this.grid.getRowByIndex(prevIndex);
-                if (prevRow && prevRow.cells) {
-                    this._focusCell(upperElementColumn.cells.find((c) => c.rowIndex === prevRow.index).nativeElement);
-                } else if (prevRow) {
-                    prevRow.nativeElement.focus({ preventScroll: true });
-                }
-            }
+            movePrev = true;
+        }
+        const rowIndex = movePrev ? selectedNode.row - 1 : selectedNode.row;
+        if (rowIndex < 0) {
+            // end of rows reached.
             return;
         }
-        this._focusCell(upperElement);
+        let prevRow;
+        const cb = () => {
+            prevRow = this.grid.getRowByIndex(rowIndex);
+            if (prevRow && prevRow.cells) {
+                this._focusCell(upperElementColumn.cells.find((c) => c.rowIndex === prevRow.index).nativeElement);
+            } else if (prevRow) {
+                prevRow.nativeElement.focus({ preventScroll: true });
+            }
+        };
+        if (this.shouldPerformVerticalScroll(rowIndex, upperElementColumn.visibleIndex)) {
+            this.grid.nativeElement.focus({ preventScroll: true });
+                this.performVerticalScroll(rowIndex, upperElementColumn.visibleIndex, cb);
+        } else {
+            cb();
+        }
     }
 
     private focusCellDownFromLayout(rowElement, selectedNode: ISelectionNode) {
@@ -190,163 +184,124 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         const columnLayout = this.grid.columns.find( x => x.columnLayout && x.visibleIndex === parentIndex);
         const currentRowEnd = selectedNode.layout ? selectedNode.layout.rowEnd || selectedNode.layout.rowStart + 1 : 2;
         const currentColStart = selectedNode.layout ? selectedNode.layout.colStart : 1;
-        let element;
-        if (!isGroupRow) {
-            const cell = this.grid.getRowByIndex(selectedNode.row).cells
-            .find(x => x.visibleColumnIndex === selectedNode.layout.columnVisibleIndex);
-            element = cell.nativeElement.parentElement;
-        }
-
-        // element down is from the same layout
+        let moveNext;
+        // check if element down is from the same layout
         let nextElementColumn = columnLayout.children.find(c => c.rowStart === currentRowEnd &&
             c.colStart <= currentColStart &&
             (currentColStart < c.colEnd || currentColStart < c.colStart + c.gridColumnSpan));
-
-        const columnIndex = columnLayout.children.toArray().indexOf(nextElementColumn);
-        const nextElement = element ? element.children[columnIndex] : null;
-
-        if (!nextElement) {
-
+        if (isGroupRow || !nextElementColumn) {
+            // no next row in current row layout, go to next row first rowstart
             nextElementColumn = columnLayout.children.find(c => c.rowStart === 1 &&
                 c.colStart <= currentColStart &&
                 (currentColStart < c.colEnd || currentColStart < c.colStart + c.gridColumnSpan));
-
-            const nextIndex = selectedNode.row + 1;
-            let nextRow;
-
-            const rowHeight = this.grid.verticalScrollContainer.getSizeAt(nextIndex);
-            const containerHeight = this.grid.calcHeight ? Math.ceil(this.grid.calcHeight) : 0;
-            const targetEndTopOffset = rowElement.nextElementSibling ?
-            rowElement.nextElementSibling.offsetTop + rowHeight + parseInt(this.verticalDisplayContainerElement.style.top, 10) :
-                containerHeight + rowHeight;
-            if (containerHeight && containerHeight < targetEndTopOffset) {
-                this.grid.nativeElement.focus({ preventScroll: true });
-                this.grid.verticalScrollContainer.onChunkLoad
-                    .pipe(first())
-                    .subscribe(() => {
-                        nextRow = this.grid.getRowByIndex(nextIndex);
-                        if (nextRow && nextRow.cells) {
-                            this._focusCell(nextElementColumn.cells.find((c) => c.rowIndex === nextRow.index).nativeElement);
-                        } else if (nextRow) {
-                            nextRow.nativeElement.focus({ preventScroll: true });
-                        }
-                    });
-                    this.grid.verticalScrollContainer.scrollTo(nextIndex);
-            } else {
-                nextRow = this.grid.getRowByIndex(nextIndex);
-                if (nextRow && nextRow.cells) {
-                    this._focusCell(nextElementColumn.cells.find((c) => c.rowIndex === nextRow.index).nativeElement);
-                } else if (nextRow) {
-                    nextRow.nativeElement.focus({ preventScroll: true });
-                }
-            }
+            moveNext = true;
+        }
+        const rowIndex = moveNext ? selectedNode.row + 1 : selectedNode.row;
+        if (rowIndex > this.grid.verticalScrollContainer.igxForOf.length - 1) {
+            // end of rows reached.
             return;
         }
-        this._focusCell(nextElement);
+        let nextRow;
+        const cb = () => {
+            nextRow = this.grid.getRowByIndex(rowIndex);
+            if (nextRow && nextRow.cells) {
+                this._focusCell(nextElementColumn.cells.find((c) => c.rowIndex === nextRow.index).nativeElement);
+            } else if (nextRow) {
+                nextRow.nativeElement.focus({ preventScroll: true });
+            }
+        };
+        if (this.shouldPerformVerticalScroll(rowIndex, nextElementColumn.visibleIndex)) {
+            this.grid.nativeElement.focus({ preventScroll: true });
+                this.performVerticalScroll(rowIndex, nextElementColumn.visibleIndex, cb);
+        } else {
+            cb();
+        }
     }
 
     private focusNextCellFromLayout(cellElement, selectedNode: ISelectionNode) {
         const parentIndex = selectedNode.column;
-        const columnLayout = this.grid.columns.find( x => x.columnLayout && x.visibleIndex === parentIndex);
+        let columnLayout = this.grid.columns.find( x => x.columnLayout && x.visibleIndex === parentIndex);
         const currentColEnd = selectedNode.layout.colEnd || selectedNode.layout.colStart + 1;
         const currentRowStart = selectedNode.layout.rowStart;
         const rowIndex = selectedNode.row;
-        const element = cellElement.parentElement;
-        // next element is from the same layout
+        let element = cellElement.parentElement;
+        // check if next element is from the same layout
         let nextElementColumn = columnLayout.children.find(c => c.colStart === currentColEnd &&
             c.rowStart <= currentRowStart &&
             (currentRowStart < c.rowEnd || currentRowStart < c.rowStart + c.gridRowSpan));
-
-        let columnIndex = columnLayout.children.toArray().indexOf(nextElementColumn);
-        let nextElement = element.children[columnIndex];
-
-        if (!nextElement) {
-            // try extracting first element from the next layout
-            const nextLayout = this.grid.columns.find(c => c.columnLayout && !c.hidden && c.visibleIndex === columnLayout.visibleIndex + 1);
-            if (!nextLayout) {
+        if (!nextElementColumn) {
+            // no next column in current layout, search for next layout
+            columnLayout = this.grid.columns.find(c => c.columnLayout && !c.hidden && c.visibleIndex === columnLayout.visibleIndex + 1);
+            if (!columnLayout) {
                 // reached the end
                 return null;
             }
-            // first element is from the next layout
-            nextElementColumn = nextLayout.children.find(c => c.colStart === 1 &&
+            // next element is from the next layout
+            nextElementColumn = columnLayout.children.find(c => c.colStart === 1 &&
                 c.rowStart <= currentRowStart &&
                 (currentRowStart < c.rowEnd || currentRowStart < c.rowStart + c.gridRowSpan));
-
-            columnIndex = nextLayout.children.toArray().indexOf(nextElementColumn);
-
-            if (element.classList.contains('igx-grid__td--pinned-last')) {
-                nextElement = element.nextElementSibling.children[0].children[columnIndex];
-            } else if (!this.isColumnFullyVisible(nextElementColumn.visibleIndex)) {
-                this.grid.nativeElement.focus({ preventScroll: true });
-                this.grid.parentVirtDir.onChunkLoad
-                .pipe(first())
-                .subscribe(() => {
-                    nextElement = element.nextElementSibling.children[columnIndex];
-                    this._focusCell(nextElement);
-                });
-                const hScroll = this.horizontalScroll(rowIndex);
-                const scrIndex = hScroll.igxForOf.indexOf(nextElementColumn.parent);
-                hScroll.scrollTo(scrIndex);
-                return;
-            } else {
-                nextElement = element.nextElementSibling.children[columnIndex];
-            }
+            element = element.nextElementSibling;
         }
-        this._focusCell(nextElement);
+        const columnIndex = columnLayout.children.toArray().indexOf(nextElementColumn);
+        let nextElement = element.children[columnIndex];
+
+        const cb = () => {
+            nextElement = element.children[columnIndex];
+            nextElement.focus({ preventScroll: true });
+        };
+        if (element.classList.contains('igx-grid__td--pinned-last')) {
+            nextElement = element.nextElementSibling.children[0].children[columnIndex];
+            nextElement.focus({ preventScroll: true });
+        } else if (!this.isColumnFullyVisible(nextElementColumn.visibleIndex)) {
+            this.grid.nativeElement.focus({ preventScroll: true });
+            this.performHorizontalScrollToCell(rowIndex, nextElementColumn.visibleIndex, false, cb);
+        } else {
+            cb();
+        }
     }
 
     private focusPrevCellFromLayout(cellElement, selectedNode: ISelectionNode) {
         const parentIndex = selectedNode.column;
-        const columnLayout = this.grid.columns.find( x => x.columnLayout && x.visibleIndex === parentIndex);
+        let columnLayout = this.grid.columns.find( x => x.columnLayout && x.visibleIndex === parentIndex);
         const currentColStart = selectedNode.layout.colStart;
         const currentRowStart = selectedNode.layout.rowStart;
         const rowIndex = selectedNode.row;
 
-        // previous element is from the same layout
+        // check previous element is from the same layout
         let prevElementColumn = columnLayout.children
         .find(c => (c.colEnd === currentColStart || c.colStart + c.gridColumnSpan === currentColStart ) &&
             c.rowStart <= currentRowStart &&
             (currentRowStart < c.rowEnd || currentRowStart < c.rowStart + c.gridRowSpan));
-
-        let columnIndex = columnLayout.children.toArray().indexOf(prevElementColumn);
-        const element = cellElement.parentElement;
-        let prevElement = element.children[columnIndex];
-
-        if (!prevElement) {
-            // try extracting first element from the previous layout
-            const prevLayout = this.grid.columns.find(c => c.columnLayout && !c.hidden && c.visibleIndex === columnLayout.visibleIndex - 1);
-            if (!prevLayout) {
+        let element = cellElement.parentElement;
+        if (!prevElementColumn) {
+            // no prev column in current layout, seacrh for prev layout
+            columnLayout = this.grid.columns.find(c => c.columnLayout && !c.hidden && c.visibleIndex === columnLayout.visibleIndex - 1);
+            if (!columnLayout) {
                 // reached the end
                 return null;
             }
-            const layoutSize = prevLayout.getInitialChildColumnSizes(prevLayout.children).length;
+            const layoutSize = columnLayout.getInitialChildColumnSizes(columnLayout.children).length;
             // first element is from the next layout
-            prevElementColumn = prevLayout.children
+            prevElementColumn = columnLayout.children
             .find(c => (c.colEnd === layoutSize + 1 || c.colStart + c.gridColumnSpan === layoutSize + 1) &&
                 c.rowStart <= currentRowStart &&
                 (currentRowStart < c.rowEnd || currentRowStart < c.rowStart + c.gridRowSpan));
-
-            columnIndex = prevLayout.children.toArray().indexOf(prevElementColumn);
-
-            if (!this.isColumnLeftFullyVisible(prevElementColumn.visibleIndex)) {
-                this.grid.nativeElement.focus({ preventScroll: true });
-                this.grid.parentVirtDir.onChunkLoad
-                .pipe(first())
-                .subscribe(() => {
-                    prevElement = element.previousElementSibling.children[columnIndex];
-                    this._focusCell(prevElement);
-                });
-                const hScroll = this.horizontalScroll(rowIndex);
-                const scrIndex = hScroll.igxForOf.indexOf(prevElementColumn.parent);
-                hScroll.scrollTo(scrIndex);
-                return;
-            } else {
-                prevElement = !element.previousElementSibling && this.grid.pinnedColumns.length ?
-                    element.parentNode.previousElementSibling.children[columnIndex] :
-                    element.previousElementSibling.children[columnIndex];
-            }
+            element = element.previousElementSibling;
         }
-        this._focusCell(prevElement);
+
+        const columnIndex = columnLayout.children.toArray().indexOf(prevElementColumn);
+        let prevElement = element.children[columnIndex];
+
+        const cb = () => {
+            prevElement = element.children[columnIndex];
+            prevElement.focus({ preventScroll: true });
+        };
+        if (!this.isColumnLeftFullyVisible(prevElementColumn.visibleIndex)) {
+            this.grid.nativeElement.focus({ preventScroll: true });
+            this.performHorizontalScrollToCell(rowIndex, prevElementColumn.visibleIndex, false, cb);
+        } else {
+            cb();
+        }
     }
 
     public onKeydownEnd(rowIndex, isSummary = false, cellRowStart?) {
@@ -368,16 +323,12 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
 
         if (!this.isColumnFullyVisible(nextElementColumn.parent.visibleIndex)) {
             this.grid.nativeElement.focus({ preventScroll: true });
-            this.grid.parentVirtDir.onChunkLoad
-            .pipe(first())
-            .subscribe(() => {
+            const cb = () => {
                 const allBlocks = rowElement.querySelectorAll(this.getColumnLayoutSelector());
                 const cell = allBlocks[allBlocks.length - 1].children[indexInLayout];
                 this._focusCell(cell);
-            });
-            const hScroll = this.horizontalScroll(rowIndex);
-            const scrIndex = hScroll.igxForOf.indexOf(nextElementColumn.parent);
-            hScroll.scrollTo(scrIndex);
+            };
+            this.performHorizontalScrollToCell(rowIndex, nextElementColumn.visibleIndex, false, cb);
             return;
         } else {
             const allBlocks = rowElement.querySelectorAll(this.getColumnLayoutSelector());
@@ -403,16 +354,12 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
 
         if (!this.isColumnLeftFullyVisible(nextElementColumn.parent.visibleIndex)) {
             this.grid.nativeElement.focus({ preventScroll: true });
-            this.grid.parentVirtDir.onChunkLoad
-            .pipe(first())
-            .subscribe(() => {
+           const cb = () => {
                 const allBlocks = rowElement.querySelectorAll(this.getColumnLayoutSelector());
                 const cell = allBlocks[0].children[indexInLayout];
                 this._focusCell(cell);
-            });
-            const hScroll = this.horizontalScroll(rowIndex);
-            const scrIndex = hScroll.igxForOf.indexOf(nextElementColumn.parent);
-            hScroll.scrollTo(scrIndex);
+            };
+            this.performHorizontalScrollToCell(rowIndex, nextElementColumn.visibleIndex, false, cb);
             return;
         } else {
             const allBlocks = rowElement.querySelectorAll(this.getColumnLayoutSelector());
@@ -425,29 +372,100 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
         return '.igx-grid__mrl-block';
     }
 
-    protected performHorizontalScrollToCell(rowIndex, visibleColumnIndex, isSummary = false) {
-        const col = this.grid.columns.find(x => !x.columnGroup && x.visibleIndex === visibleColumnIndex);
+    protected getChildColumnScrollPositions(visibleColIndex: number) {
+        const forOfDir = this.grid.dataRowList.length > 0 ? this.grid.dataRowList.first.virtDirRow : this.grid.headerContainer;
+        const targetCol: IgxColumnComponent = this.getColunmByVisibleIndex(visibleColIndex);
+        const parent = targetCol.parent;
+        const parentVIndex = forOfDir.igxForOf.indexOf(parent);
+        let leftScroll = forOfDir.getColumnScrollLeft(parentVIndex), rightScroll = 0;
+        parent.children.forEach((c) => {
+            const rowEnd = c.rowEnd !== undefined ? c.rowEnd : c.rowStart + 1;
+            const targetRowEnd = targetCol.rowEnd !== undefined ? targetCol.rowEnd : targetCol.rowStart + 1;
+            if (c.rowStart >= targetCol.rowStart && rowEnd >= targetRowEnd && c.visibleIndex < targetCol.visibleIndex) {
+                leftScroll += parseInt(c.calcWidth, 10);
+            }
+        });
+        rightScroll = leftScroll + parseInt(targetCol.width, 10);
+        return {leftScroll, rightScroll};
+    }
+
+    protected getColunmByVisibleIndex(visibleColIndex: number): IgxColumnComponent {
+        visibleColIndex = visibleColIndex < 0 ? 0 : visibleColIndex;
+        return this.grid.columnList.find((col) => !col.columnLayout && col.visibleIndex === visibleColIndex);
+    }
+
+    public shouldPerformVerticalScroll(rowIndex: number, visibleColumnIndex: number): boolean {
+        if (!super.shouldPerformVerticalScroll(rowIndex, visibleColumnIndex)) {return false; }
+       const targetRow = this.grid.summariesRowList.filter(s => s.index !== 0)
+           .concat(this.grid.rowList.toArray()).find(r => r.index === rowIndex);
+       const scrollTop =  Math.abs(this.grid.verticalScrollContainer.getVerticalScroll().scrollTop);
+       const containerHeight = this.grid.calcHeight ? Math.ceil(this.grid.calcHeight) : 0;
+       const scrollPos = this.getVerticalScrollPositions(rowIndex, visibleColumnIndex);
+       if (!targetRow || targetRow.nativeElement.offsetTop + scrollPos.topOffset < Math.abs(this.verticalDCTopOffset)
+           || containerHeight && containerHeight < scrollPos.rowBottom - scrollTop) {
+           return true;
+       } else {
+           return false;
+       }
+   }
+
+   get verticalDCTopOffset() {
+        return  parseInt(this.grid.verticalScrollContainer.dc.instance._viewContainer.element.nativeElement.style.top, 10);
+    }
+
+    public performVerticalScroll(rowIndex: number, visibleColumnIndex: number, cb?) {
+        const containerHeight = this.grid.calcHeight ? Math.ceil(this.grid.calcHeight) : 0;
+        const scrollTop = Math.abs(this.grid.verticalScrollContainer.getVerticalScroll().scrollTop);
+        const scrollPos = this.getVerticalScrollPositions(rowIndex, visibleColumnIndex);
+        const targetRow = this.grid.summariesRowList.filter(s => s.index !== 0)
+            .concat(this.grid.rowList.toArray()).find(r => r.index === rowIndex);
+        const isPrevious =  (scrollTop > scrollPos.rowTop) && (!targetRow ||
+                targetRow.nativeElement.offsetTop + scrollPos.topOffset < Math.abs(this.verticalDCTopOffset));
+        const scrollAmount = isPrevious ? scrollPos.rowTop : Math.abs(scrollTop + containerHeight - scrollPos.rowBottom);
+
+        this.grid.verticalScrollContainer.onChunkLoad
+        .pipe(first()).subscribe(() => {
+            cb();
+        });
+
+        if (isPrevious) {
+            this.grid.verticalScrollContainer.getVerticalScroll().scrollTop = scrollAmount;
+        } else {
+            this.grid.verticalScrollContainer.addScrollTop(scrollAmount);
+        }
+    }
+
+    public getVerticalScrollPositions(rowIndex: number, visibleColIndex: number) {
+        const targetCol: IgxColumnComponent = this.getColunmByVisibleIndex(visibleColIndex);
+        const topOffset = (targetCol.rowStart - 1)  * this.grid.defaultRowHeight;
+        const rowTop = this.grid.verticalScrollContainer.sizesCache[rowIndex] + topOffset;
+        const rowBottom = rowTop + (this.grid.defaultRowHeight * targetCol.gridRowSpan);
+        return { rowTop, rowBottom, topOffset };
+    }
+
+    public performHorizontalScrollToCell(rowIndex, visibleColumnIndex, isSummary = false, cb?) {
+        const scrollPos = this.getChildColumnScrollPositions(visibleColumnIndex);
         const hScroll = this.horizontalScroll(rowIndex);
-        const scrIndex = hScroll.igxForOf.indexOf(col.parent);
         this.grid.parentVirtDir.onChunkLoad
             .pipe(first())
             .subscribe(() => {
-                this._focusCell(this.getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummary));
-            });
-        hScroll.scrollTo(scrIndex);
+                if (cb) {
+                    cb();
+                } else {
+                    this._focusCell(this.getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummary));
+                }
+        });
+        const nextScroll = !(this.displayContainerScrollLeft <= scrollPos.leftScroll) &&
+        this.displayContainerWidth >= scrollPos.rightScroll - this.displayContainerScrollLeft ?
+        scrollPos.leftScroll : scrollPos.rightScroll - this.displayContainerWidth;
+        hScroll.getHorizontalScroll().scrollLeft = nextScroll;
     }
 
     protected _focusCell(cellElem) {
+        // in case of variable row heights in mrl grid make sure cell is really in view after it has been rendered.
         const gridBoundingClientRect = this.grid.tbody.nativeElement.getBoundingClientRect();
         const diffTop = cellElem.getBoundingClientRect().top - gridBoundingClientRect.top;
         const diffBottom = cellElem.getBoundingClientRect().bottom - gridBoundingClientRect.bottom;
-        const vIndex = parseInt(cellElem.getAttribute('data-visibleIndex'), 10);
-        const isPinned = this.grid.columns.find(x => !x.columnGroup && x.visibleIndex === vIndex).pinned;
-        const diffLeft = !isPinned ? cellElem.getBoundingClientRect().left - this.grid.pinnedWidth - gridBoundingClientRect.left : 0;
-        const diffRight = !isPinned ? cellElem.getBoundingClientRect().right - gridBoundingClientRect.right : 0;
-        const horizontalVirt =  this.grid.headerContainer;
-        const horizontalScroll = horizontalVirt.getHorizontalScroll();
-        let shouldFocus = false;
         if (diffTop < 0) {
             // cell is above grid top - not visible
             this.grid.nativeElement.focus({ preventScroll: true });
@@ -468,33 +486,6 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
             this.grid.verticalScrollContainer.addScrollTop(diffBottom);
         }  else {
             // cell is visible
-            shouldFocus = true;
-        }
-
-        if (diffRight > 0) {
-            // cell is left of grid left edge - not visible
-            this.grid.nativeElement.focus({ preventScroll: true });
-            this.grid.parentVirtDir.onChunkLoad
-                .pipe(first())
-                .subscribe(() => {
-                    cellElem.focus({ preventScroll: true });
-            });
-            horizontalScroll.scrollLeft += diffRight;
-        } else if (diffLeft < 0) {
-            // cell is right of grid right edge - not visible
-            this.grid.nativeElement.focus({ preventScroll: true });
-            this.grid.parentVirtDir.onChunkLoad
-                .pipe(first())
-                .subscribe(() => {
-                    cellElem.focus({ preventScroll: true });
-            });
-            horizontalScroll.scrollLeft += diffLeft;
-        } else {
-            // cell is visible
-            shouldFocus = true;
-        }
-
-        if (shouldFocus) {
             cellElem.focus({ preventScroll: true });
         }
     }

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -578,7 +578,7 @@ export class IgxGridNavigationService {
         }
     }
 
-    public shouldPerformVerticalScroll(targetRowIndex): boolean {
+    public shouldPerformVerticalScroll(targetRowIndex, visibleColumnIndex): boolean {
         const containerTopOffset = parseInt(this.verticalDisplayContainerElement.style.top, 10);
         const targetRow = this.grid.summariesRowList.filter(s => s.index !== 0)
             .concat(this.grid.rowList.toArray()).find(r => r.index === targetRowIndex);
@@ -594,13 +594,25 @@ export class IgxGridNavigationService {
         }
     }
 
-    protected performHorizontalScrollToCell(rowIndex, visibleColumnIndex, isSummary = false) {
+    public performVerticalScrollToCell(rowIndex, visibleColIndex, cb?) {
+        this.grid.verticalScrollContainer.scrollTo(rowIndex);
+        this.grid.verticalScrollContainer.onChunkLoad
+        .pipe(first()).subscribe(() => {
+            cb();
+        });
+    }
+
+    public performHorizontalScrollToCell(rowIndex, visibleColumnIndex, isSummary = false, cb?) {
         const unpinnedIndex = this.getColumnUnpinnedIndex(visibleColumnIndex);
         this.grid.nativeElement.focus({ preventScroll: true });
         this.grid.parentVirtDir.onChunkLoad
             .pipe(first())
             .subscribe(() => {
-                this.getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummary).focus({ preventScroll: true });
+                if (cb) {
+                    cb();
+                } else {
+                    this.getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummary).focus({ preventScroll: true });
+                }
             });
         this.horizontalScroll(rowIndex).scrollTo(unpinnedIndex);
     }

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
@@ -886,8 +886,10 @@ describe('IgxGrid Multi Row Layout - Keyboard navigation', () => {
         fix.detectChanges();
         const lastCell = grid.getCellByColumn(0, 'ContactTitle');
         expect(lastCell.focused).toBe(true);
-        expect(grid.parentVirtDir.getHorizontalScroll().scrollLeft).toBe(600);
-        const diff = lastCell.nativeElement.getBoundingClientRect().left - grid.tbody.nativeElement.getBoundingClientRect().left;
+        expect(grid.parentVirtDir.getHorizontalScroll().scrollLeft).toBeGreaterThan(600);
+        // check if cell right edge is visible
+        const diff = lastCell.nativeElement.getBoundingClientRect().right -
+        parseInt(grid.width, 10) + 1 - grid.tbody.nativeElement.getBoundingClientRect().right;
         expect(diff).toBe(0);
      });
 
@@ -1276,7 +1278,7 @@ describe('IgxGrid Multi Row Layout - Keyboard navigation', () => {
         cell = grid.getCellByColumn(0, 'City');
         expect(cell.focused).toBe(true);
         expect(grid.parentVirtDir.getHorizontalScroll().scrollLeft).toBeGreaterThan(300);
-        let diff = cell.nativeElement.getBoundingClientRect().right - grid.tbody.nativeElement.getBoundingClientRect().right;
+        let diff = cell.nativeElement.getBoundingClientRect().right + 1 - grid.tbody.nativeElement.getBoundingClientRect().right;
         expect(diff).toBe(0);
 
         // arrow left

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
@@ -888,8 +888,7 @@ describe('IgxGrid Multi Row Layout - Keyboard navigation', () => {
         expect(lastCell.focused).toBe(true);
         expect(grid.parentVirtDir.getHorizontalScroll().scrollLeft).toBeGreaterThan(600);
         // check if cell right edge is visible
-        const diff = lastCell.nativeElement.getBoundingClientRect().right -
-        parseInt(grid.width, 10) + 1 - grid.tbody.nativeElement.getBoundingClientRect().right;
+        const diff = lastCell.nativeElement.getBoundingClientRect().right + 1 - grid.tbody.nativeElement.getBoundingClientRect().right;
         expect(diff).toBe(0);
      });
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
@@ -2715,6 +2715,116 @@ describe('IgxGrid Multi Row Layout - Keyboard navigation', () => {
         expect(fix.componentInstance.selectedCell.column.field).toMatch('ID');
         expect(document.activeElement).toEqual(firstRowCells[firstRowCells.length - 1].nativeElement);
     });
+
+    it('navigateTo method should work in multi-row layout grid.', async () => {
+        const fix = TestBed.createComponent(ColumnLayoutTestComponent);
+        fix.componentInstance.colGroups = [
+            {
+                group: 'group1',
+                columns: [
+                    { field: 'CompanyName', rowStart: 1, colStart: 1, colEnd: 3, editable: true },
+                    { field: 'ContactName', rowStart: 2, colStart: 1, editable: false, width: '100px'  },
+                    { field: 'ContactTitle', rowStart: 2, colStart: 2, editable: true, width: '100px'  },
+                    { field: 'Address', rowStart: 3, colStart: 1, colEnd: 3, editable: true, width: '100px'  }
+                ]
+            },
+            {
+                group: 'group2',
+                columns: [
+                    { field: 'City', rowStart: 1, colStart: 1, colEnd: 3, rowEnd: 3, width: '400px', editable: true  },
+                    { field: 'Region', rowStart: 3, colStart: 1, editable: true  },
+                    { field: 'PostalCode', rowStart: 3, colStart: 2, editable: true  }
+                ]
+            },
+            {
+                group: 'group3',
+                columns: [
+                    { field: 'Phone', rowStart: 1, colStart: 1, width: '200px', editable: true  },
+                    { field: 'Fax', rowStart: 2, colStart: 1, editable: true, width: '200px' },
+                    { field: 'ID', rowStart: 3, colStart: 1, editable: true, width: '200px'  }
+                ]
+            }
+        ];
+        const grid = fix.componentInstance.grid;
+        grid.width = '500px';
+        setupGridScrollDetection(fix, grid);
+        fix.detectChanges();
+
+        // navigate down to cell in a row that is in the DOM but is not in view (half-visible row)
+        let col = grid.getColumnByName('ContactTitle');
+        grid.navigateTo(2, col.visibleIndex);
+
+        await wait(DEBOUNCETIME);
+        fix.detectChanges();
+        // cell should be at bottom of grid
+        let cell =  grid.getCellByColumn(2, 'ContactTitle');
+        expect(grid.verticalScrollContainer.getVerticalScroll().scrollTop).toBeGreaterThan(50);
+        let diff = cell.nativeElement.getBoundingClientRect().bottom - grid.tbody.nativeElement.getBoundingClientRect().bottom;
+        expect(diff).toBe(0);
+
+        // navigate up to cell in a row that is in the DOM but is not in view (half-visible row)
+        col = grid.getColumnByName('CompanyName');
+        grid.navigateTo(0, col.visibleIndex);
+        await wait(DEBOUNCETIME);
+        fix.detectChanges();
+        // cell should be at top of grid
+        cell =  grid.getCellByColumn(0, 'CompanyName');
+        expect(grid.verticalScrollContainer.getVerticalScroll().scrollTop).toBe(0);
+        diff = cell.nativeElement.getBoundingClientRect().top - grid.tbody.nativeElement.getBoundingClientRect().top;
+        expect(diff).toBe(0);
+
+        // navigate to cell in a row is not in the DOM
+        col = grid.getColumnByName('CompanyName');
+        grid.navigateTo(10, col.visibleIndex);
+        await wait(DEBOUNCETIME);
+        fix.detectChanges();
+        // cell should be at bottom of grid
+        cell =  grid.getCellByColumn(10, 'CompanyName');
+        expect(grid.verticalScrollContainer.getVerticalScroll().scrollTop).toBeGreaterThan(50 * 10);
+        diff = cell.nativeElement.getBoundingClientRect().bottom - grid.tbody.nativeElement.getBoundingClientRect().bottom;
+        expect(diff).toBe(0);
+
+        // navigate right to cell in column that is in DOM but is not in view
+        col = grid.getColumnByName('City');
+        grid.navigateTo(10, col.visibleIndex);
+        await wait(DEBOUNCETIME);
+        fix.detectChanges();
+
+        // cell should be at right edge of grid
+        cell =  grid.getCellByColumn(10, 'City');
+        expect(grid.parentVirtDir.getHorizontalScroll().scrollLeft).toBeGreaterThan(100);
+        // check if cell right edge is visible
+        diff = cell.nativeElement.getBoundingClientRect().right + 1 - grid.tbody.nativeElement.getBoundingClientRect().right;
+        expect(diff).toBe(0);
+
+        // navigate left to cell in column that is in DOM but is not in view
+        col = grid.getColumnByName('CompanyName');
+        grid.navigateTo(10, col.visibleIndex);
+        await wait(DEBOUNCETIME);
+        fix.detectChanges();
+
+        // cell should be at left edge of grid
+        cell =  grid.getCellByColumn(10, 'CompanyName');
+        expect(grid.parentVirtDir.getHorizontalScroll().scrollLeft).toBe(0);
+        // check if cell right left is visible
+        diff = cell.nativeElement.getBoundingClientRect().left - grid.tbody.nativeElement.getBoundingClientRect().left;
+        expect(diff).toBe(0);
+
+        // navigate to cell in column that is not in DOM
+
+        col = grid.getColumnByName('ID');
+        grid.navigateTo(9, col.visibleIndex);
+        await wait(DEBOUNCETIME);
+        fix.detectChanges();
+
+        // cell should be at right edge of grid
+        cell =  grid.getCellByColumn(9, 'ID');
+        expect(grid.parentVirtDir.getHorizontalScroll().scrollLeft).toBeGreaterThan(250);
+        // check if cell right right is visible
+        diff = cell.nativeElement.getBoundingClientRect().right + 1 - grid.tbody.nativeElement.getBoundingClientRect().right;
+        expect(diff).toBe(0);
+
+    });
 });
 
 @Component({

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -149,6 +149,11 @@ export class AppComponent implements OnInit {
             name: 'Grid MRL Config'
         },
         {
+            link: '/gridMRLCustomNav',
+            icon: 'view_column',
+            name: 'Grid MRL Custom Navigation'
+        },
+        {
             link: '/gridFilterTemplate',
             icon: 'view_column',
             name: 'Grid Filter Template'

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -93,6 +93,8 @@ import { GridMRLSampleComponent } from './grid-multi-row-layout/grid-mrl.sample'
 import { TreeGridLoadOnDemandSampleComponent } from './tree-grid-load-on-demand/tree-grid-load-on-demand.sample';
 import { GridFilterTemplateSampleComponent } from './grid-filter-template/grid-filter-template.sample';
 import { GridMRLConfigSampleComponent } from './grid-multi-row-layout-config/grid-mrl-config.sample';
+import { GridMRLCustomNavigationSampleComponent } from './grid-mrl-custom-navigation/grid-mrl-custom-navigation';
+
 
 
 
@@ -157,6 +159,7 @@ const components = [
     GridColumnGroupsSampleComponent,
     GridMRLSampleComponent,
     GridMRLConfigSampleComponent,
+    GridMRLCustomNavigationSampleComponent,
     GridCellStylingSampleComponent,
     GridRowEditSampleComponent,
     GridWithTransactionsComponent,

--- a/src/app/grid-mrl-custom-navigation/grid-mrl-custom-navigation.sample.html
+++ b/src/app/grid-mrl-custom-navigation/grid-mrl-custom-navigation.sample.html
@@ -1,0 +1,28 @@
+<div  class="sample-wrapper">
+    <app-page-header title="Grid MRL"></app-page-header>
+    <section style="height: 800px" class="sample-content">
+        <div class="density-chooser" style="margin-bottom: 16px">
+            <igx-buttongroup [values]="displayDensities" (onSelect)="selectDensity($event)" style="display: block; width: 500px"></igx-buttongroup>
+        </div>
+        <igx-grid (onGridKeydown)="customNavigation($event)" [showToolbar]="true"  [columnHiding] = "true" [columnPinning]='true' [rowSelectable]="false" [primaryKey]="'PostalCode'" #grid [data]="data" [displayDensity]="density" [width]="'600px'" [height]="'500px'" [rowEditable]="true" >
+            <igx-column-layout field='group1'>
+                <igx-column [rowStart]="1" [colStart]="1" [rowEnd]="4" field="ID" [groupable]='true' ></igx-column>
+            </igx-column-layout>
+            <igx-column-layout field='group2'>
+                <igx-column editable="true" [rowStart]="1" [colStart]="1" [colEnd]="3" field="CompanyName"></igx-column>
+                <igx-column [rowStart]="2" [colStart]="1" field="ContactName" ></igx-column>
+                <igx-column [rowStart]="2" [colStart]="2" field="ContactTitle"></igx-column>
+                <igx-column [rowStart]="3" [colStart]="1" [colEnd]="3" field="Address"></igx-column>
+            </igx-column-layout>
+            <igx-column-layout>
+                <igx-column [rowStart]="1" [colStart]="1" [colEnd]="3" [rowEnd]="3" field="City"></igx-column>
+                <igx-column [rowStart]="3" [colStart]="1"  [colEnd]="3" [movable]="false" sortable="true" field="Region"></igx-column>
+            </igx-column-layout>
+            <igx-column-layout>
+                <igx-column [rowStart]="1" [colStart]="1" field="Country"></igx-column>
+                <igx-column [rowStart]="1" [colStart]="2" [movable]="false" sortable="true" field="Phone"></igx-column>
+                <igx-column [rowStart]="2" [colStart]="1" [colEnd]="3" [rowEnd]="4" [movable]="false" sortable="true" field="Fax"></igx-column>
+            </igx-column-layout>
+        </igx-grid>
+    </section>
+</div>

--- a/src/app/grid-mrl-custom-navigation/grid-mrl-custom-navigation.sample.html
+++ b/src/app/grid-mrl-custom-navigation/grid-mrl-custom-navigation.sample.html
@@ -4,7 +4,7 @@
         <div class="density-chooser" style="margin-bottom: 16px">
             <igx-buttongroup [values]="displayDensities" (onSelect)="selectDensity($event)" style="display: block; width: 500px"></igx-buttongroup>
         </div>
-        <igx-grid (onGridKeydown)="customNavigation($event)" [showToolbar]="true"  [columnHiding] = "true" [columnPinning]='true' [rowSelectable]="false" [primaryKey]="'PostalCode'" #grid [data]="data" [displayDensity]="density" [width]="'600px'" [height]="'500px'" [rowEditable]="true" >
+        <igx-grid (onGridKeydown)="customNavigation($event)" [showToolbar]="true"  [columnHiding] = "true" [columnPinning]='true' [rowSelectable]="false" [primaryKey]="'PostalCode'" #grid [data]="data" [displayDensity]="density" [width]="'100%'" [height]="'500px'" [rowEditable]="true" >
             <igx-column-layout field='group1'>
                 <igx-column [rowStart]="1" [colStart]="1" [rowEnd]="4" field="ID" [groupable]='true' ></igx-column>
             </igx-column-layout>

--- a/src/app/grid-mrl-custom-navigation/grid-mrl-custom-navigation.ts
+++ b/src/app/grid-mrl-custom-navigation/grid-mrl-custom-navigation.ts
@@ -1,0 +1,115 @@
+import { Component, ViewChild, AfterViewInit } from '@angular/core';
+import { IgxGridComponent, DropPosition } from 'igniteui-angular';
+
+@Component({
+    selector: 'app-grid-mrl-custom-navigation-sample',
+    templateUrl: 'grid-mrl-custom-navigation.sample.html'
+})
+export class GridMRLCustomNavigationSampleComponent {
+    @ViewChild(IgxGridComponent, { read: IgxGridComponent })
+    grid: IgxGridComponent;
+    width = null;
+    cols: Array<any> = [
+        { field: 'ID', rowStart: 1, colStart: 1},
+        { field: 'CompanyName', rowStart: 1, colStart: 2},
+        { field: 'ContactName', rowStart: 1, colStart: 3},
+        { field: 'ContactTitle', rowStart: 2, colStart: 1, rowEnd: 'span 2', colEnd : 'span 3'},
+    ];
+    colGroups = [
+        {
+            group: 'group1',
+            columns: this.cols
+        }
+    ];
+
+    public density = 'compact';
+    public displayDensities;
+    data = [
+        // tslint:disable:max-line-length
+        { 'ID': 'ALFKI', 'CompanyName': 'Alfreds Futterkiste', 'ContactName': 'Maria Anders', 'ContactTitle': 'Sales Representative', 'Address': 'Obere Str. 57', 'City': 'Berlin', 'Region': null, 'PostalCode': '12209', 'Country': 'Germany', 'Phone': '030-0074321', 'Fax': '030-0076545' },
+        { 'ID': 'ANATR', 'CompanyName': 'Ana Trujillo Emparedados y helados', 'ContactName': 'Ana Trujillo', 'ContactTitle': 'Owner', 'Address': 'Avda. de la Constitución 2222', 'City': 'México D.F.', 'Region': null, 'PostalCode': '05021', 'Country': 'Mexico', 'Phone': '(5) 555-4729', 'Fax': '(5) 555-3745' },
+        { 'ID': 'ANTON', 'CompanyName': 'Antonio Moreno Taquería', 'ContactName': 'Antonio Moreno', 'ContactTitle': 'Owner', 'Address': 'Mataderos 2312', 'City': 'México D.F.', 'Region': null, 'PostalCode': '05023', 'Country': 'Mexico', 'Phone': '(5) 555-3932', 'Fax': null },
+        { 'ID': 'AROUT', 'CompanyName': 'Around the Horn', 'ContactName': 'Thomas Hardy', 'ContactTitle': 'Sales Representative', 'Address': '120 Hanover Sq.', 'City': 'London', 'Region': null, 'PostalCode': 'WA1 1DP', 'Country': 'UK', 'Phone': '(171) 555-7788', 'Fax': '(171) 555-6750' },
+        { 'ID': 'BERGS', 'CompanyName': 'Berglunds snabbköp', 'ContactName': 'Christina Berglund', 'ContactTitle': 'Order Administrator', 'Address': 'Berguvsvägen 8', 'City': 'Luleå', 'Region': null, 'PostalCode': 'S-958 22', 'Country': 'Sweden', 'Phone': '0921-12 34 65', 'Fax': '0921-12 34 67' },
+        { 'ID': 'BLAUS', 'CompanyName': 'Blauer See Delikatessen', 'ContactName': 'Hanna Moos', 'ContactTitle': 'Sales Representative', 'Address': 'Forsterstr. 57', 'City': 'Mannheim', 'Region': null, 'PostalCode': '68306', 'Country': 'Germany', 'Phone': '0621-08460', 'Fax': '0621-08924' },
+        { 'ID': 'BLONP', 'CompanyName': 'Blondesddsl père et fils', 'ContactName': 'Frédérique Citeaux', 'ContactTitle': 'Marketing Manager', 'Address': '24, place Kléber', 'City': 'Strasbourg', 'Region': null, 'PostalCode': '67000', 'Country': 'France', 'Phone': '88.60.15.31', 'Fax': '88.60.15.32' },
+        { 'ID': 'BOLID', 'CompanyName': 'Bólido Comidas preparadas', 'ContactName': 'Martín Sommer', 'ContactTitle': 'Owner', 'Address': 'C/ Araquil, 67', 'City': 'Madrid', 'Region': null, 'PostalCode': '28023', 'Country': 'Spain', 'Phone': '(91) 555 22 82', 'Fax': '(91) 555 91 99' },
+        { 'ID': 'BONAP', 'CompanyName': 'Bon app\'', 'ContactName': 'Laurence Lebihan', 'ContactTitle': 'Owner', 'Address': '12, rue des Bouchers', 'City': 'Marseille', 'Region': null, 'PostalCode': '13008', 'Country': 'France', 'Phone': '91.24.45.40', 'Fax': '91.24.45.41' },
+        { 'ID': 'BOTTM', 'CompanyName': 'Bottom-Dollar Markets', 'ContactName': 'Elizabeth Lincoln', 'ContactTitle': 'Accounting Manager', 'Address': '23 Tsawassen Blvd.', 'City': 'Tsawassen', 'Region': 'BC', 'PostalCode': 'T2F 8M4', 'Country': 'Canada', 'Phone': '(604) 555-4729', 'Fax': '(604) 555-3745' },
+        { 'ID': 'BSBEV', 'CompanyName': 'B\'s Beverages', 'ContactName': 'Victoria Ashworth', 'ContactTitle': 'Sales Representative', 'Address': 'Fauntleroy Circus', 'City': 'London', 'Region': null, 'PostalCode': 'EC2 5NT', 'Country': 'UK', 'Phone': '(171) 555-1212', 'Fax': null },
+        { 'ID': 'CACTU', 'CompanyName': 'Cactus Comidas para llevar', 'ContactName': 'Patricio Simpson', 'ContactTitle': 'Sales Agent', 'Address': 'Cerrito 333', 'City': 'Buenos Aires', 'Region': null, 'PostalCode': '1010', 'Country': 'Argentina', 'Phone': '(1) 135-5555', 'Fax': '(1) 135-4892' },
+        { 'ID': 'CENTC', 'CompanyName': 'Centro comercial Moctezuma', 'ContactName': 'Francisco Chang', 'ContactTitle': 'Marketing Manager', 'Address': 'Sierras de Granada 9993', 'City': 'México D.F.', 'Region': null, 'PostalCode': '05022', 'Country': 'Mexico', 'Phone': '(5) 555-3392', 'Fax': '(5) 555-7293' },
+        { 'ID': 'CHOPS', 'CompanyName': 'Chop-suey Chinese', 'ContactName': 'Yang Wang', 'ContactTitle': 'Owner', 'Address': 'Hauptstr. 29', 'City': 'Bern', 'Region': null, 'PostalCode': '3012', 'Country': 'Switzerland', 'Phone': '0452-076545', 'Fax': null },
+        { 'ID': 'COMMI', 'CompanyName': 'Comércio Mineiro', 'ContactName': 'Pedro Afonso', 'ContactTitle': 'Sales Associate', 'Address': 'Av. dos Lusíadas, 23', 'City': 'Sao Paulo', 'Region': 'SP', 'PostalCode': '05432-043', 'Country': 'Brazil', 'Phone': '(11) 555-7647', 'Fax': null },
+        { 'ID': 'CONSH', 'CompanyName': 'Consolidated Holdings', 'ContactName': 'Elizabeth Brown', 'ContactTitle': 'Sales Representative', 'Address': 'Berkeley Gardens 12 Brewery', 'City': 'London', 'Region': null, 'PostalCode': 'WX1 6LT', 'Country': 'UK', 'Phone': '(171) 555-2282', 'Fax': '(171) 555-9199' },
+        { 'ID': 'DRACD', 'CompanyName': 'Drachenblut Delikatessen', 'ContactName': 'Sven Ottlieb', 'ContactTitle': 'Order Administrator', 'Address': 'Walserweg 21', 'City': 'Aachen', 'Region': null, 'PostalCode': '52066', 'Country': 'Germany', 'Phone': '0241-039123', 'Fax': '0241-059428' },
+        { 'ID': 'DUMON', 'CompanyName': 'Du monde entier', 'ContactName': 'Janine Labrune', 'ContactTitle': 'Owner', 'Address': '67, rue des Cinquante Otages', 'City': 'Nantes', 'Region': null, 'PostalCode': '44000', 'Country': 'France', 'Phone': '40.67.88.88', 'Fax': '40.67.89.89' },
+        { 'ID': 'EASTC', 'CompanyName': 'Eastern Connection', 'ContactName': 'Ann Devon', 'ContactTitle': 'Sales Agent', 'Address': '35 King George', 'City': 'London', 'Region': null, 'PostalCode': 'WX3 6FW', 'Country': 'UK', 'Phone': '(171) 555-0297', 'Fax': '(171) 555-3373' },
+        { 'ID': 'ERNSH', 'CompanyName': 'Ernst Handel', 'ContactName': 'Roland Mendel', 'ContactTitle': 'Sales Manager', 'Address': 'Kirchgasse 6', 'City': 'Graz', 'Region': null, 'PostalCode': '8010', 'Country': 'Austria', 'Phone': '7675-3425', 'Fax': '7675-3426' },
+        { 'ID': 'FAMIA', 'CompanyName': 'Familia Arquibaldo', 'ContactName': 'Aria Cruz', 'ContactTitle': 'Marketing Assistant', 'Address': 'Rua Orós, 92', 'City': 'Sao Paulo', 'Region': 'SP', 'PostalCode': '05442-030', 'Country': 'Brazil', 'Phone': '(11) 555-9857', 'Fax': null },
+        { 'ID': 'FISSA', 'CompanyName': 'FISSA Fabrica Inter. Salchichas S.A.', 'ContactName': 'Diego Roel', 'ContactTitle': 'Accounting Manager', 'Address': 'C/ Moralzarzal, 86', 'City': 'Madrid', 'Region': null, 'PostalCode': '28034', 'Country': 'Spain', 'Phone': '(91) 555 94 44', 'Fax': '(91) 555 55 93' },
+        { 'ID': 'FOLIG', 'CompanyName': 'Folies gourmandes', 'ContactName': 'Martine Rancé', 'ContactTitle': 'Assistant Sales Agent', 'Address': '184, chaussée de Tournai', 'City': 'Lille', 'Region': null, 'PostalCode': '59000', 'Country': 'France', 'Phone': '20.16.10.16', 'Fax': '20.16.10.17' },
+        { 'ID': 'FOLKO', 'CompanyName': 'Folk och fä HB', 'ContactName': 'Maria Larsson', 'ContactTitle': 'Owner', 'Address': 'Åkergatan 24', 'City': 'Bräcke', 'Region': null, 'PostalCode': 'S-844 67', 'Country': 'Sweden', 'Phone': '0695-34 67 21', 'Fax': null },
+        { 'ID': 'FRANK', 'CompanyName': 'Frankenversand', 'ContactName': 'Peter Franken', 'ContactTitle': 'Marketing Manager', 'Address': 'Berliner Platz 43', 'City': 'München', 'Region': null, 'PostalCode': '80805', 'Country': 'Germany', 'Phone': '089-0877310', 'Fax': '089-0877451' },
+        { 'ID': 'FRANR', 'CompanyName': 'France restauration', 'ContactName': 'Carine Schmitt', 'ContactTitle': 'Marketing Manager', 'Address': '54, rue Royale', 'City': 'Nantes', 'Region': null, 'PostalCode': '44000', 'Country': 'France', 'Phone': '40.32.21.21', 'Fax': '40.32.21.20' },
+        { 'ID': 'FRANS', 'CompanyName': 'Franchi S.p.A.', 'ContactName': 'Paolo Accorti', 'ContactTitle': 'Sales Representative', 'Address': 'Via Monte Bianco 34', 'City': 'Torino', 'Region': null, 'PostalCode': '10100', 'Country': 'Italy', 'Phone': '011-4988260', 'Fax': '011-4988261' }
+    ];
+
+    constructor() {
+        this.displayDensities = [
+            { label: 'compact', selected: this.density === 'compact', togglable: true },
+            { label: 'cosy', selected: this.density === 'cosy', togglable: true },
+            { label: 'comfortable', selected: this.density === 'comfortable', togglable: true }
+        ];
+    }
+
+    public selectDensity(event) {
+        this.density = this.displayDensities[event.index].label;
+    }
+
+    public customNavigation(args) {
+        const target = args.target;
+        const type = args.targetType;
+        if (args.event.key.toLowerCase() === 'enter') {
+            args.event.preventDefault();
+            args.cancel = true;
+            const rowIndex = target.rowIndex === undefined ? target.index : target.rowIndex;
+            this.grid.navigateTo(rowIndex + 1 , -1 , (obj) => { obj.target.nativeElement.focus(); });
+        }
+        if (type === 'dataCell'  && args.event.key.toLowerCase() === 'arrowright') {
+            args.event.preventDefault();
+            args.cancel = true;
+            this.grid.navigateTo(target.rowIndex, target.visibleColumnIndex + 1, (obj) => { obj.target.nativeElement.focus(); });
+        }
+        if (type === 'dataCell'  && args.event.key.toLowerCase() === 'arrowleft') {
+            args.event.preventDefault();
+            args.cancel = true;
+            this.grid.navigateTo(target.rowIndex, target.visibleColumnIndex - 1, (obj) => { obj.target.nativeElement.focus(); });
+        }
+        if (type === 'dataCell'  && args.event.key.toLowerCase() === 'arrowdown') {
+            args.event.preventDefault();
+            args.cancel = true;
+            // const cell = this.grid.getNextCell(target.rowIndex, target.visibleColumnIndex, (col) => col.field === 'City');
+            this.grid.navigateTo(target.rowIndex + 1, target.visibleColumnIndex, (obj) => { obj.target.nativeElement.focus(); });
+        }
+        if (type === 'dataCell'  && args.event.key.toLowerCase() === 'arrowup') {
+            args.event.preventDefault();
+            args.cancel = true;
+            // const cell = this.grid.getPreviousCell(target.rowIndex, target.visibleColumnIndex, (col) => col.field === 'City');
+            this.grid.navigateTo(target.rowIndex - 1, target.visibleColumnIndex, (obj) => { obj.target.nativeElement.focus(); });
+        }
+        if (type === 'dataCell' && args.event.shiftKey && args.event.key.toLowerCase() === 'tab') {
+            args.event.preventDefault();
+            args.cancel = true;
+            const cell = this.grid.getPreviousCell(target.rowIndex, target.visibleColumnIndex);
+            this.grid.navigateTo(cell.rowIndex, cell.visibleColumnIndex, (obj) => { obj.target.nativeElement.focus(); });
+            return;
+        }
+        if (type === 'dataCell'  && args.event.key.toLowerCase() === 'tab') {
+            args.event.preventDefault();
+            args.cancel = true;
+            const cell = this.grid.getNextCell(target.rowIndex, target.visibleColumnIndex);
+            this.grid.navigateTo(cell.rowIndex, cell.visibleColumnIndex, (obj) => { obj.target.nativeElement.focus(); });
+        }
+    }
+}

--- a/src/app/grid-mrl-custom-navigation/grid-mrl-custom-navigation.ts
+++ b/src/app/grid-mrl-custom-navigation/grid-mrl-custom-navigation.ts
@@ -69,47 +69,11 @@ export class GridMRLCustomNavigationSampleComponent {
 
     public customNavigation(args) {
         const target = args.target;
-        const type = args.targetType;
         if (args.event.key.toLowerCase() === 'enter') {
             args.event.preventDefault();
             args.cancel = true;
             const rowIndex = target.rowIndex === undefined ? target.index : target.rowIndex;
-            this.grid.navigateTo(rowIndex + 1 , -1 , (obj) => { obj.target.nativeElement.focus(); });
-        }
-        if (type === 'dataCell'  && args.event.key.toLowerCase() === 'arrowright') {
-            args.event.preventDefault();
-            args.cancel = true;
-            this.grid.navigateTo(target.rowIndex, target.visibleColumnIndex + 1, (obj) => { obj.target.nativeElement.focus(); });
-        }
-        if (type === 'dataCell'  && args.event.key.toLowerCase() === 'arrowleft') {
-            args.event.preventDefault();
-            args.cancel = true;
-            this.grid.navigateTo(target.rowIndex, target.visibleColumnIndex - 1, (obj) => { obj.target.nativeElement.focus(); });
-        }
-        if (type === 'dataCell'  && args.event.key.toLowerCase() === 'arrowdown') {
-            args.event.preventDefault();
-            args.cancel = true;
-            // const cell = this.grid.getNextCell(target.rowIndex, target.visibleColumnIndex, (col) => col.field === 'City');
-            this.grid.navigateTo(target.rowIndex + 1, target.visibleColumnIndex, (obj) => { obj.target.nativeElement.focus(); });
-        }
-        if (type === 'dataCell'  && args.event.key.toLowerCase() === 'arrowup') {
-            args.event.preventDefault();
-            args.cancel = true;
-            // const cell = this.grid.getPreviousCell(target.rowIndex, target.visibleColumnIndex, (col) => col.field === 'City');
-            this.grid.navigateTo(target.rowIndex - 1, target.visibleColumnIndex, (obj) => { obj.target.nativeElement.focus(); });
-        }
-        if (type === 'dataCell' && args.event.shiftKey && args.event.key.toLowerCase() === 'tab') {
-            args.event.preventDefault();
-            args.cancel = true;
-            const cell = this.grid.getPreviousCell(target.rowIndex, target.visibleColumnIndex);
-            this.grid.navigateTo(cell.rowIndex, cell.visibleColumnIndex, (obj) => { obj.target.nativeElement.focus(); });
-            return;
-        }
-        if (type === 'dataCell'  && args.event.key.toLowerCase() === 'tab') {
-            args.event.preventDefault();
-            args.cancel = true;
-            const cell = this.grid.getNextCell(target.rowIndex, target.visibleColumnIndex);
-            this.grid.navigateTo(cell.rowIndex, cell.visibleColumnIndex, (obj) => { obj.target.nativeElement.focus(); });
+            this.grid.navigateTo(args.event.shiftKey ? rowIndex - 1 : rowIndex + 1, target.visibleColumnIndex, (obj) => { obj.target.nativeElement.focus(); });
         }
     }
 }

--- a/src/app/grid-multi-row-layout/grid-mrl.sample.html
+++ b/src/app/grid-multi-row-layout/grid-mrl.sample.html
@@ -16,7 +16,7 @@
             </igx-column-layout>
             <igx-column-layout>
                 <igx-column [rowStart]="1" [colStart]="1" [colEnd]="3" [rowEnd]="3" field="City" [width]="'300px'"></igx-column>
-                <igx-column [rowStart]="3" [colStart]="1"  [colEnd]="3" [movable]="false" sortable="true" field="Region" [width]='"150px"'></igx-column>
+                <igx-column [rowStart]="3" [colStart]="1"  [colEnd]="3" [movable]="false" sortable="true" field="Region" [width]='"300px"'></igx-column>
             </igx-column-layout>
             <igx-column-layout>
                 <igx-column [rowStart]="1" [colStart]="1" field="Country" [width]="'300px'"></igx-column>

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -71,6 +71,7 @@ import { GridMRLSampleComponent } from './grid-multi-row-layout/grid-mrl.sample'
 import { TreeGridLoadOnDemandSampleComponent } from './tree-grid-load-on-demand/tree-grid-load-on-demand.sample';
 import { GridFilterTemplateSampleComponent } from './grid-filter-template/grid-filter-template.sample';
 import { GridMRLConfigSampleComponent } from './grid-multi-row-layout-config/grid-mrl-config.sample';
+import { GridMRLCustomNavigationSampleComponent } from './grid-mrl-custom-navigation/grid-mrl-custom-navigation';
 
 const appRoutes = [
     {
@@ -326,6 +327,10 @@ const appRoutes = [
     {
         path: 'gridMRLConfig',
         component: GridMRLConfigSampleComponent
+    },
+    {
+        path: 'gridMRLCustomNav',
+        component: GridMRLCustomNavigationSampleComponent
     },
     {
         path: 'gridGroupBy',


### PR DESCRIPTION
This PR includes:
1) MRL Custom Navigation 
 - Exposing common perfromVerticalScrollToCell/performHorizontalScrollToCell functions in base navigation and mrl navigation service, which can be used for the public navigateTo method.
- Adding custom navigation sample with custom navigation up/down via Enter/Shift+Enter keys.
2) Calculating cell top/left offsets in pixels and using it when scrolling it in view(getVerticalScrollPositions/getChildColumnScrollPositions) as implemented here: https://github.com/IgniteUI/igniteui-angular/pull/4882/
3) Additional refactoring to minimize duplicated code specifically in focusCellUpFromLayout/focusCellDownFromLayout/focusNextCellFromLayout/focusPrevCellFromLayout functions.

