### PR TITLE
Fix grid flickering test

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -2238,7 +2238,7 @@ describe('IgxGrid Component Tests', () => {
                 // go to last editable cell
                 UIInteractions.triggerKeyDownWithBlur('tab', document.activeElement, true, false, true);
                 fixture.detectChanges();
-                await wait();
+                await wait(DEBOUNCETIME);
 
                 currentEditCell = fixture.componentInstance.getCurrentEditCell();
                 expect(grid.parentVirtDir.getHorizontalScroll().scrollLeft).toBeGreaterThan(0);


### PR DESCRIPTION
Force test to wait additional 30ms after focus moves from cancel button to the last cell. This allows cell to has time to get focus and to enter in edit mode.

Closes - there is no issue for this fix.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [x] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 