### PR TITLE
Fix - IgxCombo - Change combo default height to 40, itemsMaxHeight scales w/ item Height - 7.3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,10 +45,16 @@ Now you can set `minWindth` for a column to a value smaller than `defaultMinWidt
     - The component can also get it's display density from Angular's DI engine (if the `DisplayDensityToken` is provided on a lower level)
     - Setting `[displayDensity]` affects the control's items' and inputs' css properties, most notably heights, padding, font-size
     - Available display densities are `compact`, `cosy` and `comfortable` (default)
-    - **Behavioral Change** - default item `igx-drop-down-item` height is now `40px` (down from `48px`)
+    - **Behavioral Change** - default `igx-drop-down-item` height is now `40px` (down from `48px`)
 - `IgxCombo` - Setting `[displayDensity]` now also affects the combo's items
+    - **Behavioral Changes**
+    - `[itemHeight]` defaults to `40` (`[displayDensity]` default is `comfortable`)
+    - `[itemsMaxHeight]` defaults to `10 * itemHeight`.
+    - Changing `[displayDensity]` or `[itemHeight]` affect the drop-down container height if `[itemsMaxHeight]` is not provided
     - Setting `[itemHeight]` overrides the height provided by the `[displayDensity]` input
-- `IgxSelect`- Setting `[displayDensity]` now also affects the select's items
+- `IgxSelect`
+    - Setting `[displayDensity]` now also affects the select's items
+    - **Behavioral Change** - default `igx-select-item` height is now `40px` (down from `48px`)
 
 ## 7.3.4
 - `IgxGrid` - summaries

--- a/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
@@ -1673,12 +1673,12 @@ describe('igxCombo', () => {
             fix.detectChanges();
             expect(combo.collapsed).toBeFalsy();
             // NOTE: Minimum itemHeight is 2 rem, per Material Design Guidelines (for mobile only)
-            expect(combo.itemHeight).toEqual(48); // Default value for itemHeight
-            expect(combo.itemsMaxHeight).toEqual(480); // Default value for itemsMaxHeight
+            expect(combo.itemHeight).toEqual(40); // Default value for itemHeight
+            expect(combo.itemsMaxHeight).toEqual(400); // Default value for itemsMaxHeight
             const dropdownItems = fix.debugElement.queryAll(By.css('.' + CSS_CLASS_DROPDOWNLISTITEM));
             const dropdownList = fix.debugElement.query(By.css('.' + CSS_CLASS_CONTENT));
-            expect(dropdownList.nativeElement.clientHeight).toEqual(480);
-            expect(dropdownItems[0].nativeElement.clientHeight).toEqual(48);
+            expect(dropdownList.nativeElement.clientHeight).toEqual(400);
+            expect(dropdownItems[0].nativeElement.clientHeight).toEqual(40);
 
             combo.itemHeight = 48;
             tick();
@@ -3162,6 +3162,24 @@ describe('igxCombo', () => {
             expect(document.getElementsByClassName(CSS_CLASS_INPUT_COMFORTABLE).length).toBe(2);
             expect(document.getElementsByClassName(CSS_CLASS_ITEM_COMPACT).length).toEqual(0);
             expect(document.getElementsByClassName(CSS_CLASS_ITEM_COSY).length).toEqual(0);
+        }));
+        it('Should scale items container depending on displayDensity (itemHeight * 10)', fakeAsync(() => {
+            const fixutre = TestBed.createComponent(DensityInputComponent);
+            tick();
+            fixutre.detectChanges();
+            const combo = fixutre.componentInstance.combo;
+            combo.toggle();
+            tick();
+            fixutre.detectChanges();
+            expect(combo.itemsMaxHeight).toEqual(320);
+            fixutre.componentInstance.density = DisplayDensity.compact;
+            tick();
+            fixutre.detectChanges();
+            expect(combo.itemsMaxHeight).toEqual(280);
+            fixutre.componentInstance.density = DisplayDensity.comfortable;
+            tick();
+            fixutre.detectChanges();
+            expect(combo.itemsMaxHeight).toEqual(400);
         }));
     });
 });

--- a/projects/igniteui-angular/src/lib/combo/combo.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.ts
@@ -73,7 +73,7 @@ enum DataTypes {
  * @hidden
  */
 const ItemHeights = {
-    'comfortable': 48,
+    'comfortable': 40,
     'cosy': 32,
     'compact': 28,
 };
@@ -141,6 +141,7 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
     private _data = [];
     private _filteredData = [];
     private _itemHeight = null;
+    private _itemsMaxHeight = null;
     private _positionCallback: () => void;
     private _onChangeCallback: (_: any) => void = noop;
     private overlaySettings: OverlaySettings = {
@@ -651,7 +652,16 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
      * ```
     */
     @Input()
-    public itemsMaxHeight = 480;
+    public get itemsMaxHeight(): number {
+        if (this._itemsMaxHeight === null || this._itemsMaxHeight === undefined) {
+            return this.itemHeight * 10;
+        }
+        return this._itemsMaxHeight;
+    }
+
+    public set itemsMaxHeight(val: number) {
+        this._itemsMaxHeight = val;
+    }
 
     /**
      * Configures the drop down list width

--- a/projects/igniteui-angular/src/lib/combo/combo.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.ts
@@ -78,6 +78,13 @@ const ItemHeights = {
     'compact': 28,
 };
 
+/**
+ * @hidden
+ * The default number of items that should be in the combo's
+ * drop-down list if no `[itemsMaxHeight]` is specified
+ */
+const itemsInContainer = 10;
+
 export enum IgxComboState {
     /**
      * Combo with initial state.
@@ -654,7 +661,7 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
     @Input()
     public get itemsMaxHeight(): number {
         if (this._itemsMaxHeight === null || this._itemsMaxHeight === undefined) {
-            return this.itemHeight * 10;
+            return this.itemHeight * itemsInContainer;
         }
         return this._itemsMaxHeight;
     }


### PR DESCRIPTION
Closes #5184 

### Additional information (check all that apply):
 - [x] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [x] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
