### PR TITLE
fix(igx-grid): getSelectedRanges inside event handler

### DIFF
--- a/projects/igniteui-angular/src/lib/core/grid-selection.ts
+++ b/projects/igniteui-angular/src/lib/core/grid-selection.ts
@@ -212,7 +212,7 @@ export class IgxGridSelectionService {
     selection = new Map<number, Set<number>>();
     temp = new Map<number, Set<number>>();
     _ranges: Set<string> = new Set<string>();
-    _selectionRange: Range;
+    _selectionRange = new Range();
 
 
     /**
@@ -474,8 +474,8 @@ export class IgxGridSelectionService {
         if (this.pointerState.shift) {
             this.clearTextSelection();
             this.restoreTextSelection();
-            emitter.emit(this.generateRange(node, this.pointerState));
             this.addRangeMeta(node, this.pointerState);
+            emitter.emit(this.generateRange(node, this.pointerState));
             return true;
         }
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-multi-cell-selection.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-multi-cell-selection.spec.ts
@@ -245,6 +245,20 @@ describe('IgxGrid - Multi Cell selection', () => {
             HelperUtils.verifySelectedRange(grid, 0, 3, 2, 3);
         });
 
+        it('Should return correct ranges from `getSelectedRanges` on shfit + click in the event handler', () => {
+            const firstCell = grid.getCellByColumn(3, 'HireDate');
+            const secondCell = grid.getCellByColumn(1, 'ID');
+
+            const sub = grid.onRangeSelection.subscribe(_ => {
+                expect(grid.selectedCells.length).toEqual(12);
+                const range = grid.getSelectedRanges()[0];
+                HelperUtils.verifySelectedRange(grid, range.rowStart, range.rowEnd, range.columnStart, range.columnEnd);
+                HelperUtils.verifySelectedRange(grid, 1, 3, 0, 3);
+            });
+            HelperUtils.selectCellsRangeWithShiftKeyNoWait(fix, firstCell, secondCell);
+            sub.unsubscribe();
+        });
+
         it('Should be able to select range with Shift key when first cell is not visible', (async () => {
             const firstCell = grid.getCellByColumn(1, 'ID');
             const selectionChangeSpy = spyOn<any>(grid.onRangeSelection, 'emit').and.callThrough();


### PR DESCRIPTION
Fixed a possible error with an empty range when restoring the document
selection

Closes #5135


### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 