### PR TITLE
Focus last edited cell on end edit 7.3.x

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -5442,9 +5442,32 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
 
         this.endRowTransaction(commit, row);
 
-        const currentCell = this.gridAPI.get_cell_by_index(ri, columnindex);
-        if (currentCell && event) {
-            currentCell.nativeElement.focus();
+        if (event) {
+            if (cell) {
+                const columnVisibleIndex =
+                    this.selectionService.activeElement.layout ?
+                        this.selectionService.activeElement.layout.columnVisibleIndex :
+                        cell.column.visibleIndex;
+                // if cell is not fully visible scroll to it and focus it
+                // else focus the cell
+                if (!this.navigation.isColumnFullyVisible(columnVisibleIndex)) {
+                    this.navigation.performHorizontalScrollToCell(ri, columnVisibleIndex, false);
+                } else {
+                    const currentCell = this.gridAPI.get_cell_by_index(ri, columnIndex);
+                    currentCell.nativeElement.focus();
+                }
+            } else {
+                // when there's no cell in edit mode (focus is on the row edit buttons), use last active
+                const activeCell = this.gridAPI.grid.selectionService.activeElement;
+                if (activeCell) {
+                    const currentCellElement = this.gridAPI.grid.navigation.getCellElementByVisibleIndex(
+                        activeCell.row,
+                        activeCell.layout ? activeCell.layout.columnVisibleIndex : activeCell.column);
+                    if (currentCellElement) {
+                        currentCellElement.focus();
+                    }
+                }
+            }
         }
     }
     /**

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -5428,7 +5428,7 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
     public endEdit(commit = true, event?: Event) {
         const row = this.crudService.row;
         const cell = this.crudService.cell;
-        const columnindex = cell ? cell.column.index : -1;
+        const columnIndex = cell ? cell.column.index : -1;
         const ri = row ? row.index : -1;
 
         // TODO: Merge the crudService with wht BaseAPI service
@@ -5444,14 +5444,14 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
 
         if (event) {
             if (cell) {
-                const columnVisibleIndex =
-                    this.selectionService.activeElement.layout ?
-                        this.selectionService.activeElement.layout.columnVisibleIndex :
-                        cell.column.visibleIndex;
-                // if cell is not fully visible scroll to it and focus it
+                const vi = this.selectionService.activeElement.layout ?
+                    this.selectionService.activeElement.layout.columnVisibleIndex :
+                    cell.column.visibleIndex;
+
+                    // if cell is not fully visible scroll to it and focus it
                 // else focus the cell
-                if (!this.navigation.isColumnFullyVisible(columnVisibleIndex)) {
-                    this.navigation.performHorizontalScrollToCell(ri, columnVisibleIndex, false);
+                if (!(this.navigation.isColumnFullyVisible(vi) && this.navigation.isColumnLeftFullyVisible(vi))) {
+                    this.navigation.performHorizontalScrollToCell(ri, vi, false);
                 } else {
                     const currentCell = this.gridAPI.get_cell_by_index(ri, columnIndex);
                     currentCell.nativeElement.focus();

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -5428,7 +5428,6 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
     public endEdit(commit = true, event?: Event) {
         const row = this.crudService.row;
         const cell = this.crudService.cell;
-        const ri = row ? row.index : -1;
 
         // TODO: Merge the crudService with wht BaseAPI service
         if (!row && !cell) { return; }
@@ -5443,9 +5442,10 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
 
         if (event) {
             if (cell) {
+                const ri = row ? row.index : -1;
                 const vi = cell.column.visibleIndex;
                 this.navigateTo(ri, vi, (c) => {
-                    if (c.target) {
+                    if (c.targetType === GridKeydownTargetType.dataCell && c.target) {
                         c.target.nativeElement.focus();
                     }
                 });

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -5440,27 +5440,15 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
 
         this.endRowTransaction(commit, row);
 
-        if (event) {
-            if (cell) {
-                const ri = row ? row.index : -1;
-                const vi = cell.column.visibleIndex;
-                this.navigateTo(ri, vi, (c) => {
-                    if (c.targetType === GridKeydownTargetType.dataCell && c.target) {
-                        c.target.nativeElement.focus();
-                    }
-                });
-            } else {
-                // when there's no cell in edit mode (focus is on the row edit buttons), use last active
-                const activeCell = this.gridAPI.grid.selectionService.activeElement;
-                if (activeCell) {
-                    const currentCellElement = this.gridAPI.grid.navigation.getCellElementByVisibleIndex(
-                        activeCell.row,
-                        activeCell.layout ? activeCell.layout.columnVisibleIndex : activeCell.column);
-                    if (currentCellElement) {
-                        currentCellElement.focus();
-                    }
+        const activeCell = this.selectionService.activeElement;
+        if (event && activeCell) {
+            const rowIndex = activeCell.row;
+            const visibleColIndex = activeCell.layout ? activeCell.layout.columnVisibleIndex : activeCell.column;
+            this.navigateTo(rowIndex, visibleColIndex, (c) => {
+                if (c.targetType === GridKeydownTargetType.dataCell && c.target) {
+                    c.target.nativeElement.focus();
                 }
-            }
+            });
         }
     }
     /**

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -5428,7 +5428,6 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
     public endEdit(commit = true, event?: Event) {
         const row = this.crudService.row;
         const cell = this.crudService.cell;
-        const columnIndex = cell ? cell.column.index : -1;
         const ri = row ? row.index : -1;
 
         // TODO: Merge the crudService with wht BaseAPI service
@@ -5444,18 +5443,12 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
 
         if (event) {
             if (cell) {
-                const vi = this.selectionService.activeElement.layout ?
-                    this.selectionService.activeElement.layout.columnVisibleIndex :
-                    cell.column.visibleIndex;
-
-                    // if cell is not fully visible scroll to it and focus it
-                // else focus the cell
-                if (!(this.navigation.isColumnFullyVisible(vi) && this.navigation.isColumnLeftFullyVisible(vi))) {
-                    this.navigation.performHorizontalScrollToCell(ri, vi, false);
-                } else {
-                    const currentCell = this.gridAPI.get_cell_by_index(ri, columnIndex);
-                    currentCell.nativeElement.focus();
-                }
+                const vi = cell.column.visibleIndex;
+                this.navigateTo(ri, vi, (c) => {
+                    if (c.target) {
+                        c.target.nativeElement.focus();
+                    }
+                });
             } else {
                 // when there's no cell in edit mode (focus is on the row edit buttons), use last active
                 const activeCell = this.gridAPI.grid.selectionService.activeElement;

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -598,7 +598,10 @@ export class IgxGridNavigationService {
                 if (cb) {
                     cb();
                 } else {
-                    this.getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummary).focus({ preventScroll: true });
+                    const cellElement = this.getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummary);
+                    if (cellElement) {
+                        cellElement.focus({ preventScroll: true });
+                    }
                 }
             });
         this.horizontalScroll(rowIndex).scrollTo(unpinnedIndex);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -2182,60 +2182,6 @@ describe('IgxGrid Component Tests', () => {
                 expect(editedCell.inEditMode).toEqual(true);
             }));
 
-            it(`Should update row changes when focus overlay buttons on tabbing`, (async() => {
-                let currentEditCell: IgxGridCellComponent;
-                const targetCell = fixture.componentInstance.focusGridCell(0, 'Downloads');
-                fixture.detectChanges();
-                await wait();
-
-                // go to first editable cell
-                UIInteractions.triggerKeyDownEvtUponElem('Enter', targetCell.nativeElement, true);
-                fixture.detectChanges();
-                await wait();
-
-                // change first editable cell value
-                targetCell.editValue = '500';
-                fixture.detectChanges();
-                await wait();
-
-                // go to Done
-                fixture.componentInstance.moveNext(true);
-                fixture.detectChanges();
-                await wait();
-
-                let overlayText = document.getElementsByClassName(BANNER_TEXT)[0] as HTMLElement;
-                expect(overlayText.textContent.trim()).toBe('You have 1 changes in this row');
-
-                // focus Cancel
-                const bannerRowElement = fixture.debugElement.query(By.css('.igx-banner__row')).nativeElement;
-                const cancelButtonElement = bannerRowElement.firstElementChild;
-                cancelButtonElement.focus();
-                fixture.detectChanges();
-                await wait();
-
-                // go to last editable cell
-                UIInteractions.triggerKeyDownWithBlur('tab', document.activeElement, true, false, true);
-                fixture.detectChanges();
-                await wait(DEBOUNCETIME);
-
-                currentEditCell = fixture.componentInstance.getCurrentEditCell();
-                expect(grid.parentVirtDir.getHorizontalScroll().scrollLeft).toBeGreaterThan(0);
-                expect(currentEditCell.column.field).toEqual('Test');
-
-                // change last editable cell value
-                targetCell.editValue = 'No test';
-                fixture.detectChanges();
-                await wait();
-
-                // move to Cancel
-                fixture.componentInstance.moveNext(false);
-                fixture.detectChanges();
-                await wait();
-
-                overlayText = document.getElementsByClassName(BANNER_TEXT)[0] as HTMLElement;
-                expect(overlayText.textContent.trim()).toBe('You have 2 changes in this row');
-            }));
-
             it(`Should focus last edited cell after click on editable buttons`, (async () => {
                 const targetCell = fixture.componentInstance.getCell(0, 'Downloads');
                 targetCell.nativeElement.focus();

--- a/src/app/grid-row-edit/grid-row-edit-sample.component.html
+++ b/src/app/grid-row-edit/grid-row-edit-sample.component.html
@@ -146,10 +146,10 @@
                             </div>
                             <div class="igx-banner__actions">
                                 <div class="igx-banner__row">
-                                    <button igxButton igxRowEditTabStop (click)="gridRowEditTransaction.endEdit()">Cancel</button>
+                                    <button igxButton igxRowEditTabStop (click)="gridRowEditTransaction.endEdit(false, $event)">Cancel</button>
                                     <button igxButton igxRowEditTabStop (click)="console.log(gridRowEditTransaction.transactions)">Log
                                         Changes</button>
-                                    <button igxButton igxRowEditTabStop (click)="gridRowEditTransaction.endEdit(true)">Apply</button>
+                                    <button igxButton igxRowEditTabStop (click)="gridRowEditTransaction.endEdit(true, $event)">Apply</button>
                                 </div>
                             </div>
                         </div>
@@ -159,8 +159,8 @@
                     </ng-template>
                     <!-- https://github.com/angular/angular/issues/16643 -->
                     <ng-template igxRowEditActions let-endEdit>
-                        <button igxButton igxRowEditTabStop (click)="endEdit(false)">Cancel</button>
-                        <button igxButton igxRowEditTabStop (click)="endEdit(true)">Apply</button>
+                        <button igxButton igxRowEditTabStop (click)="endEdit(false, $event)">Cancel</button>
+                        <button igxButton igxRowEditTabStop (click)="endEdit(true, $event)">Apply</button>
                     </ng-template>
                 </igx-grid>
             </app-grid-with-transactions>

--- a/src/app/select/select.sample.ts
+++ b/src/app/select/select.sample.ts
@@ -15,9 +15,9 @@ import {
 })
 export class SelectSampleComponent implements OnInit {
     @ViewChildren(IgxSelectComponent) private selectComponents: QueryList<IgxSelectComponent>;
-    @ViewChild('selectReactive', { read: IgxSelectComponent, static: true })
+    @ViewChild('selectReactive', { read: IgxSelectComponent })
     public select: IgxSelectComponent;
-    @ViewChild('model', { read: IgxSelectComponent, static: true })
+    @ViewChild('model', { read: IgxSelectComponent })
     public selectFruits: IgxSelectComponent;
 
 


### PR DESCRIPTION
If the last edited cell is not visible grid was not able to focus it. Now, on end edit, we are scrolling to the last edited cell and focus it. This allows user to continue keyboard navigation.

Closes #5181   

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 