### PR TITLE
Commit pending transactions on addRow - 7.3.x

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -3486,6 +3486,12 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
      * @memberof IgxGridBaseComponent
      */
     public addRow(data: any): void {
+        // If row editing is enabled and there is a row in edit mode
+        if (this.rowEditable && this.crudService.row) {
+            // Commit all pending transactions
+            this.transactions.endPending(true);
+        }
+
         this.gridAPI.addRowToData(data);
 
         this.onRowAdded.emit({ data });

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -3486,12 +3486,8 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
      * @memberof IgxGridBaseComponent
      */
     public addRow(data: any): void {
-        // If row editing is enabled and there is a row in edit mode
-        if (this.rowEditable && this.crudService.row) {
-            // Commit all pending states
-            this.transactions.endPending(true);
-        }
-
+        // commit pending states prior to adding a row
+        this.endEdit(true);
         this.gridAPI.addRowToData(data);
 
         this.onRowAdded.emit({ data });

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -3488,7 +3488,7 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
     public addRow(data: any): void {
         // If row editing is enabled and there is a row in edit mode
         if (this.rowEditable && this.crudService.row) {
-            // Commit all pending transactions
+            // Commit all pending states
             this.transactions.endPending(true);
         }
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1541,6 +1541,37 @@ describe('IgxGrid Component Tests', () => {
             expect(trans.add).toHaveBeenCalledWith({ id: 3, type: 'update', newValue: updateRowData }, oldRowData);
             expect(grid.data[2]).toBe(oldRowData);
         }));
+
+        it(`Should be able to add a row if another row is in edit mode`, fakeAsync(() => {
+            const fixture = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
+            fixture.detectChanges();
+            tick(16);
+
+            const grid = fixture.componentInstance.grid;
+            const rowCount = grid.rowList.length;
+            grid.rowEditable = true;
+            fixture.detectChanges();
+
+            const targetRow = fixture.debugElement.query(By.css(`${CELL_CLASS}:last-child`));
+            targetRow.nativeElement.dispatchEvent(new Event('focus'));
+            flush();
+            fixture.detectChanges();
+            targetRow.triggerEventHandler('dblclick', {});
+            flush();
+            fixture.detectChanges();
+
+            grid.addRow({
+                ProductID: 1000,
+                ProductName: 'New Product',
+                InStock: true,
+                UnitsInStock: 1,
+                OrderDate: new Date()
+            });
+            fixture.detectChanges();
+            tick(16);
+
+            expect(grid.rowList.length).toBeGreaterThan(rowCount);
+        }));
     });
 
     describe('IgxGrid - Row Editing', () => {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1572,6 +1572,31 @@ describe('IgxGrid Component Tests', () => {
 
             expect(grid.rowList.length).toBeGreaterThan(rowCount);
         }));
+
+        it(`Should be able to add a row if a cell is in edit mode`, fakeAsync(() => {
+            const fixture = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
+            fixture.detectChanges();
+            tick(16);
+
+            const grid = fixture.componentInstance.grid;
+            const rowCount = grid.rowList.length;
+            const cell = grid.getCellByColumn(0, 'ProductName');
+            cell.inEditMode = true;
+            tick(16);
+            fixture.detectChanges();
+
+            grid.addRow({
+                ProductID: 1000,
+                ProductName: 'New Product',
+                InStock: true,
+                UnitsInStock: 1,
+                OrderDate: new Date()
+            });
+            fixture.detectChanges();
+            tick(16);
+
+            expect(grid.rowList.length).toBeGreaterThan(rowCount);
+        }));
     });
 
     describe('IgxGrid - Row Editing', () => {

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
@@ -600,6 +600,7 @@ export class IgxTreeGridComponent extends IgxGridBaseComponent implements IGridD
      */
     public addRow(data: any, parentRowID?: any) {
         if (parentRowID) {
+            super.endEdit(true);
             const parentRecord = this.records.get(parentRowID);
 
             if (!parentRecord) {


### PR DESCRIPTION
Closes #5214

Entering edit mode creates an internal transaction in a pending state. This prevents the addition of a new row since it has not completed. Now if you are in edit mode and you attempt to add a new row - the previous pending state will be committed.

### UPDATE: On addRow all pending states will be committed regardless if there is a row/cell in edit mode.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 