### PR TITLE
Move overlay utilities functions to static class

### DIFF
--- a/projects/igniteui-angular/src/lib/select/select-positioning-strategy.ts
+++ b/projects/igniteui-angular/src/lib/select/select-positioning-strategy.ts
@@ -1,4 +1,4 @@
-import { VerticalAlignment, HorizontalAlignment, PositionSettings, Size, Point, getViewportRect } from '../services/overlay/utilities';
+import { VerticalAlignment, HorizontalAlignment, PositionSettings, Size, Point, Util } from '../services/overlay/utilities';
 import { ConnectedPositioningStrategy } from '../services/overlay/position/connected-positioning-strategy';
 import { IPositionStrategy } from '../services/overlay/position';
 import { fadeOut, fadeIn } from '../animations/main';
@@ -32,7 +32,7 @@ export class SelectPositioningStrategy extends ConnectedPositioningStrategy impl
     }
 
     private defaultWindowToListOffset = 5;
-    private viewPort = getViewportRect(document);
+    private viewPort = Util.getViewportRect(document);
     private deltaY: number;
     private deltaX: number;
     private itemTextPadding: number;
@@ -86,7 +86,7 @@ export class SelectPositioningStrategy extends ConnectedPositioningStrategy impl
             TOP: elementContainer.top,
             BOTTOM: elementContainer.bottom,
         };
-        const viewPort = getViewportRect(document);
+        const viewPort = Util.getViewportRect(document);
         const documentElement = {
             TOP: viewPort.top,
             BOTTOM: viewPort.bottom

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -24,9 +24,9 @@ import {
     OverlaySettings,
     Point,
     OverlayEventArgs,
-    OverlayCancelableEventArgs
+    OverlayCancelableEventArgs,
+    Util
 } from './utilities';
-import * as utilities from './utilities';
 import { NoOpScrollStrategy } from './scroll/NoOpScrollStrategy';
 import { BlockScrollStrategy } from './scroll/block-scroll-strategy';
 import { AbsoluteScrollStrategy } from './scroll/absolute-scroll-strategy';
@@ -547,7 +547,7 @@ describe('igxOverlay', () => {
         }));
 
         // TODO: refactor utilities to include all exported methods in a class
