### PR TITLE
Should not add child row to deleted parent row

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-integration.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-integration.spec.ts
@@ -1159,42 +1159,30 @@ describe('IgxTreeGrid - Integration', () => {
         }));
 
         it('Should not add child row to deleted parent row - Hierarchical DS', fakeAsync(() => {
-            fix = TestBed.createComponent(IgxTreeGridRowEditingHierarchicalDSTransactionComponent);
-            fix.detectChanges();
-            treeGrid = (fix as ComponentFixture<IgxTreeGridRowEditingHierarchicalDSTransactionComponent>).componentInstance.treeGrid;
+            const fixture = TestBed.createComponent(IgxTreeGridRowEditingHierarchicalDSTransactionComponent);
+            const grid = fixture.componentInstance.treeGrid;
             tick();
-            fix.detectChanges();
+            fixture.detectChanges();
 
-            treeGrid.deleteRowById(147);
-            tick();
-            fix.detectChanges();
-            expect(treeGrid.transactions.getTransactionLog().length).toBe(1);
+            grid.deleteRowById(147);
+            expect(grid.transactions.getTransactionLog().length).toBe(1);
 
-            treeGrid.addRow(treeGrid.data, 147);
-            tick();
-            fix.detectChanges();
-
-            expect(treeGrid.transactions.getTransactionLog().length).toBe(1);
+            expect(() => grid.addRow(grid.data, 147)).toThrow(Error(`Cannot add child row to deleted parent row`));
+            expect(grid.transactions.getTransactionLog().length).toBe(1);
         }));
 
         it('Should not add child row to deleted parent row - Flat DS', fakeAsync(() => {
-            fix = TestBed.createComponent(IgxTreeGridRowEditingTransactionComponent);
-            fix.detectChanges();
-            treeGrid = (fix as ComponentFixture<IgxTreeGridRowEditingTransactionComponent>).componentInstance.treeGrid;
-            treeGrid.cascadeOnDelete = false;
+            const fixture = TestBed.createComponent(IgxTreeGridRowEditingTransactionComponent);
+            const grid = (fixture as ComponentFixture<IgxTreeGridRowEditingTransactionComponent>).componentInstance.treeGrid;
+            grid.cascadeOnDelete = false;
             tick();
-            fix.detectChanges();
+            fixture.detectChanges();
 
-            treeGrid.deleteRowById(1);
-            tick();
-            fix.detectChanges();
-            expect(treeGrid.transactions.getTransactionLog().length).toBe(1);
+            grid.deleteRowById(1);
+            expect(grid.transactions.getTransactionLog().length).toBe(1);
 
-            treeGrid.addRow(treeGrid.data, 1);
-            tick();
-            fix.detectChanges();
-
-            expect(treeGrid.transactions.getTransactionLog().length).toBe(1);
+            expect(() => grid.addRow(grid.data, 1)).toThrow(Error(`Cannot add child row to deleted parent row`));
+            expect(grid.transactions.getTransactionLog().length).toBe(1);
         }));
     });
 

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-integration.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-integration.spec.ts
@@ -1,4 +1,4 @@
-import { async, fakeAsync, TestBed, tick, flush } from '@angular/core/testing';
+import { async, fakeAsync, TestBed, tick, flush, ComponentFixture } from '@angular/core/testing';
 import { DebugElement } from '@angular/core';
 import { IgxTreeGridComponent } from './tree-grid.component';
 import { SortingDirection } from '../../data-operations/sorting-expression.interface';
@@ -1156,6 +1156,45 @@ describe('IgxTreeGrid - Integration', () => {
             tick();
             fix.detectChanges();
             expect(treeGrid.selectedRows()).toEqual([]);
+        }));
+
+        it('Should not add child row to deleted parent row - Hierarchical DS', fakeAsync(() => {
+            fix = TestBed.createComponent(IgxTreeGridRowEditingHierarchicalDSTransactionComponent);
+            fix.detectChanges();
+            treeGrid = (fix as ComponentFixture<IgxTreeGridRowEditingHierarchicalDSTransactionComponent>).componentInstance.treeGrid;
+            tick();
+            fix.detectChanges();
+
+            treeGrid.deleteRowById(147);
+            tick();
+            fix.detectChanges();
+            expect(treeGrid.transactions.getTransactionLog().length).toBe(1);
+
+            treeGrid.addRow(treeGrid.data, 147);
+            tick();
+            fix.detectChanges();
+
+            expect(treeGrid.transactions.getTransactionLog().length).toBe(1);
+        }));
+
+        it('Should not add child row to deleted parent row - Flat DS', fakeAsync(() => {
+            fix = TestBed.createComponent(IgxTreeGridRowEditingTransactionComponent);
+            fix.detectChanges();
+            treeGrid = (fix as ComponentFixture<IgxTreeGridRowEditingTransactionComponent>).componentInstance.treeGrid;
+            treeGrid.cascadeOnDelete = false;
+            tick();
+            fix.detectChanges();
+
+            treeGrid.deleteRowById(1);
+            tick();
+            fix.detectChanges();
+            expect(treeGrid.transactions.getTransactionLog().length).toBe(1);
+
+            treeGrid.addRow(treeGrid.data, 1);
+            tick();
+            fix.detectChanges();
+
+            expect(treeGrid.transactions.getTransactionLog().length).toBe(1);
         }));
     });
 

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
@@ -605,7 +605,7 @@ export class IgxTreeGridComponent extends IgxGridBaseComponent implements IGridD
             const state = this.transactions.getState(parentRowID);
             // we should not allow adding of rows as child of deleted row
             if (state && state.type === TransactionType.DELETE) {
-                return;
+                throw Error(`Cannot add child row to deleted parent row`);
             }
 
             const parentRecord = this.records.get(parentRowID);

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
@@ -601,6 +601,13 @@ export class IgxTreeGridComponent extends IgxGridBaseComponent implements IGridD
     public addRow(data: any, parentRowID?: any) {
         if (parentRowID) {
             super.endEdit(true);
+
+            const state = this.transactions.getState(parentRowID);
+            // we should not allow adding of rows as child of deleted row
+            if (state && state.type === TransactionType.DELETE) {
+                return;
+            }
+
             const parentRecord = this.records.get(parentRowID);
 
             if (!parentRecord) {


### PR DESCRIPTION
Add a check if the parent row has a deleted state. If so do not add child row.

Closes #5237

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 