### PR TITLE
fix(grid): tab between editable cells in correct order, 7.3.x, #4945

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-mrl-navigation.service.ts
@@ -127,9 +127,9 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
                     nextCell = row.cells.find(currCell => currCell.column === nextElementColumn);
                     if (this.grid.rowEditable && this.isRowInEditMode(row.index)) {
                         if (dir === 'next') {
-                            this.moveNextEditable(nextCell.nativeElement, selectedNode);
+                            this.moveNextEditable(row.index, selectedNode.layout.columnVisibleIndex);
                         } else {
-                            this.movePreviousEditable(nextCell.nativeElement, selectedNode);
+                            this.movePreviousEditable(row.index, selectedNode.layout.columnVisibleIndex);
                         }
                         return;
                     }
@@ -139,10 +139,9 @@ export class IgxGridMRLNavigationService extends IgxGridNavigationService {
             } else {
                 if (this.grid.rowEditable && this.isRowInEditMode(row.index)) {
                     if (dir === 'next') {
-                        this.moveNextEditable(nextCell.nativeElement, { row: row.index, column: selectedNode.layout.columnVisibleIndex});
+                        this.moveNextEditable(row.index, selectedNode.layout.columnVisibleIndex);
                     } else {
-                        this.movePreviousEditable(nextCell.nativeElement,
-                             { row: row.index, column: selectedNode.layout.columnVisibleIndex});
+                        this.movePreviousEditable(row.index, selectedNode.layout.columnVisibleIndex);
                     }
                     return;
                 }

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -29,7 +29,7 @@ export class IgxGridNavigationService {
 
     public horizontalScroll(rowIndex) {
         let rowComp = this.grid.dataRowList.find((row) => row.index === rowIndex) ?
-        this.grid.dataRowList.find((row) => row.index === rowIndex) : this.grid.dataRowList.first;
+            this.grid.dataRowList.find((row) => row.index === rowIndex) : this.grid.dataRowList.first;
         if (!rowComp) {
             rowComp = this.grid.summariesRowList.find((row) => row.index === rowIndex);
         }
@@ -50,7 +50,7 @@ export class IgxGridNavigationService {
             forOfDir = this.grid.headerContainer;
         }
         const horizontalScroll = forOfDir.getHorizontalScroll();
-        const column =  this.grid.columnList.filter(c => !c.columnGroup).find((col) => col.visibleIndex === visibleColumnIndex);
+        const column = this.grid.columnList.filter(c => !c.columnGroup).find((col) => col.visibleIndex === visibleColumnIndex);
         if (!horizontalScroll.clientWidth || column.pinned) {
             return true;
         }
@@ -82,18 +82,29 @@ export class IgxGridNavigationService {
         return this.grid.rowEditable && (this.grid.rowInEditMode && this.grid.rowInEditMode.index === rowIndex);
     }
 
-    public isColumnEditable(visibleColumnIndex: number): boolean {
-        const column = this.gridOrderedColumns.find(c => c.visibleIndex === visibleColumnIndex);
-        return column ? column.editable : false;
-    }
-
     public findNextEditable(direction: string, visibleColumnIndex: number) {
+        // go trough all columns in one cycle instead of
+        // splice().reverse().find()
         const gridColumns = this.gridOrderedColumns;
+        const start = visibleColumnIndex;
+        let end = 0;
+        let step = 0;
+        let result = -1;
         if (direction === MoveDirection.LEFT) {
-            return gridColumns.splice(0, visibleColumnIndex + 1).reverse().findIndex(e => e.editable);
+            end = 0;
+            step = -1;
         } else if (direction === MoveDirection.RIGHT) {
-            return gridColumns.splice(visibleColumnIndex, gridColumns.length - 1).findIndex(e => e.editable);
+            end = gridColumns.length - 1;
+            step = 1;
         }
+        for (let c = start; (c * step) <= end; c += step) {
+            const column = gridColumns[c];
+            if (column.editable) {
+                result = c;
+                break;
+            }
+        }
+        return result;
     }
 
     public getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummary = false) {
@@ -148,52 +159,29 @@ export class IgxGridNavigationService {
 
     }
 
-    public movePreviousEditable(element, selectedNode: ISelectionNode) {
-        const rowIndex = selectedNode.row;
-        const visibleColumnIndex = selectedNode.column;
-        const addedIndex = this.isColumnEditable(visibleColumnIndex - 1) ?
-            0 :
-            this.findNextEditable(MoveDirection.LEFT, visibleColumnIndex - 1);
-        if (addedIndex === -1) {
+    public movePreviousEditable(rowIndex: number, currentColumnVisibleIndex: number) {
+        const prevEditableColumnIndex = this.findNextEditable(MoveDirection.LEFT, currentColumnVisibleIndex - 1);
+        if (prevEditableColumnIndex === -1 && this.grid.rowEditTabs.length) {
             this.grid.rowEditTabs.last.element.nativeElement.focus();
             return;
         }
-        const editableIndex = visibleColumnIndex - 1 - addedIndex;
-        if (this.getColumnUnpinnedIndex(editableIndex) === -1 && this.grid.pinnedColumns.length) {
-            // if target is NOT pinned and there are pinned columns
-            // since addedIndex !== -1, there will always be a target
-            this.getCellElementByVisibleIndex(rowIndex, editableIndex).focus();
-        } else if (!this.isColumnLeftFullyVisible(editableIndex)) {  // if not fully visible, perform scroll
-            this.performHorizontalScrollToCell(rowIndex, editableIndex);
-        } else {
-            this.getCellElementByVisibleIndex(rowIndex, editableIndex).focus(); // if fully visible, just focus
-        }
+        this.focusNextEditableTarget(rowIndex, prevEditableColumnIndex);
     }
 
-    public moveNextEditable(element, selectedNode: ISelectionNode) {
-        const rowIndex = selectedNode.row;
-        const visibleColumnIndex = selectedNode.column;
-        let addedIndex = 0;
-        addedIndex = this.isColumnEditable(visibleColumnIndex + 1) ?
-            0 :
-            this.findNextEditable(MoveDirection.RIGHT, visibleColumnIndex + 1);
-        if (addedIndex === -1 && this.grid.rowEditTabs) { // no previous edit column -> go to RE buttons
+    public moveNextEditable(rowIndex: number, currentColumnVisibleIndex: number) {
+        const nextEditableColumnIndex = this.findNextEditable(MoveDirection.RIGHT, currentColumnVisibleIndex + 1);
+        if (nextEditableColumnIndex === -1 && this.grid.rowEditTabs.length) {
             this.grid.rowEditTabs.first.element.nativeElement.focus();
             return;
         }
-        const editableIndex = visibleColumnIndex + 1 + addedIndex;
-        if (this.isColumnFullyVisible(editableIndex)) { // If column is fully visible
-            if (element.classList.contains('igx-grid__td--pinned-last')) { // If this is pinned
-                if (this.isColumnLeftFullyVisible(editableIndex)) { // If next column is fully visible LEFT
-                    this.getCellElementByVisibleIndex(rowIndex, editableIndex).focus(); // focus
-                } else { // if NOT fully visible, perform scroll
-                    this.performHorizontalScrollToCell(rowIndex, editableIndex);
-                }
-            } else { // cell is next cell
-                this.getCellElementByVisibleIndex(rowIndex, editableIndex).focus();
-            }
+        this.focusNextEditableTarget(rowIndex, nextEditableColumnIndex);
+    }
+
+    public focusNextEditableTarget(rowIndex: number, columnIndex: number) {
+        if (this.isColumnFullyVisible(columnIndex) && this.isColumnLeftFullyVisible(columnIndex)) {
+            this.getCellElementByVisibleIndex(rowIndex, columnIndex).focus();
         } else {
-            this.performHorizontalScrollToCell(rowIndex, editableIndex);
+            this.performHorizontalScrollToCell(rowIndex, columnIndex);
         }
     }
 
@@ -203,7 +191,7 @@ export class IgxGridNavigationService {
         const cellSelector = this.getCellSelector(0, isSummary);
         if (!rowElement) { return; }
         rowElement = rowElement.nativeElement;
-        let firstCell =  rowElement.querySelector(cellSelector);
+        let firstCell = rowElement.querySelector(cellSelector);
         if (this.grid.pinnedColumns.length || this.displayContainerScrollLeft === 0) {
             firstCell.focus({ preventScroll: true });
         } else {
@@ -351,12 +339,12 @@ export class IgxGridNavigationService {
                 return cell;
             }
             this.performHorizontalScrollToCell(parseInt(
-            rowElement.getAttribute('data-rowindex'), 10), visibleColumnIndex, isSummaryRow);
+                rowElement.getAttribute('data-rowindex'), 10), visibleColumnIndex, isSummaryRow);
         }
     }
 
     protected focusNextElement(rowElement, visibleColumnIndex) {
-        return  this.focusElem(rowElement.nextElementSibling, visibleColumnIndex);
+        return this.focusElem(rowElement.nextElementSibling, visibleColumnIndex);
     }
 
     public goToFirstCell() {
@@ -434,11 +422,10 @@ export class IgxGridNavigationService {
         const isSummaryRow = selectedNode.isSummaryRow;
         if (isSummaryRow && rowIndex === 0 &&
             this.grid.unpinnedColumns[this.grid.unpinnedColumns.length - 1].visibleIndex === visibleColumnIndex) {
-                return;
-
+            return;
         }
         if (this.grid.unpinnedColumns[this.grid.unpinnedColumns.length - 1].visibleIndex === visibleColumnIndex) {
-            if (this.isRowInEditMode(rowIndex)) {
+            if (this.isRowInEditMode(rowIndex) && this.grid.rowEditTabs.length) {
                 this.grid.rowEditTabs.first.element.nativeElement.focus();
                 return;
             }
@@ -450,13 +437,13 @@ export class IgxGridNavigationService {
                 return;
             }
             if (rowEl) {
-                this.navigateDown(currentRowEl, { row: rowIndex, column: 0});
+                this.navigateDown(currentRowEl, { row: rowIndex, column: 0 });
             }
         } else {
             const cell = this.getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummaryRow);
             if (cell) {
                 if (this.grid.rowEditable && this.isRowInEditMode(rowIndex)) {
-                    this.moveNextEditable(cell, selectedNode);
+                    this.moveNextEditable(rowIndex, visibleColumnIndex);
                     return;
                 }
                 this.onKeydownArrowRight(cell, selectedNode);
@@ -504,7 +491,7 @@ export class IgxGridNavigationService {
 
     public navigateFirstCellIfPossible(eventArgs) {
         if (this.grid.rowList.length > 0) {
-            if (this.grid.rowList.filter(row => row instanceof IgxGridGroupByRowComponent).length > 0 ) {
+            if (this.grid.rowList.filter(row => row instanceof IgxGridGroupByRowComponent).length > 0) {
                 eventArgs.stopPropagation();
                 return;
             }
@@ -553,7 +540,7 @@ export class IgxGridNavigationService {
             return;
         }
         if (visibleColumnIndex === 0) {
-            if (this.isRowInEditMode(rowIndex)) {
+            if (this.isRowInEditMode(rowIndex) && this.grid.rowEditTabs.length) {
                 this.grid.rowEditTabs.last.element.nativeElement.focus();
                 return;
             }
@@ -561,16 +548,16 @@ export class IgxGridNavigationService {
                 this.moveFocusToFilterCell();
             } else {
                 this.navigateUp(currentRowEl,
-                     {
-                         row: rowIndex,
-                         column: this.grid.unpinnedColumns[this.grid.unpinnedColumns.length - 1].visibleIndex
+                    {
+                        row: rowIndex,
+                        column: this.grid.unpinnedColumns[this.grid.unpinnedColumns.length - 1].visibleIndex
                     });
             }
         } else {
             const cell = this.getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummary);
             if (cell) {
                 if (this.grid.rowEditable && this.isRowInEditMode(rowIndex)) {
-                    this.movePreviousEditable(rowIndex, selectedNode);
+                    this.movePreviousEditable(rowIndex, visibleColumnIndex);
                     return;
                 }
                 this.onKeydownArrowLeft(cell, selectedNode);
@@ -585,9 +572,9 @@ export class IgxGridNavigationService {
         const rowHeight = this.grid.verticalScrollContainer.getSizeAt(targetRowIndex);
         const containerHeight = this.grid.calcHeight ? Math.ceil(this.grid.calcHeight) : 0;
         const targetEndTopOffset = targetRow ? targetRow.nativeElement.offsetTop + rowHeight + containerTopOffset :
-                containerHeight + rowHeight;
+            containerHeight + rowHeight;
         if (!targetRow || targetRow.nativeElement.offsetTop < Math.abs(containerTopOffset)
-                || containerHeight && containerHeight < targetEndTopOffset) {
+            || containerHeight && containerHeight < targetEndTopOffset) {
             return true;
         } else {
             return false;
@@ -597,9 +584,9 @@ export class IgxGridNavigationService {
     public performVerticalScrollToCell(rowIndex: number, visibleColIndex: number, cb?: () => void) {
         this.grid.verticalScrollContainer.scrollTo(rowIndex);
         this.grid.verticalScrollContainer.onChunkLoad
-        .pipe(first()).subscribe(() => {
-            cb();
-        });
+            .pipe(first()).subscribe(() => {
+                cb();
+            });
     }
 
     public performHorizontalScrollToCell(rowIndex: number, visibleColumnIndex: number, isSummary: boolean = false, cb?: () => void) {
@@ -619,7 +606,7 @@ export class IgxGridNavigationService {
 
     protected getRowByIndex(index, selector = this.getRowSelector()) {
         return this.grid.nativeElement.querySelector(
-                `${selector}[data-rowindex="${index}"]`);
+            `${selector}[data-rowindex="${index}"]`);
     }
 
     protected getNextRowByIndex(nextIndex) {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-keyBoardNav.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-keyBoardNav.spec.ts
@@ -844,7 +844,6 @@ describe('IgxGrid - Keyboard navigation', () => {
             expect(target.focused).toBe(true);
         });
 
-
         it('Custom KB navigation: onGridKeydown should be emitted', async () => {
             fix.componentInstance.columns = fix.componentInstance.generateCols(25);
             fix.componentInstance.data = fix.componentInstance.generateData(25);
@@ -858,7 +857,49 @@ describe('IgxGrid - Keyboard navigation', () => {
 
             expect(gridKeydown).toHaveBeenCalledTimes(1);
             expect(gridKeydown).toHaveBeenCalledWith({
-                targetType: 'dataCell', target: cell, cancel: false, event: new KeyboardEvent ('keydown') });
+                targetType: 'dataCell', target: cell, cancel: false, event: new KeyboardEvent('keydown')
+            });
+        });
+
+        it('should scroll into view not visible cell when in row edit and move from pinned to unpinned column', async () => {
+            fix.componentInstance.columns = fix.componentInstance.generateCols(100, 50);
+            fix.componentInstance.data = fix.componentInstance.generateData(100);
+
+            fix.detectChanges();
+            await wait(DEBOUNCETIME);
+
+            grid.primaryKey = '0';
+            grid.rowEditable = true;
+            grid.columns.every(c => c.editable = true);
+
+            grid.getColumnByName('2').pinned = true;
+            grid.getColumnByName('3').pinned = true;
+            grid.getColumnByName('3').editable = false;
+            grid.getColumnByName('0').editable = false;
+
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            grid.navigateTo(0, 99);
+
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            const rows = fix.nativeElement.querySelectorAll('igx-grid-row');
+            const cell = rows[0].querySelectorAll('igx-grid-cell')[0];
+            cell.dispatchEvent(new Event('focus'));
+            UIInteractions.triggerKeyDownEvtUponElem('F2', cell, true);
+
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            expect(grid.crudService.cell.column.header).toBe('2');
+            UIInteractions.triggerKeyDownEvtUponElem('tab', cell, true);
+
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            expect(grid.crudService.cell.column.header).toBe('1');
         });
     });
 
@@ -1390,7 +1431,8 @@ describe('IgxGrid - Keyboard navigation', () => {
 
             expect(gridKeydown).toHaveBeenCalledTimes(1);
             expect(gridKeydown).toHaveBeenCalledWith({
-                targetType: 'groupRow', target: rowEl, cancel: false, event: new KeyboardEvent ('keydown') });
+                targetType: 'groupRow', target: rowEl, cancel: false, event: new KeyboardEvent('keydown')
+            });
 
             rowEl.nativeElement.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', ctrlKey: false }));
             await wait(DEBOUNCETIME);
@@ -1398,7 +1440,8 @@ describe('IgxGrid - Keyboard navigation', () => {
 
             expect(gridKeydown).toHaveBeenCalledTimes(2);
             expect(gridKeydown).toHaveBeenCalledWith({
-                targetType: 'groupRow', target: rowEl, cancel: false, event: new KeyboardEvent ('keydown') });
+                targetType: 'groupRow', target: rowEl, cancel: false, event: new KeyboardEvent('keydown')
+            });
         });
 
     });

--- a/projects/igniteui-angular/src/lib/test-utils/grid-samples.spec.ts
+++ b/projects/igniteui-angular/src/lib/test-utils/grid-samples.spec.ts
@@ -835,12 +835,12 @@ export class VirtualGridComponent extends BasicGridComponent {
         super();
         this.data = this.generateData(1000);
     }
-     public generateCols(numCols: number, defaultColWidth = null) {
+     public generateCols(numCols: number, defaultColWidth: number = null) {
         const cols = [];
         for (let j = 0; j < numCols; j++) {
             cols.push({
                 field: j.toString(),
-                width: defaultColWidth !== null ? defaultColWidth : j % 8 < 2 ? 100 : (j % 6) * 125
+                width: defaultColWidth || j % 8 < 2 ? 100 : (j % 6) * 125
             });
         }
         return cols;


### PR DESCRIPTION
1. There was error in findNextEditable when direction is right and it was returning wrong index;
2. There was error and in check if we are in last editable pinned column. If last pinned column is read-only the old logic was wrong.
3. moveNext/PrevEditable logic was too complex. What we are doing now is check if the cell is visible. If so focus cell. If not scroll.

Closes #4945

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 