### PR TITLE
fix(grid): indentation overwrites border of row in edit mode

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
@@ -1620,7 +1620,7 @@
 
     %igx-grid__row-indentation {
         background: transparent;
-        z-index: 9999;
+        z-index: 1;
         display: flex;
         justify-content: center;
         align-items: center;

--- a/src/app/grid-multi-row-layout/grid-mrl.sample.html
+++ b/src/app/grid-multi-row-layout/grid-mrl.sample.html
@@ -3,7 +3,7 @@
     <section style="height: 800px" class="sample-content">
         <igx-grid [rowEditable]="true" [primaryKey]="'PostalCode'" [rowSelectable]="true" #grid [data]="data" displayDensity="compact" [width]="'100%'" [showToolbar]='true' [columnHiding]='true'>
             <igx-column-layout [movable]="false" [pinned]="true" field='group1'>
-                <igx-column [rowStart]="1" [colStart]="1" [colEnd]="5" field="ContactName"></igx-column>
+                <igx-column [groupable]="true" [rowStart]="1" [colStart]="1" [colEnd]="5" field="ContactName"></igx-column>
                 <igx-column [rowStart]="1" [colStart]="5" field="ContactTitle"></igx-column>
                 <igx-column [rowStart]="1" [colStart]="6" field="Country"></igx-column>
                 <igx-column [rowStart]="2" [colStart]="1" [colEnd]="3" field="Phone"></igx-column>


### PR DESCRIPTION
When using the grid in MRL mode with row editing enabled, the
indentation border would overwrite the row border.

Closes #4968

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 