### PR TITLE
Remove usage of ES7 Object.entries and polyfill requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes for each version of this project will be documented in this file.
 ## 8.0.1
 
+- **General**
+    - Importing ES7 polyfill for Object (`'core-js/es7/object'`) for IE is no longer required.
+
 ### New Features
 - `IgxDropDown` now supports `DisplayDensity`.
     - `[displayDensity]` - `@Input()` added to the `igx-drop-down`. Takes prevelance over any other `DisplayDensity` provider (e.g. parent component or `DisplayDensityToken` provided in module)

--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -75,10 +75,10 @@
         "@angular/core": "^8.0.0",
         "@angular/animations": "^8.0.0",
         "@angular/forms": "^8.0.0",
-        "web-animations-js": "^2.3.1"
+        "web-animations-js": "github:angular/web-animations-js#release_pr208"
     },
     "devDependencies": {
-        "igniteui-cli": "~4.1.0"
+        "igniteui-cli": "~4.2.0"
     },
     "ng-update": {
         "migrations": "./migrations/migration-collection.json"

--- a/projects/igniteui-angular/schematics/ng-add/index.spec.ts
+++ b/projects/igniteui-angular/schematics/ng-add/index.spec.ts
@@ -134,9 +134,6 @@ import 'core-js/es6/set';
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run \`npm install --save classlist.js\`.
 
-/** ES7 \`Object.entries\` needed for igxGrid to render in IE. */
-import 'core-js/es7/object';
-
 /** comment */
 import 'web-animations-js';  // Run \`npm install --save web-animations-js\`.
 `;
@@ -225,9 +222,6 @@ import 'web-animations-js';  // Run \`npm install --save web-animations-js\`.
     const result = `
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run \`npm install --save classlist.js\`.
-
-/** ES7 \`Object.entries\` needed for igxGrid to render in IE. */
-import 'core-js/es7/object';
 
 import 'web-animations-js';  // Run \`npm install --save web-animations-js\`.
     `;

--- a/projects/igniteui-angular/schematics/ng-add/index.ts
+++ b/projects/igniteui-angular/schematics/ng-add/index.ts
@@ -8,21 +8,6 @@ import { addResetCss } from './add-normalize';
 import { getWorkspace } from '@schematics/angular/utility/config';
 import { WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
 
-/**
- *  ES7 `Object.entries` needed for igxGrid to render in IE.
- * - https://github.com/IgniteUI/igniteui-cli/issues/344
- */
-function addIgxGridSupportForIe(polyfillsData: string): string {
-  const targetImportPattern = /import \'classlist.js\';.*/;
-  const targetImport = targetImportPattern.exec(polyfillsData);
-  const lineToAdd = 'import \'core-js/es7/object\';';
-  const comment = '/** ES7 `Object.entries` needed for igxGrid to render in IE. */';
-  if (!polyfillsData.includes(lineToAdd)) {
-    return polyfillsData.replace(targetImportPattern, `${targetImport}${os.EOL}${os.EOL}${comment}${os.EOL}${lineToAdd}`);
-  }
-
-  return polyfillsData;
-}
 
 /**
  * Checks whether a property exists in the angular workspace.
@@ -58,7 +43,6 @@ function enableWebAnimationsAndGridSupport(tree: Tree, targetFile: string, polyf
   polyfillsData = polyfillsData.replace(webAnimationsLine,
     webAnimationsLine.substring(3, webAnimationsLine.length));
 
-  polyfillsData = addIgxGridSupportForIe(polyfillsData);
   tree.overwrite(targetFile, polyfillsData);
 }
 

--- a/projects/igniteui-angular/schematics/ng-add/index.ts
+++ b/projects/igniteui-angular/schematics/ng-add/index.ts
@@ -3,7 +3,6 @@ import { Options } from '../interfaces/options';
 import { installPackageJsonDependencies } from '../utils/package-handler';
 import { logSuccess, addDependencies, overwriteJsonFile, getPropertyFromWorkspace } from '../utils/dependency-handler';
 
-import * as os from 'os';
 import { addResetCss } from './add-normalize';
 import { getWorkspace } from '@schematics/angular/utility/config';
 import { WorkspaceSchema } from '@schematics/angular/utility/workspace-models';

--- a/projects/igniteui-angular/src/lib/grids/grid-common.pipes.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-common.pipes.ts
@@ -16,12 +16,13 @@ export class IgxGridCellStylesPipe implements PipeTransform {
 
         const result = [];
 
-        Object.entries(cssClasses).forEach(([cssClass, callbackOrValue]) => {
+        for (const cssClass of Object.keys(cssClasses)) {
+            const callbackOrValue = cssClasses[cssClass];
             const apply = typeof callbackOrValue === 'function' ? callbackOrValue(data, field) : callbackOrValue;
             if (apply) {
                 result.push(cssClass);
             }
-        });
+        }
 
         return result.join(' ');
     }

--- a/projects/igniteui-angular/src/lib/grids/grid-header-group.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-header-group.component.ts
@@ -128,11 +128,11 @@ export class IgxGridHeaderGroupComponent implements DoCheck {
             'igx-grid__th--filtering': this.isFiltered
         };
 
-        Object.entries(classList).forEach(([className, value]) => {
-            if (value) {
+        for (const className of Object.keys(classList)) {
+            if (classList[className]) {
                 defaultClasses.push(className);
             }
-        });
+        }
         return defaultClasses.join(' ');
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid-header.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-header.component.ts
@@ -69,11 +69,11 @@ export class IgxGridHeaderComponent implements DoCheck, OnInit, OnDestroy {
             'igx-grid__th--sorted': this.sorted
         };
 
-        Object.entries(classList).forEach(([klass, value]) => {
-            if (value) {
+        for (const klass of Object.keys(classList)) {
+            if (classList[klass]) {
                 defaultClasses.push(klass);
             }
-        });
+        }
         return defaultClasses.join(' ');
     }
 

--- a/src/polyfills.ts
+++ b/src/polyfills.ts
@@ -21,9 +21,6 @@
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 import 'classlist.js';  // Run `npm install --save classlist.js`.
 
-/** Adding ES7 polyfills for Object for IE11. */
-import 'core-js/es7/object';
-
 /**
  * Web Animations `@angular/platform-browser/animations`
  * Only required if AnimationBuilder is used within the application and using IE/Edge or Safari.


### PR DESCRIPTION
Closes #5136  

I've checked the list of things the poly adds:
- `Object.prototype.__defineGetter__`
- `Object.prototype.__defineSetter__`
- `Object.prototype.__lookupGetter__`
- `Object.prototype.__lookupSetter__`
- `Object.entries`
- `Object.getOwnPropertyDescriptors`
- `Object.values`

Of which we used just the `entries`.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [x] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 