### PR TITLE
Adding height 100% for mrl container in header for IE, sinc…

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-header-group.component.html
+++ b/projects/igniteui-angular/src/lib/grids/grid-header-group.component.html
@@ -5,7 +5,8 @@
      [ngStyle]="{'grid-template-rows':column.getGridTemplate(true, false),
      'grid-template-columns':column.getGridTemplate(false, false),
      '-ms-grid-rows':column.getGridTemplate(true, true),
-     '-ms-grid-columns':column.getGridTemplate(false, true)}">
+     '-ms-grid-columns':column.getGridTemplate(false, true),
+        'height':  mrlBlockHeight }">
         <ng-container *ngFor="let child of column.children" >
             <igx-grid-header-group *ngIf="!child.hidden" class="igx-grid__thead-subgroup"
                 [column]="child"

--- a/projects/igniteui-angular/src/lib/grids/grid-header-group.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-header-group.component.ts
@@ -176,6 +176,10 @@ export class IgxGridHeaderGroupComponent implements DoCheck {
         return this.grid.hasColumnLayouts && this.column.children && !isIE() ? 'flex' : '';
     }
 
+    get mrlBlockHeight() {
+        return this.grid.hasColumnLayouts && this.column.children && isIE() ? '100%' : '';
+    }
+
     /**
      * Gets whether the header group is stored in a pinned column.
      * @memberof IgxGridHeaderGroupComponent


### PR DESCRIPTION
…e it does not render correctly if display: flex is used like in other normal browsers.

Closes #4825  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 