-        xit('fix for #1799 - content div should reposition on window resize.', fakeAsync(() => {
+        it('fix for #1799 - content div should reposition on window resize.', fakeAsync(() => {
             const rect: ClientRect = {
                 bottom: 50,
                 height: 0,
@@ -556,7 +556,7 @@ describe('igxOverlay', () => {
                 top: 50,
                 width: 0
             };
-            const getPointSpy = spyOn(utilities, 'getTargetRect').and.returnValue(rect);
+            const getPointSpy = spyOn(Util, 'getTargetRect').and.returnValue(rect);
             const fix = TestBed.createComponent(FlexContainerComponent);
             fix.detectChanges();
             const overlayInstance = fix.componentInstance.overlay;

--- a/projects/igniteui-angular/src/lib/services/overlay/position/base-fit-position-strategy.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/position/base-fit-position-strategy.ts
@@ -1,5 +1,5 @@
 import { ConnectedPositioningStrategy } from './connected-positioning-strategy';
-import { HorizontalAlignment, VerticalAlignment, PositionSettings, Size, getViewportRect, getTargetRect } from '../utilities';
+import { HorizontalAlignment, VerticalAlignment, PositionSettings, Size, Util } from '../utilities';
 
 export abstract class BaseFitPositionStrategy extends ConnectedPositioningStrategy {
     protected _initialSize: Size;
@@ -7,7 +7,7 @@ export abstract class BaseFitPositionStrategy extends ConnectedPositioningStrate
 
     /** @inheritdoc */
     position(contentElement: HTMLElement, size: Size, document?: Document, initialCall?: boolean): void {
-        const targetRect = getTargetRect(this.settings);
+        const targetRect = Util.getTargetRect(this.settings);
         const contentElementRect = contentElement.getBoundingClientRect();
         if (initialCall) {
             const connectedFit: ConnectedFit = {};
@@ -15,7 +15,7 @@ export abstract class BaseFitPositionStrategy extends ConnectedPositioningStrate
             connectedFit.contentElementRect = contentElementRect;
             this._initialSettings = this._initialSettings || Object.assign({}, this.settings);
             this.settings = Object.assign({}, this._initialSettings);
-            connectedFit.viewPortRect = getViewportRect(document);
+            connectedFit.viewPortRect = Util.getViewportRect(document);
             this.updateViewPortFit(connectedFit);
             if (!connectedFit.fitHorizontal || !connectedFit.fitVertical) {
                 this.fitInViewport(contentElement, connectedFit);

--- a/projects/igniteui-angular/src/lib/services/overlay/position/connected-positioning-strategy.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/position/connected-positioning-strategy.ts
@@ -1,11 +1,10 @@
 import { IPositionStrategy } from './IPositionStrategy';
 import {
-  getTargetRect,
-  cloneInstance,
   HorizontalAlignment,
   Point,
   PositionSettings,
   Size,
+  Util,
   VerticalAlignment
 } from './../utilities';
 import { scaleInVerTop, scaleOutVerTop } from '../../../animations/main';
@@ -36,7 +35,7 @@ export class ConnectedPositioningStrategy implements IPositionStrategy {
 
   /** @inheritdoc */
   position(contentElement: HTMLElement, size: Size, document?: Document, initialCall?: boolean): void {
-    const targetRect = getTargetRect(this.settings);
+    const targetRect = Util.getTargetRect(this.settings);
     const contentElementRect = contentElement.getBoundingClientRect();
     this.setStyle(contentElement, targetRect, contentElementRect);
   }
@@ -47,7 +46,7 @@ export class ConnectedPositioningStrategy implements IPositionStrategy {
    * @returns clone of this position strategy
    */
   clone(): IPositionStrategy {
-    return cloneInstance(this);
+    return Util.cloneInstance(this);
   }
 
   /**

--- a/projects/igniteui-angular/src/lib/services/overlay/position/global-position-strategy.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/position/global-position-strategy.ts
@@ -1,5 +1,5 @@
 import { IPositionStrategy } from './IPositionStrategy';
-import { PositionSettings, HorizontalAlignment, VerticalAlignment, Size, cloneInstance } from './../utilities';
+import { PositionSettings, HorizontalAlignment, VerticalAlignment, Size, Util } from './../utilities';
 import { fadeIn, fadeOut } from '../../../animations/main';
 
 /**
@@ -58,7 +58,7 @@ export class GlobalPositionStrategy implements IPositionStrategy {
 
     /** @inheritdoc */
     clone(): IPositionStrategy {
-        return cloneInstance(this);
+        return Util.cloneInstance(this);
     }
 }
 

--- a/projects/igniteui-angular/src/lib/services/overlay/utilities.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/utilities.ts
@@ -89,39 +89,6 @@ export interface Size {
     height: number;
 }
 
-/**
- * @hidden
- * Calculates the rectangle of target for provided overlay settings. Defaults to 0,0,0,0 rectangle
- * if no target is provided
- * @param settings Overlay settings for which to calculate target rectangle
- */
-export function getTargetRect(settings: PositionSettings): ClientRect {
-    let targetRect: ClientRect = {
-        bottom: 0,
-        height: 0,
-        left: 0,
-        right: 0,
-        top: 0,
-        width: 0
-    };
-
-    if (settings.target instanceof HTMLElement) {
-        targetRect = (settings.target as HTMLElement).getBoundingClientRect();
-    } else if (settings.target instanceof Point) {
-        const targetPoint = settings.target as Point;
-        targetRect = {
-            bottom: targetPoint.y,
-            height: 0,
-            left: targetPoint.x,
-            right: targetPoint.x,
-            top: targetPoint.y,
-            width: 0
-        };
-    }
-
-    return targetRect;
-}
-
 /** @hidden */
 export interface OverlayInfo {
     id?: string;
@@ -137,36 +104,73 @@ export interface OverlayInfo {
     ngZone: NgZone;
 }
 
-/** @hidden @internal */
-export function getViewportRect(document: Document): ClientRect {
-    const width = document.documentElement.clientWidth;
-    const height = document.documentElement.clientHeight;
-    const scrollPosition = getViewportScrollPosition();
+/** @hidden */
+export class Util {
+    /**
+     * @hidden
+     * Calculates the rectangle of target for provided overlay settings. Defaults to 0,0,0,0,0,0 rectangle
+     * if no target is provided
+     * @param settings Overlay settings for which to calculate target rectangle
+     */
+    static getTargetRect(settings: PositionSettings): ClientRect {
+        let targetRect: ClientRect = {
+            bottom: 0,
+            height: 0,
+            left: 0,
+            right: 0,
+            top: 0,
+            width: 0
+        };
 
-    return {
-        top: scrollPosition.y,
-        left: scrollPosition.x,
-        right: scrollPosition.x + width,
-        bottom: scrollPosition.y + height,
-        width: width,
-        height: height,
-    };
-}
+        if (settings.target instanceof HTMLElement) {
+            targetRect = (settings.target as HTMLElement).getBoundingClientRect();
+        } else if (settings.target instanceof Point) {
+            const targetPoint = settings.target as Point;
+            targetRect = {
+                bottom: targetPoint.y,
+                height: 0,
+                left: targetPoint.x,
+                right: targetPoint.x,
+                top: targetPoint.y,
+                width: 0
+            };
+        }
 
-/** @hidden @internal */
-export function getViewportScrollPosition(): Point {
-    const documentElement = document.documentElement;
-    const documentRect = documentElement.getBoundingClientRect();
+        return targetRect;
+    }
 
-    const horizontalScrollPosition = -documentRect.left || document.body.scrollLeft || window.scrollX || documentElement.scrollLeft || 0;
-    const verticalScrollPosition = -documentRect.top || document.body.scrollTop || window.scrollY || documentElement.scrollTop || 0;
+    /** @hidden @internal */
+    static getViewportRect(document: Document): ClientRect {
+        const width = document.documentElement.clientWidth;
+        const height = document.documentElement.clientHeight;
+        const scrollPosition = Util.getViewportScrollPosition(document);
 
-    return new Point(horizontalScrollPosition, verticalScrollPosition);
-}
+        return {
+            top: scrollPosition.y,
+            left: scrollPosition.x,
+            right: scrollPosition.x + width,
+            bottom: scrollPosition.y + height,
+            width: width,
+            height: height,
+        };
+    }
 
-/** @hidden @internal*/
-export function cloneInstance(object) {
-    const clonedObj = Object.assign(Object.create(Object.getPrototypeOf(object)), object);
-    clonedObj.settings = cloneValue(clonedObj.settings);
-    return clonedObj;
+    /** @hidden @internal */
+    static getViewportScrollPosition(document: Document): Point {
+        const documentElement = document.documentElement;
+        const documentRect = documentElement.getBoundingClientRect();
+
+        const horizontalScrollPosition =
+            -documentRect.left || document.body.scrollLeft || window.scrollX || documentElement.scrollLeft || 0;
+        const verticalScrollPosition = -documentRect.top || document.body.scrollTop || window.scrollY || documentElement.scrollTop || 0;
+
+        return new Point(horizontalScrollPosition, verticalScrollPosition);
+    }
+
+    /** @hidden @internal*/
+    static cloneInstance(object) {
+        const clonedObj = Object.assign(Object.create(Object.getPrototypeOf(object)), object);
+        clonedObj.settings = cloneValue(clonedObj.settings);
+        return clonedObj;
+    }
 }


### PR DESCRIPTION
We should not use `export function`. The new ES defines exported functions via `definePorperty`. This makes the exported functions as read-only properties. When Jasmine tries to spy on such function it fails and throws an exception.

To solve this put all the functions to a new class as static methods. This is what I am doing in this PR.

Closes #4986

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 