### PR TITLE
refactor(themes): igx-css-vars must ignore nested maps

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/base/utilities/_mixins.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/base/utilities/_mixins.scss
@@ -164,19 +164,16 @@
 /// Generates CSS variables for a given palette.
 /// @access public
 /// @param {Map} $palette - The igx palette to use to generate css variables for.
-/// @param {string} $scope [null] - The scope of the generated css variables.
 ///
 /// @example scss Generate css variables for the `$default-palette`.
-///   @include css-vars-from-palette($default-palette, ':root');
+///   @include css-vars-from-palette($default-palette);
 ///
 /// @requires {mixin} css-vars-from-palette
-@mixin igx-palette-vars($palette, $scope: null) {
-    @if $scope == null {
+@mixin igx-palette-vars($palette) {
+    $scope: if(is-root(), ':root', '&');
+
+    #{$scope} {
         @include css-vars-from-palette($palette);
-    } @else {
-        #{$scope} {
-            @include css-vars-from-palette($palette);
-        }
     }
 }
 
@@ -212,7 +209,7 @@
     $prefix: map-get($theme, 'name');
 
     @each $key, $value in $theme {
-        @if $key != 'name' and $key != 'palette' {
+        @if $key != 'name' and $key != 'palette' and type-of($value) != 'map' {
             --#{$prefix}-#{$key}: #{$value};
         }
     }


### PR DESCRIPTION
Closes #5152

Also improves igx-palette-vars

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [x] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 