### PR TITLE
Focusing on parent grid using keyboard navigation in IE.

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -159,7 +159,6 @@ export class IgxGridNavigationService {
         if (!element.previousElementSibling && this.grid.pinnedColumns.length && index === - 1) {
             element.parentNode.previousElementSibling.focus({ preventScroll: true });
         } else if (!this.isColumnLeftEdgeVisible(visibleColumnIndex - 1)) {
-        } else if (!this.isColumnLeftFullyVisible(visibleColumnIndex - 1)) {
             this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex - 1, isSummary);
         } else {

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -131,7 +131,7 @@ export class IgxGridNavigationService {
                 if (this.isColumnLeftEdgeVisible(visibleColumnIndex + 1)) {
                     element.nextElementSibling.firstElementChild.focus({ preventScroll: true });
                 } else {
-                    focusElement.nativeElement.focus({ preventScroll: true });
+                    this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
                     this.grid.parentVirtDir.onChunkLoad
                         .pipe(first())
                         .subscribe(() => {
@@ -143,7 +143,7 @@ export class IgxGridNavigationService {
                 element.nextElementSibling.focus({ preventScroll: true });
             }
         } else {
-            focusElement.nativeElement.focus({ preventScroll: true });
+            this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex + 1, isSummary);
         }
     }
@@ -159,6 +159,8 @@ export class IgxGridNavigationService {
         if (!element.previousElementSibling && this.grid.pinnedColumns.length && index === - 1) {
             element.parentNode.previousElementSibling.focus({ preventScroll: true });
         } else if (!this.isColumnLeftEdgeVisible(visibleColumnIndex - 1)) {
+        } else if (!this.isColumnLeftFullyVisible(visibleColumnIndex - 1)) {
+            this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex - 1, isSummary);
         } else {
             element.previousElementSibling.focus({ preventScroll: true });
@@ -196,7 +198,7 @@ export class IgxGridNavigationService {
         }
     }
 
-    public onKeydownHome(rowIndex, isSummary = false, focusElement = this.grid) {
+    public onKeydownHome(rowIndex, isSummary = false) {
         const rowList = isSummary ? this.grid.summariesRowList : this.grid.dataRowList;
         let rowElement = rowList.find((row) => row.index === rowIndex);
         const cellSelector = this.getCellSelector(0, isSummary);
@@ -206,7 +208,7 @@ export class IgxGridNavigationService {
         if (this.grid.pinnedColumns.length || this.displayContainerScrollLeft === 0) {
             firstCell.focus({ preventScroll: true });
         } else {
-            focusElement.nativeElement.focus({ preventScroll: true });
+            this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.grid.parentVirtDir.onChunkLoad
                 .pipe(first())
                 .subscribe(() => {
@@ -217,7 +219,7 @@ export class IgxGridNavigationService {
         }
     }
 
-    public onKeydownEnd(rowIndex, isSummary = false, focusElement = this.grid) {
+    public onKeydownEnd(rowIndex, isSummary = false) {
         const index = this.grid.unpinnedColumns[this.grid.unpinnedColumns.length - 1].visibleIndex;
         const rowList = isSummary ? this.grid.summariesRowList : this.grid.dataRowList;
         let rowElement = rowList.find((row) => row.index === rowIndex);
@@ -227,7 +229,7 @@ export class IgxGridNavigationService {
             const allCells = rowElement.querySelectorAll(this.getCellSelector(-1, isSummary));
             allCells[allCells.length - 1].focus({ preventScroll: true });
         } else {
-            focusElement.nativeElement.focus({ preventScroll: true });
+            this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.grid.parentVirtDir.onChunkLoad
                 .pipe(first())
                 .subscribe(() => {
@@ -612,12 +614,8 @@ export class IgxGridNavigationService {
         this.horizontalScroll(rowIndex).scrollTo(unpinnedIndex);
     }
 
-    private focusGridWithoutScrolling() {
-        if(isIE() && (<IgxHierarchicalGridComponent>this.grid).parent) {
-            (<IgxHierarchicalGridComponent>this.grid).parent.nativeElement.focus();
-        } else {
-            this.grid.nativeElement.focus({ preventScroll: true });
-        }
+    protected getFocusableGrid() {
+        return this.grid;
     }
 
     protected getRowByIndex(index, selector = this.getRowSelector()) {

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -3,13 +3,15 @@ import { IgxGridBaseComponent, FilterMode } from './grid-base.component';
 import { first } from 'rxjs/operators';
 import { IgxColumnComponent } from './column.component';
 import { IgxGridGroupByRowComponent } from './grid/groupby-row.component';
+import { IgxHierarchicalGridComponent } from './hierarchical-grid';
+import { isIE } from '../core/utils';
 import { ISelectionNode } from '../core/grid-selection';
 import { IgxForOfDirective } from '../directives/for-of/for_of.directive';
 
 enum MoveDirection {
     LEFT = 'left',
     RIGHT = 'right'
-}
+};
 
 /** @hidden */
 @Injectable()
@@ -131,7 +133,7 @@ export class IgxGridNavigationService {
                 if (this.isColumnLeftEdgeVisible(visibleColumnIndex + 1)) {
                     element.nextElementSibling.firstElementChild.focus({ preventScroll: true });
                 } else {
-                    this.grid.nativeElement.focus({ preventScroll: true });
+                    this.focusGridWithoutScrolling();
                     this.grid.parentVirtDir.onChunkLoad
                         .pipe(first())
                         .subscribe(() => {
@@ -143,6 +145,7 @@ export class IgxGridNavigationService {
                 element.nextElementSibling.focus({ preventScroll: true });
             }
         } else {
+            this.focusGridWithoutScrolling();
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex + 1, isSummary);
         }
     }
@@ -160,7 +163,7 @@ export class IgxGridNavigationService {
         } else if (!this.isColumnLeftEdgeVisible(visibleColumnIndex - 1)) {
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex - 1, isSummary);
         } else {
-            element.previousElementSibling.focus({ preventScroll: true });
+            this.focusGridWithoutScrolling();
         }
 
     }
@@ -205,7 +208,7 @@ export class IgxGridNavigationService {
         if (this.grid.pinnedColumns.length || this.displayContainerScrollLeft === 0) {
             firstCell.focus({ preventScroll: true });
         } else {
-            this.grid.nativeElement.focus({ preventScroll: true });
+            this.focusGridWithoutScrolling();
             this.grid.parentVirtDir.onChunkLoad
                 .pipe(first())
                 .subscribe(() => {
@@ -226,7 +229,7 @@ export class IgxGridNavigationService {
             const allCells = rowElement.querySelectorAll(this.getCellSelector(-1, isSummary));
             allCells[allCells.length - 1].focus({ preventScroll: true });
         } else {
-            this.grid.nativeElement.focus({ preventScroll: true });
+            this.focusGridWithoutScrolling();
             this.grid.parentVirtDir.onChunkLoad
                 .pipe(first())
                 .subscribe(() => {
@@ -609,6 +612,14 @@ export class IgxGridNavigationService {
                 }
             });
         this.horizontalScroll(rowIndex).scrollTo(unpinnedIndex);
+    }
+
+    private focusGridWithoutScrolling() {
+        if(isIE() && (<IgxHierarchicalGridComponent>this.grid).parent) {
+            (<IgxHierarchicalGridComponent>this.grid).parent.nativeElement.focus();
+        } else {
+            this.grid.nativeElement.focus({ preventScroll: true });
+        }
     }
 
     protected getRowByIndex(index, selector = this.getRowSelector()) {

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -248,7 +248,7 @@ export class IgxGridNavigationService {
                 `${cellSelector}[data-visibleIndex="${visibleColumnIndex}"]`);
             cells[0].focus();
         } else {
-            this.grid.nativeElement.focus({ preventScroll: true });
+           this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.grid.verticalScrollContainer.scrollTo(0);
             this.grid.verticalScrollContainer.onChunkLoad
                 .pipe(first()).subscribe(() => {
@@ -268,7 +268,7 @@ export class IgxGridNavigationService {
                 `${cellSelector}[data-visibleIndex="${visibleColumnIndex}"]`);
             cells[cells.length - 1].focus();
         } else {
-            this.grid.nativeElement.focus({ preventScroll: true });
+           this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.grid.verticalScrollContainer.scrollTo(this.grid.verticalScrollContainer.igxForOf.length - 1);
             this.grid.verticalScrollContainer.onChunkLoad
                 .pipe(first()).subscribe(() => {
@@ -288,7 +288,7 @@ export class IgxGridNavigationService {
         const containerTopOffset = parseInt(this.verticalDisplayContainerElement.style.top, 10);
         if (!rowElement.previousElementSibling ||
             rowElement.previousElementSibling.offsetTop < Math.abs(containerTopOffset)) {
-            this.grid.nativeElement.focus({ preventScroll: true });
+           this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.grid.verticalScrollContainer.scrollTo(currentRowIndex - 1);
             this.grid.verticalScrollContainer.onChunkLoad
                 .pipe(first())
@@ -325,7 +325,7 @@ export class IgxGridNavigationService {
         const targetEndTopOffset = rowElement.nextElementSibling ?
             rowElement.nextElementSibling.offsetTop + rowHeight + parseInt(this.verticalDisplayContainerElement.style.top, 10) :
             containerHeight + rowHeight;
-        this.grid.nativeElement.focus({ preventScroll: true });
+       this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
         if (containerHeight && containerHeight < targetEndTopOffset) {
             const nextIndex = currentRowIndex + 1;
             this.grid.verticalScrollContainer.scrollTo(nextIndex);
@@ -369,7 +369,7 @@ export class IgxGridNavigationService {
             if (!horizontalScroll.clientWidth || parseInt(horizontalScroll.scrollLeft, 10) <= 1 || this.grid.pinnedColumns.length) {
                 this.navigateTop(0);
             } else {
-                this.grid.nativeElement.focus({ preventScroll: true });
+               this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
                 this.horizontalScroll(this.grid.dataRowList.first.index).scrollTo(0);
                 this.grid.parentVirtDir.onChunkLoad
                     .pipe(first())
@@ -388,7 +388,7 @@ export class IgxGridNavigationService {
             const rowIndex = parseInt(rows[rows.length - 1].getAttribute('data-rowIndex'), 10);
             this.onKeydownEnd(rowIndex);
         } else {
-            this.grid.nativeElement.focus({ preventScroll: true });
+           this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.grid.verticalScrollContainer.scrollTo(this.grid.verticalScrollContainer.igxForOf.length - 1);
             this.grid.verticalScrollContainer.onChunkLoad
                 .pipe(first()).subscribe(() => {
@@ -601,7 +601,7 @@ export class IgxGridNavigationService {
     public performHorizontalScrollToCell(
         rowIndex: number, visibleColumnIndex: number, isSummary: boolean = false, cb?: () => void) {
         const unpinnedIndex = this.getColumnUnpinnedIndex(visibleColumnIndex);
-        this.grid.nativeElement.focus({ preventScroll: true });
+       this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
         this.grid.parentVirtDir.onChunkLoad
             .pipe(first())
             .subscribe(() => {

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -143,7 +143,6 @@ export class IgxGridNavigationService {
                 element.nextElementSibling.focus({ preventScroll: true });
             }
         } else {
-            this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex + 1, isSummary);
         }
     }
@@ -159,7 +158,6 @@ export class IgxGridNavigationService {
         if (!element.previousElementSibling && this.grid.pinnedColumns.length && index === - 1) {
             element.parentNode.previousElementSibling.focus({ preventScroll: true });
         } else if (!this.isColumnLeftEdgeVisible(visibleColumnIndex - 1)) {
-            this.getFocusableGrid().nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex - 1, isSummary);
         } else {
             element.previousElementSibling.focus({ preventScroll: true });

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -9,7 +9,7 @@ import { IgxForOfDirective } from '../directives/for-of/for_of.directive';
 enum MoveDirection {
     LEFT = 'left',
     RIGHT = 'right'
-};
+}
 
 /** @hidden */
 @Injectable()

--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -3,8 +3,6 @@ import { IgxGridBaseComponent, FilterMode } from './grid-base.component';
 import { first } from 'rxjs/operators';
 import { IgxColumnComponent } from './column.component';
 import { IgxGridGroupByRowComponent } from './grid/groupby-row.component';
-import { IgxHierarchicalGridComponent } from './hierarchical-grid';
-import { isIE } from '../core/utils';
 import { ISelectionNode } from '../core/grid-selection';
 import { IgxForOfDirective } from '../directives/for-of/for_of.directive';
 
@@ -133,7 +131,7 @@ export class IgxGridNavigationService {
                 if (this.isColumnLeftEdgeVisible(visibleColumnIndex + 1)) {
                     element.nextElementSibling.firstElementChild.focus({ preventScroll: true });
                 } else {
-                    this.focusGridWithoutScrolling();
+                    focusElement.nativeElement.focus({ preventScroll: true });
                     this.grid.parentVirtDir.onChunkLoad
                         .pipe(first())
                         .subscribe(() => {
@@ -145,7 +143,7 @@ export class IgxGridNavigationService {
                 element.nextElementSibling.focus({ preventScroll: true });
             }
         } else {
-            this.focusGridWithoutScrolling();
+            focusElement.nativeElement.focus({ preventScroll: true });
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex + 1, isSummary);
         }
     }
@@ -163,7 +161,7 @@ export class IgxGridNavigationService {
         } else if (!this.isColumnLeftEdgeVisible(visibleColumnIndex - 1)) {
             this.performHorizontalScrollToCell(rowIndex, visibleColumnIndex - 1, isSummary);
         } else {
-            this.focusGridWithoutScrolling();
+            element.previousElementSibling.focus({ preventScroll: true });
         }
 
     }
@@ -198,7 +196,7 @@ export class IgxGridNavigationService {
         }
     }
 
-    public onKeydownHome(rowIndex, isSummary = false) {
+    public onKeydownHome(rowIndex, isSummary = false, focusElement = this.grid) {
         const rowList = isSummary ? this.grid.summariesRowList : this.grid.dataRowList;
         let rowElement = rowList.find((row) => row.index === rowIndex);
         const cellSelector = this.getCellSelector(0, isSummary);
@@ -208,7 +206,7 @@ export class IgxGridNavigationService {
         if (this.grid.pinnedColumns.length || this.displayContainerScrollLeft === 0) {
             firstCell.focus({ preventScroll: true });
         } else {
-            this.focusGridWithoutScrolling();
+            focusElement.nativeElement.focus({ preventScroll: true });
             this.grid.parentVirtDir.onChunkLoad
                 .pipe(first())
                 .subscribe(() => {
@@ -219,7 +217,7 @@ export class IgxGridNavigationService {
         }
     }
 
-    public onKeydownEnd(rowIndex, isSummary = false) {
+    public onKeydownEnd(rowIndex, isSummary = false, focusElement = this.grid) {
         const index = this.grid.unpinnedColumns[this.grid.unpinnedColumns.length - 1].visibleIndex;
         const rowList = isSummary ? this.grid.summariesRowList : this.grid.dataRowList;
         let rowElement = rowList.find((row) => row.index === rowIndex);
@@ -229,7 +227,7 @@ export class IgxGridNavigationService {
             const allCells = rowElement.querySelectorAll(this.getCellSelector(-1, isSummary));
             allCells[allCells.length - 1].focus({ preventScroll: true });
         } else {
-            this.focusGridWithoutScrolling();
+            focusElement.nativeElement.focus({ preventScroll: true });
             this.grid.parentVirtDir.onChunkLoad
                 .pipe(first())
                 .subscribe(() => {

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
@@ -200,18 +200,6 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
         }
     }
 
-    public onKeydownArrowRight(element, rowIndex, visibleColumnIndex, isSummary = false) {
-        super.onKeydownArrowRight(element, rowIndex, visibleColumnIndex, isSummary, this.getFocusableGrid());
-    }
-
-    public onKeydownArrowLeft(element, rowIndex, visibleColumnIndex, isSummary = false) {
-        super.onKeydownArrowLeft(element, rowIndex, visibleColumnIndex, isSummary, this.getFocusableGrid());
-    }
-
-    public onKeydownHome(rowIndex, isSummary = false) {
-        super.onKeydownHome(rowIndex, isSummary, this.getFocusableGrid());
-    }
-
     public onKeydownEnd(rowIndex, isSummary = false) {
         if (this.grid.parent && !isSummary) {
             // handle scenario where last child row might not be in view
@@ -236,10 +224,10 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
                     this.grid.rootGrid.tbody.nativeElement.getBoundingClientRect().top ? scrGrid : this.grid.rootGrid;
                 this.scrollGrid(topGrid, diffTop, () => super.onKeydownEnd(rowIndex));
             } else {
-                super.onKeydownEnd(rowIndex, isSummary, this.getFocusableGrid());
+                super.onKeydownEnd(rowIndex, isSummary);
             }
         } else {
-            super.onKeydownEnd(rowIndex, isSummary, this.getFocusableGrid());
+            super.onKeydownEnd(rowIndex, isSummary);
         }
 
     }
@@ -428,7 +416,7 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
         }
     }
 
-    private getFocusableGrid() {
+    public getFocusableGrid() {
         return (isIE() && this.grid.rootGrid) ? this.grid.rootGrid : this.grid;
     }
 

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
@@ -175,6 +175,18 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
                         if (cells.length > 0) { cells[cells.length - 1].focus(); }
                     });
             }
+        } else  if (this.grid.parent !== null) {
+            const childContainer = this.grid.nativeElement.parentNode.parentNode;
+            const diff =
+            childContainer.getBoundingClientRect().bottom - this.grid.rootGrid.nativeElement.getBoundingClientRect().bottom;
+            const endIsVisible = diff < 0;
+            const scrollable = this.getNextScrollableDown(this.grid);
+            if (!endIsVisible) {
+                this.scrollGrid(scrollable.grid, diff,
+                    () => super.navigateBottom(visibleColumnIndex));
+            } else {
+                super.navigateBottom(visibleColumnIndex);
+            }
         } else {
             super.navigateBottom(visibleColumnIndex);
         }

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
@@ -714,7 +714,7 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
         grid.dataRowList.toArray()[0].virtDirRow.scrollTo(unpinnedIndex);
     }
     private scrollGrid(grid, target, callBackFunc) {
-        grid.nativeElement.focus({ preventScroll: true });
+        this.getFocusableGrid().nativeElement.focus({preventScroll: true});
         requestAnimationFrame(() => {
             if (typeof target === 'number') {
                 grid.verticalScrollContainer.addScrollTop(target);

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
@@ -178,7 +178,7 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
         } else  if (this.grid.parent !== null) {
             const childContainer = this.grid.nativeElement.parentNode.parentNode;
             const diff =
-            childContainer.getBoundingClientRect().bottom - this.grid.rootGrid.nativeElement.getBoundingClientRect().bottom;
+            childContainer.getBoundingClientRect().bottom - this.grid.rootGrid.tbody.nativeElement.getBoundingClientRect().bottom;
             const endIsVisible = diff < 0;
             const scrollable = this.getNextScrollableDown(this.grid);
             if (!endIsVisible) {

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
@@ -4,6 +4,7 @@ import { first } from 'rxjs/operators';
 import { FilterMode } from '../grid-base.component';
 import { IgxColumnComponent } from '../../grids/column.component';
 import { ISelectionNode } from '../../core/grid-selection';
+import { isIE } from '../../core/utils';
 
 export class IgxHierarchicalGridNavigationService extends IgxGridNavigationService {
     public grid: IgxHierarchicalGridComponent;
@@ -199,6 +200,18 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
         }
     }
 
+    public onKeydownArrowRight(element, rowIndex, visibleColumnIndex, isSummary = false) {
+        super.onKeydownArrowRight(element, rowIndex, visibleColumnIndex, isSummary, this.getFocusableGrid());
+    }
+
+    public onKeydownArrowLeft(element, rowIndex, visibleColumnIndex, isSummary = false) {
+        super.onKeydownArrowLeft(element, rowIndex, visibleColumnIndex, isSummary, this.getFocusableGrid());
+    }
+
+    public onKeydownHome(rowIndex, isSummary = false) {
+        super.onKeydownHome(rowIndex, isSummary, this.getFocusableGrid());
+    }
+
     public onKeydownEnd(rowIndex, isSummary = false) {
         if (this.grid.parent && !isSummary) {
             // handle scenario where last child row might not be in view
@@ -223,10 +236,10 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
                     this.grid.rootGrid.tbody.nativeElement.getBoundingClientRect().top ? scrGrid : this.grid.rootGrid;
                 this.scrollGrid(topGrid, diffTop, () => super.onKeydownEnd(rowIndex));
             } else {
-                super.onKeydownEnd(rowIndex, isSummary);
+                super.onKeydownEnd(rowIndex, isSummary, this.getFocusableGrid());
             }
         } else {
-            super.onKeydownEnd(rowIndex, isSummary);
+            super.onKeydownEnd(rowIndex, isSummary, this.getFocusableGrid());
         }
 
     }
@@ -413,6 +426,10 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
         } else {
             super.performShiftTabKey(currentRowEl, selectedNode);
         }
+    }
+
+    private getFocusableGrid() {
+        return (isIE() && this.grid.rootGrid) ? this.grid.rootGrid : this.grid;
     }
 
     private getLastGridElem(trContainer) {


### PR DESCRIPTION
Closes #4488
Internet explorer doesn't support [preventScroll](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus) option. Try this sample [here](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/focus#Focus_prevent_scroll) (Click on the "Click me to focus on the button without scrolling!" in IE).
This is why we should not focus on a child grid but rather on the parent grid in some cases when using keyboard navigation in IE.
Please test the solution for IE with ctr + right, ctr + left, home, end, arrowLeft and arrowRight navigation keys.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 