### PR TITLE
Focus last edited cell on end edit, master

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -5463,8 +5463,16 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
 
         if (event) {
             if (cell) {
-                const currentCell = this.gridAPI.get_cell_by_index(ri, columnIndex);
-                if (currentCell) {
+                const columnVisibleIndex =
+                    this.selectionService.activeElement.layout ?
+                        this.selectionService.activeElement.layout.columnVisibleIndex :
+                        cell.column.visibleIndex;
+                // if cell is not fully visible scroll to it and focus it
+                // else focus the cell
+                if (!this.navigation.isColumnFullyVisible(columnVisibleIndex)) {
+                    this.navigation.performHorizontalScrollToCell(ri, columnVisibleIndex, false);
+                } else {
+                    const currentCell = this.gridAPI.get_cell_by_index(ri, columnIndex);
                     currentCell.nativeElement.focus();
                 }
             } else {

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -5450,9 +5450,6 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
         // TODO: Merge the crudService with wht BaseAPI service
         if (!row && !cell) { return; }
 
-        const columnIndex = cell ? cell.column.index : -1;
-        const ri = row ? row.index : -1;
-
         commit ? this.gridAPI.submit_value() : this.gridAPI.escape_editMode();
 
         if (!this.rowEditable || this.rowEditingOverlay && this.rowEditingOverlay.collapsed || !row) {
@@ -5463,18 +5460,13 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
 
         if (event) {
             if (cell) {
-                const columnVisibleIndex =
-                    this.selectionService.activeElement.layout ?
-                        this.selectionService.activeElement.layout.columnVisibleIndex :
-                        cell.column.visibleIndex;
-                // if cell is not fully visible scroll to it and focus it
-                // else focus the cell
-                if (!this.navigation.isColumnFullyVisible(columnVisibleIndex)) {
-                    this.navigation.performHorizontalScrollToCell(ri, columnVisibleIndex, false);
-                } else {
-                    const currentCell = this.gridAPI.get_cell_by_index(ri, columnIndex);
-                    currentCell.nativeElement.focus();
-                }
+                const ri = row ? row.index : -1;
+                const vi = cell.column.visibleIndex;
+                this.navigateTo(ri, vi, (c) => {
+                    if (c.targetType === GridKeydownTargetType.dataCell && c.target) {
+                        c.target.nativeElement.focus();
+                    }
+                });
             } else {
                 // when there's no cell in edit mode (focus is on the row edit buttons), use last active
                 const activeCell = this.gridAPI.grid.selectionService.activeElement;

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -5458,27 +5458,15 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
 
         this.endRowTransaction(commit, row);
 
-        if (event) {
-            if (cell) {
-                const ri = row ? row.index : -1;
-                const vi = cell.column.visibleIndex;
-                this.navigateTo(ri, vi, (c) => {
-                    if (c.targetType === GridKeydownTargetType.dataCell && c.target) {
-                        c.target.nativeElement.focus();
-                    }
-                });
-            } else {
-                // when there's no cell in edit mode (focus is on the row edit buttons), use last active
-                const activeCell = this.gridAPI.grid.selectionService.activeElement;
-                if (activeCell) {
-                    const currentCellElement = this.gridAPI.grid.navigation.getCellElementByVisibleIndex(
-                        activeCell.row,
-                        activeCell.layout ? activeCell.layout.columnVisibleIndex : activeCell.column);
-                    if (currentCellElement) {
-                        currentCellElement.focus();
-                    }
+        const activeCell = this.selectionService.activeElement;
+        if (event && activeCell) {
+            const rowIndex = activeCell.row;
+            const visibleColIndex = activeCell.layout ? activeCell.layout.columnVisibleIndex : activeCell.column;
+            this.navigateTo(rowIndex, visibleColIndex, (c) => {
+                if (c.targetType === GridKeydownTargetType.dataCell && c.target) {
+                    c.target.nativeElement.focus();
                 }
-            }
+            });
         }
     }
     /**

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -605,7 +605,10 @@ export class IgxGridNavigationService {
                 if (cb) {
                     cb();
                 } else {
-                    this.getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummary).focus({ preventScroll: true });
+                    const cellElement = this.getCellElementByVisibleIndex(rowIndex, visibleColumnIndex, isSummary);
+                    if (cellElement) {
+                        cellElement.focus({ preventScroll: true });
+                    }
                 }
             });
         this.horizontalScroll(rowIndex).scrollTo(unpinnedIndex);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -2,7 +2,7 @@ import {
     AfterViewInit, ChangeDetectorRef, Component, DebugElement, Injectable,
     OnInit, ViewChild, ViewChildren, QueryList, TemplateRef
 } from '@angular/core';
-import { async, TestBed, fakeAsync, tick, flush } from '@angular/core/testing';
+import { async, TestBed, fakeAsync, tick, flush, ComponentFixture } from '@angular/core/testing';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -1854,8 +1854,8 @@ describe('IgxGrid Component Tests', () => {
         });
 
         describe('Row Editing - Navigation - Keyboard', () => {
-            let fixture;
-            let grid;
+            let fixture: ComponentFixture<IgxGridWithEditingAndFeaturesComponent>;
+            let grid: IgxGridComponent;
 
             beforeEach(fakeAsync(/** height/width setter rAF */() => {
                 fixture = TestBed.createComponent(IgxGridWithEditingAndFeaturesComponent);
@@ -2184,7 +2184,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(editedCell.inEditMode).toEqual(true);
             }));
 
-            it(`Should skip non-editable columns when column when all column features are enabled`, fakeAsync(() => {
+            it(`Should skip non-editable columns when all column features are enabled`, fakeAsync(() => {
                 let targetCell: IgxGridCellComponent;
                 let editedCell: IgxGridCellComponent;
                 fixture.componentInstance.hiddenFlag = true;
@@ -2282,6 +2282,34 @@ describe('IgxGrid Component Tests', () => {
 
                 overlayText = document.getElementsByClassName(BANNER_TEXT)[0] as HTMLElement;
                 expect(overlayText.textContent.trim()).toBe('You have 2 changes in this row');
+            }));
+
+            it(`Should focus last edited cell after click on editable buttons`, (async () => {
+                const targetCell = fixture.componentInstance.getCell(0, 'Downloads');
+                targetCell.nativeElement.focus();
+                fixture.detectChanges();
+                targetCell.onKeydownEnterEditMode();
+                fixture.detectChanges();
+                await wait(DEBOUNCETIME);
+
+                // Scroll the grid
+                grid.parentVirtDir.getHorizontalScroll().scrollLeft = grid.parentVirtDir.getHorizontalScroll().clientWidth;
+                fixture.detectChanges();
+                await wait(DEBOUNCETIME);
+
+                // Focus done button
+                const rowEditingBannerElement = fixture.debugElement.query(By.css('.igx-banner__row')).nativeElement;
+                const doneButtonElement = rowEditingBannerElement.lastElementChild;
+                doneButtonElement.focus();
+                fixture.detectChanges();
+                await wait(DEBOUNCETIME);
+
+                expect(document.activeElement).toEqual(doneButtonElement);
+                doneButtonElement.click();
+                fixture.detectChanges();
+                await wait(DEBOUNCETIME);
+
+                expect(document.activeElement).toEqual(targetCell.nativeElement);
             }));
         });
 


### PR DESCRIPTION
If the last edited cell is not visible grid was not able to focus it. Now, on end edit, we are scrolling to the last edited cell and focus it. This allows user to continue keyboard navigation.

Closes #5181  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 