### PR TITLE
Focusing on parent grid using keyboard navigation in IE.

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -125,7 +125,7 @@ export class IgxGridNavigationService {
                 if (this.isColumnLeftFullyVisible(visibleColumnIndex + 1)) {
                     element.nextElementSibling.firstElementChild.focus({ preventScroll: true });
                 } else {
-                    focusElement.nativeElement.focus({ preventScroll: true });
+                    this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
                     this.grid.parentVirtDir.onChunkLoad
                         .pipe(first())
                         .subscribe(() => {
@@ -137,7 +137,7 @@ export class IgxGridNavigationService {
                 element.nextElementSibling.focus({ preventScroll: true });
             }
         } else {
-            focusElement.nativeElement.focus({ preventScroll: true });
+            this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex + 1, isSummary);
         }
     }
@@ -153,7 +153,7 @@ export class IgxGridNavigationService {
         if (!element.previousElementSibling && this.grid.pinnedColumns.length && index === - 1) {
             element.parentNode.previousElementSibling.focus({ preventScroll: true });
         } else if (!this.isColumnLeftFullyVisible(visibleColumnIndex - 1)) {
-            focusElement.nativeElement.focus({ preventScroll: true });
+            this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex - 1, isSummary);
         } else {
             element.previousElementSibling.focus({ preventScroll: true });
@@ -187,7 +187,7 @@ export class IgxGridNavigationService {
         }
     }
 
-    public onKeydownHome(rowIndex, isSummary = false, focusElement = this.grid) {
+    public onKeydownHome(rowIndex, isSummary = false) {
         const rowList = isSummary ? this.grid.summariesRowList : this.grid.dataRowList;
         let rowElement = rowList.find((row) => row.index === rowIndex);
         const cellSelector = this.getCellSelector(0, isSummary);
@@ -197,7 +197,7 @@ export class IgxGridNavigationService {
         if (this.grid.pinnedColumns.length || this.displayContainerScrollLeft === 0) {
             firstCell.focus({ preventScroll: true });
         } else {
-            focusElement.nativeElement.focus({ preventScroll: true });
+            this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.grid.parentVirtDir.onChunkLoad
                 .pipe(first())
                 .subscribe(() => {
@@ -208,7 +208,7 @@ export class IgxGridNavigationService {
         }
     }
 
-    public onKeydownEnd(rowIndex, isSummary = false, focusElement = this.grid) {
+    public onKeydownEnd(rowIndex, isSummary = false) {
         const index = this.grid.unpinnedColumns[this.grid.unpinnedColumns.length - 1].visibleIndex;
         const rowList = isSummary ? this.grid.summariesRowList : this.grid.dataRowList;
         let rowElement = rowList.find((row) => row.index === rowIndex);
@@ -218,7 +218,7 @@ export class IgxGridNavigationService {
             const allCells = rowElement.querySelectorAll(this.getCellSelector(-1, isSummary));
             allCells[allCells.length - 1].focus({ preventScroll: true });
         } else {
-            focusElement.nativeElement.focus({ preventScroll: true });
+            this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.grid.parentVirtDir.onChunkLoad
                 .pipe(first())
                 .subscribe(() => {
@@ -604,6 +604,10 @@ export class IgxGridNavigationService {
                 }
             });
         this.horizontalScroll(rowIndex).scrollTo(unpinnedIndex);
+    }
+
+    protected getFocusableGrid() {
+        return this.grid;
     }
 
     protected getRowByIndex(index, selector = this.getRowSelector()) {

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -10,7 +10,7 @@ import { ISelectionNode } from '../core/grid-selection';
 enum MoveDirection {
     LEFT = 'left',
     RIGHT = 'right'
-};
+}
 
 /** @hidden */
 @Injectable()
@@ -609,7 +609,7 @@ export class IgxGridNavigationService {
     }
 
     private focusGridWithoutScrolling() {
-        if(isIE() && (<IgxHierarchicalGridComponent>this.grid).parent) {
+        if (isIE() && (<IgxHierarchicalGridComponent>this.grid).parent) {
             (<IgxHierarchicalGridComponent>this.grid).parent.nativeElement.focus();
         } else {
             this.grid.nativeElement.focus({ preventScroll: true });

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -237,7 +237,7 @@ export class IgxGridNavigationService {
                 `${cellSelector}[data-visibleIndex="${visibleColumnIndex}"]`);
             cells[0].focus();
         } else {
-            this.grid.nativeElement.focus({ preventScroll: true });
+           this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.grid.verticalScrollContainer.scrollTo(0);
             this.grid.verticalScrollContainer.onChunkLoad
                 .pipe(first()).subscribe(() => {
@@ -257,7 +257,7 @@ export class IgxGridNavigationService {
                 `${cellSelector}[data-visibleIndex="${visibleColumnIndex}"]`);
             cells[cells.length - 1].focus();
         } else {
-            this.grid.nativeElement.focus({ preventScroll: true });
+           this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.grid.verticalScrollContainer.scrollTo(this.grid.verticalScrollContainer.igxForOf.length - 1);
             this.grid.verticalScrollContainer.onChunkLoad
                 .pipe(first()).subscribe(() => {
@@ -277,7 +277,7 @@ export class IgxGridNavigationService {
         const containerTopOffset = parseInt(this.verticalDisplayContainerElement.style.top, 10);
         if (!rowElement.previousElementSibling ||
             rowElement.previousElementSibling.offsetTop < Math.abs(containerTopOffset)) {
-            this.grid.nativeElement.focus({ preventScroll: true });
+           this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.grid.verticalScrollContainer.scrollTo(currentRowIndex - 1);
             this.grid.verticalScrollContainer.onChunkLoad
                 .pipe(first())
@@ -314,7 +314,7 @@ export class IgxGridNavigationService {
         const targetEndTopOffset = rowElement.nextElementSibling ?
             rowElement.nextElementSibling.offsetTop + rowHeight + parseInt(this.verticalDisplayContainerElement.style.top, 10) :
             containerHeight + rowHeight;
-        this.grid.nativeElement.focus({ preventScroll: true });
+       this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
         if (containerHeight && containerHeight < targetEndTopOffset) {
             const nextIndex = currentRowIndex + 1;
             this.grid.verticalScrollContainer.scrollTo(nextIndex);
@@ -358,7 +358,7 @@ export class IgxGridNavigationService {
             if (!horizontalScroll.clientWidth || parseInt(horizontalScroll.scrollLeft, 10) <= 1 || this.grid.pinnedColumns.length) {
                 this.navigateTop(0);
             } else {
-                this.grid.nativeElement.focus({ preventScroll: true });
+               this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
                 this.horizontalScroll(this.grid.dataRowList.first.index).scrollTo(0);
                 this.grid.parentVirtDir.onChunkLoad
                     .pipe(first())
@@ -377,7 +377,7 @@ export class IgxGridNavigationService {
             const rowIndex = parseInt(rows[rows.length - 1].getAttribute('data-rowIndex'), 10);
             this.onKeydownEnd(rowIndex);
         } else {
-            this.grid.nativeElement.focus({ preventScroll: true });
+           this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.grid.verticalScrollContainer.scrollTo(this.grid.verticalScrollContainer.igxForOf.length - 1);
             this.grid.verticalScrollContainer.onChunkLoad
                 .pipe(first()).subscribe(() => {
@@ -593,7 +593,7 @@ export class IgxGridNavigationService {
 
     public performHorizontalScrollToCell(rowIndex: number, visibleColumnIndex: number, isSummary: boolean = false, cb?: () => void) {
         const unpinnedIndex = this.getColumnUnpinnedIndex(visibleColumnIndex);
-        this.grid.nativeElement.focus({ preventScroll: true });
+       this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
         this.grid.parentVirtDir.onChunkLoad
             .pipe(first())
             .subscribe(() => {

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -3,8 +3,6 @@ import { IgxGridBaseComponent, FilterMode } from './grid-base.component';
 import { first } from 'rxjs/operators';
 import { IgxColumnComponent } from './column.component';
 import { IgxGridGroupByRowComponent } from './grid/groupby-row.component';
-import { IgxHierarchicalGridComponent } from './hierarchical-grid';
-import { isIE } from '../core/utils';
 import { ISelectionNode } from '../core/grid-selection';
 
 enum MoveDirection {
@@ -127,7 +125,7 @@ export class IgxGridNavigationService {
                 if (this.isColumnLeftFullyVisible(visibleColumnIndex + 1)) {
                     element.nextElementSibling.firstElementChild.focus({ preventScroll: true });
                 } else {
-                    this.focusGridWithoutScrolling();
+                    focusElement.nativeElement.focus({ preventScroll: true });
                     this.grid.parentVirtDir.onChunkLoad
                         .pipe(first())
                         .subscribe(() => {
@@ -139,7 +137,7 @@ export class IgxGridNavigationService {
                 element.nextElementSibling.focus({ preventScroll: true });
             }
         } else {
-            this.focusGridWithoutScrolling();
+            focusElement.nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex + 1, isSummary);
         }
     }
@@ -155,10 +153,10 @@ export class IgxGridNavigationService {
         if (!element.previousElementSibling && this.grid.pinnedColumns.length && index === - 1) {
             element.parentNode.previousElementSibling.focus({ preventScroll: true });
         } else if (!this.isColumnLeftFullyVisible(visibleColumnIndex - 1)) {
-            this.focusGridWithoutScrolling();
+            focusElement.nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex - 1, isSummary);
         } else {
-            this.focusGridWithoutScrolling();
+            element.previousElementSibling.focus({ preventScroll: true });
         }
 
     }
@@ -189,7 +187,7 @@ export class IgxGridNavigationService {
         }
     }
 
-    public onKeydownHome(rowIndex, isSummary = false) {
+    public onKeydownHome(rowIndex, isSummary = false, focusElement = this.grid) {
         const rowList = isSummary ? this.grid.summariesRowList : this.grid.dataRowList;
         let rowElement = rowList.find((row) => row.index === rowIndex);
         const cellSelector = this.getCellSelector(0, isSummary);
@@ -199,7 +197,7 @@ export class IgxGridNavigationService {
         if (this.grid.pinnedColumns.length || this.displayContainerScrollLeft === 0) {
             firstCell.focus({ preventScroll: true });
         } else {
-            this.focusGridWithoutScrolling();
+            focusElement.nativeElement.focus({ preventScroll: true });
             this.grid.parentVirtDir.onChunkLoad
                 .pipe(first())
                 .subscribe(() => {
@@ -210,7 +208,7 @@ export class IgxGridNavigationService {
         }
     }
 
-    public onKeydownEnd(rowIndex, isSummary = false) {
+    public onKeydownEnd(rowIndex, isSummary = false, focusElement = this.grid) {
         const index = this.grid.unpinnedColumns[this.grid.unpinnedColumns.length - 1].visibleIndex;
         const rowList = isSummary ? this.grid.summariesRowList : this.grid.dataRowList;
         let rowElement = rowList.find((row) => row.index === rowIndex);
@@ -220,7 +218,7 @@ export class IgxGridNavigationService {
             const allCells = rowElement.querySelectorAll(this.getCellSelector(-1, isSummary));
             allCells[allCells.length - 1].focus({ preventScroll: true });
         } else {
-            this.focusGridWithoutScrolling();
+            focusElement.nativeElement.focus({ preventScroll: true });
             this.grid.parentVirtDir.onChunkLoad
                 .pipe(first())
                 .subscribe(() => {
@@ -606,14 +604,6 @@ export class IgxGridNavigationService {
                 }
             });
         this.horizontalScroll(rowIndex).scrollTo(unpinnedIndex);
-    }
-
-    private focusGridWithoutScrolling() {
-        if (isIE() && (<IgxHierarchicalGridComponent>this.grid).parent) {
-            (<IgxHierarchicalGridComponent>this.grid).parent.nativeElement.focus();
-        } else {
-            this.grid.nativeElement.focus({ preventScroll: true });
-        }
     }
 
     protected getRowByIndex(index, selector = this.getRowSelector()) {

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -3,12 +3,14 @@ import { IgxGridBaseComponent, FilterMode } from './grid-base.component';
 import { first } from 'rxjs/operators';
 import { IgxColumnComponent } from './column.component';
 import { IgxGridGroupByRowComponent } from './grid/groupby-row.component';
+import { IgxHierarchicalGridComponent } from './hierarchical-grid';
+import { isIE } from '../core/utils';
 import { ISelectionNode } from '../core/grid-selection';
 
 enum MoveDirection {
     LEFT = 'left',
     RIGHT = 'right'
-}
+};
 
 /** @hidden */
 @Injectable()
@@ -125,7 +127,7 @@ export class IgxGridNavigationService {
                 if (this.isColumnLeftFullyVisible(visibleColumnIndex + 1)) {
                     element.nextElementSibling.firstElementChild.focus({ preventScroll: true });
                 } else {
-                    this.grid.nativeElement.focus({ preventScroll: true });
+                    this.focusGridWithoutScrolling();
                     this.grid.parentVirtDir.onChunkLoad
                         .pipe(first())
                         .subscribe(() => {
@@ -137,6 +139,7 @@ export class IgxGridNavigationService {
                 element.nextElementSibling.focus({ preventScroll: true });
             }
         } else {
+            this.focusGridWithoutScrolling();
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex + 1, isSummary);
         }
     }
@@ -152,9 +155,10 @@ export class IgxGridNavigationService {
         if (!element.previousElementSibling && this.grid.pinnedColumns.length && index === - 1) {
             element.parentNode.previousElementSibling.focus({ preventScroll: true });
         } else if (!this.isColumnLeftFullyVisible(visibleColumnIndex - 1)) {
+            this.focusGridWithoutScrolling();
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex - 1, isSummary);
         } else {
-            element.previousElementSibling.focus({ preventScroll: true });
+            this.focusGridWithoutScrolling();
         }
 
     }
@@ -195,7 +199,7 @@ export class IgxGridNavigationService {
         if (this.grid.pinnedColumns.length || this.displayContainerScrollLeft === 0) {
             firstCell.focus({ preventScroll: true });
         } else {
-            this.grid.nativeElement.focus({ preventScroll: true });
+            this.focusGridWithoutScrolling();
             this.grid.parentVirtDir.onChunkLoad
                 .pipe(first())
                 .subscribe(() => {
@@ -216,7 +220,7 @@ export class IgxGridNavigationService {
             const allCells = rowElement.querySelectorAll(this.getCellSelector(-1, isSummary));
             allCells[allCells.length - 1].focus({ preventScroll: true });
         } else {
-            this.grid.nativeElement.focus({ preventScroll: true });
+            this.focusGridWithoutScrolling();
             this.grid.parentVirtDir.onChunkLoad
                 .pipe(first())
                 .subscribe(() => {
@@ -602,6 +606,14 @@ export class IgxGridNavigationService {
                 }
             });
         this.horizontalScroll(rowIndex).scrollTo(unpinnedIndex);
+    }
+
+    private focusGridWithoutScrolling() {
+        if(isIE() && (<IgxHierarchicalGridComponent>this.grid).parent) {
+            (<IgxHierarchicalGridComponent>this.grid).parent.nativeElement.focus();
+        } else {
+            this.grid.nativeElement.focus({ preventScroll: true });
+        }
     }
 
     protected getRowByIndex(index, selector = this.getRowSelector()) {

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -137,7 +137,6 @@ export class IgxGridNavigationService {
                 element.nextElementSibling.focus({ preventScroll: true });
             }
         } else {
-            this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex + 1, isSummary);
         }
     }
@@ -153,7 +152,6 @@ export class IgxGridNavigationService {
         if (!element.previousElementSibling && this.grid.pinnedColumns.length && index === - 1) {
             element.parentNode.previousElementSibling.focus({ preventScroll: true });
         } else if (!this.isColumnLeftFullyVisible(visibleColumnIndex - 1)) {
-            this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex - 1, isSummary);
         } else {
             element.previousElementSibling.focus({ preventScroll: true });

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
@@ -4,6 +4,7 @@ import { first } from 'rxjs/operators';
 import { FilterMode } from '../grid-base.component';
 import { IgxColumnComponent } from '../../grids/column.component';
 import { ISelectionNode } from '../../core/grid-selection';
+import { isIE } from '../../core/utils';
 
 export class IgxHierarchicalGridNavigationService extends IgxGridNavigationService {
     public grid: IgxHierarchicalGridComponent;
@@ -199,6 +200,18 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
         }
     }
 
+    public onKeydownArrowRight(element, rowIndex, visibleColumnIndex, isSummary = false) {
+        super.onKeydownArrowRight(element, rowIndex, visibleColumnIndex, isSummary, this.getFocusableGrid());
+    }
+
+    public onKeydownArrowLeft(element, rowIndex, visibleColumnIndex, isSummary = false) {
+        super.onKeydownArrowLeft(element, rowIndex, visibleColumnIndex, isSummary, this.getFocusableGrid());
+    }
+
+    public onKeydownHome(rowIndex, isSummary = false) {
+        super.onKeydownHome(rowIndex, isSummary, this.getFocusableGrid());
+    }
+
     public onKeydownEnd(rowIndex, isSummary = false) {
         if (this.grid.parent && !isSummary) {
             // handle scenario where last child row might not be in view
@@ -223,10 +236,10 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
                 this.grid.rootGrid.tbody.nativeElement.getBoundingClientRect().top ? scrGrid : this.grid.rootGrid;
                 this.scrollGrid(topGrid, diffTop, () => super.onKeydownEnd(rowIndex));
             } else {
-                super.onKeydownEnd(rowIndex, isSummary);
+                super.onKeydownEnd(rowIndex, isSummary, this.getFocusableGrid());
             }
         } else {
-            super.onKeydownEnd(rowIndex, isSummary);
+            super.onKeydownEnd(rowIndex, isSummary, this.getFocusableGrid());
         }
 
     }
@@ -413,6 +426,10 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
         } else {
             super.performShiftTabKey(currentRowEl, selectedNode);
         }
+    }
+
+    private getFocusableGrid() {
+        return (isIE() && this.grid.rootGrid) ? this.grid.rootGrid : this.grid;
     }
 
     private getLastGridElem(trContainer) {

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
@@ -714,7 +714,7 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
         grid.dataRowList.toArray()[0].virtDirRow.scrollTo(unpinnedIndex);
     }
     private scrollGrid(grid, target, callBackFunc) {
-        grid.nativeElement.focus({preventScroll: true});
+        this.getFocusableGrid().nativeElement.focus({preventScroll: true});
         requestAnimationFrame(() => {
             if (typeof target === 'number') {
                 grid.verticalScrollContainer.addScrollTop(target);

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
@@ -175,6 +175,18 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
                     if (cells.length > 0) { cells[cells.length - 1].focus(); }
                 });
             }
+        } else  if (this.grid.parent !== null) {
+            const childContainer = this.grid.nativeElement.parentNode.parentNode;
+            const diff =
+            childContainer.getBoundingClientRect().bottom - this.grid.rootGrid.nativeElement.getBoundingClientRect().bottom;
+            const endIsVisible = diff < 0;
+            const scrollable = this.getNextScrollableDown(this.grid);
+            if (!endIsVisible) {
+                this.scrollGrid(scrollable.grid, diff,
+                    () => super.navigateBottom(visibleColumnIndex));
+            } else {
+                super.navigateBottom(visibleColumnIndex);
+            }
         } else {
             super.navigateBottom(visibleColumnIndex);
         }

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
@@ -178,7 +178,7 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
         } else  if (this.grid.parent !== null) {
             const childContainer = this.grid.nativeElement.parentNode.parentNode;
             const diff =
-            childContainer.getBoundingClientRect().bottom - this.grid.rootGrid.nativeElement.getBoundingClientRect().bottom;
+            childContainer.getBoundingClientRect().bottom - this.grid.rootGrid.tbody.nativeElement.getBoundingClientRect().bottom;
             const endIsVisible = diff < 0;
             const scrollable = this.getNextScrollableDown(this.grid);
             if (!endIsVisible) {

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
@@ -200,18 +200,6 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
         }
     }
 
-    public onKeydownArrowRight(element, rowIndex, visibleColumnIndex, isSummary = false) {
-        super.onKeydownArrowRight(element, rowIndex, visibleColumnIndex, isSummary, this.getFocusableGrid());
-    }
-
-    public onKeydownArrowLeft(element, rowIndex, visibleColumnIndex, isSummary = false) {
-        super.onKeydownArrowLeft(element, rowIndex, visibleColumnIndex, isSummary, this.getFocusableGrid());
-    }
-
-    public onKeydownHome(rowIndex, isSummary = false) {
-        super.onKeydownHome(rowIndex, isSummary, this.getFocusableGrid());
-    }
-
     public onKeydownEnd(rowIndex, isSummary = false) {
         if (this.grid.parent && !isSummary) {
             // handle scenario where last child row might not be in view
@@ -236,10 +224,10 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
                 this.grid.rootGrid.tbody.nativeElement.getBoundingClientRect().top ? scrGrid : this.grid.rootGrid;
                 this.scrollGrid(topGrid, diffTop, () => super.onKeydownEnd(rowIndex));
             } else {
-                super.onKeydownEnd(rowIndex, isSummary, this.getFocusableGrid());
+                super.onKeydownEnd(rowIndex, isSummary);
             }
         } else {
-            super.onKeydownEnd(rowIndex, isSummary, this.getFocusableGrid());
+            super.onKeydownEnd(rowIndex, isSummary);
         }
 
     }
@@ -428,7 +416,7 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
         }
     }
 
-    private getFocusableGrid() {
+    public getFocusableGrid() {
         return (isIE() && this.grid.rootGrid) ? this.grid.rootGrid : this.grid;
     }
 


### PR DESCRIPTION
Closes #4488
Internet explorer doesn't support [preventScroll](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) option. Try this sample [here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#Focus_prevent_scroll) (Click on the "Click me to focus on the button without scrolling!" in IE).
This is why we should not focus on a child grid but rather on the parent grid in some cases when using keyboard navigation in IE.
Please test the solution for IE with ctr + right, ctr + left, home, end, arrowLeft and arrowRight navigation keys.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 