### PR TITLE
Make sure that if grid is created in detached state and height is in %, then size is recalculated once it is added back in the DOM.

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -2816,6 +2816,7 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
                     return mutation.type === 'childList';
                 }).length > 0;
                 if (childListHasChanged && this.isAttachedToDom) {
+                    this._autoSize = false;
                     this.reflow();
                     this._observer.disconnect();
                     this._observer = null;

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -4618,7 +4618,7 @@ export class IgxGridInsideIgxTabsComponent {
     public grid5: IgxGridComponent;
     @ViewChild('grid6', { read: IgxGridComponent })
     public grid6: IgxGridComponent;
-    @ViewChild(IgxTabsComponent, { read: IgxTabsComponen })
+    @ViewChild(IgxTabsComponent, { read: IgxTabsComponent })
     public tabs: IgxTabsComponent;
 
     public columns = [

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -3918,6 +3918,25 @@ describe('IgxGrid Component Tests', () => {
             expect(parseInt(window.getComputedStyle(gridBody.nativeElement).height, 10)).toBe(204);
             expect(parseInt(window.getComputedStyle(paging.nativeElement).height, 10)).toBe(47);
         });
+
+        it('IgxTabs: should initialize a grid with correct height height = 100% when parent has height', async () => {
+            const fix = TestBed.createComponent(IgxGridInsideIgxTabsComponent);
+            fix.detectChanges();
+            await wait(16);
+
+            const grid = fix.componentInstance.grid6;
+            const tab = fix.componentInstance.tabs;
+            expect(grid.calcHeight).toBe(510);
+            tab.tabs.toArray()[5].select();
+            await wait(100);
+            fix.detectChanges();
+            await wait(100);
+            grid.cdr.detectChanges();
+            const gridBody = fix.debugElement.query(By.css(TBODY_CLASS));
+            expect(grid.calcHeight).toBe(230);
+            expect(parseInt(window.getComputedStyle(gridBody.nativeElement).height, 10)).toBe(230);
+            expect(parseInt(window.getComputedStyle(grid.nativeElement).height, 10)).toBe(300);
+        });
     });
 });
 
@@ -4571,6 +4590,19 @@ export class IgxGridRowEditingWithFeaturesComponent extends DataParent {
         </igx-column>
         </igx-grid>
       </igx-tabs-group>
+      <igx-tabs-group label="Tab 6">
+      <div style='height:300px;'>
+      <igx-grid #grid6 [data]="data" [primaryKey]="'id'" [width]="'500px'" [height]="'100%'"
+       >
+      <igx-column
+          *ngFor="let column of columns"
+          [field]="column.field"
+          [header]="column.field"
+      >
+      </igx-column>
+      </igx-grid>
+      </div>
+    </igx-tabs-group>
     </igx-tabs>
   </div>
     `
@@ -4584,7 +4616,9 @@ export class IgxGridInsideIgxTabsComponent {
     public grid4: IgxGridComponent;
     @ViewChild('grid5', { read: IgxGridComponent })
     public grid5: IgxGridComponent;
-    @ViewChild(IgxTabsComponent, { read: IgxTabsComponent })
+    @ViewChild('grid6', { read: IgxGridComponent })
+    public grid6: IgxGridComponent;
+    @ViewChild(IgxTabsComponent, { read: IgxTabsComponen })
     public tabs: IgxTabsComponent;
 
     public columns = [


### PR DESCRIPTION
Closes #5167

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 