### PR TITLE
Should exit row edit on display density change 7.3

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -2806,6 +2806,7 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
         this.onDensityChanged.pipe(takeUntil(this.destroy$)).subscribe(() => {
             requestAnimationFrame(() => {
                 this.summaryService.summaryHeight = 0;
+                this.endEdit(true);
                 this.reflow();
                 this.verticalScrollContainer.recalcUpdateSizes();
             });

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1876,6 +1876,7 @@ describe('IgxGrid Component Tests', () => {
                 grid = fixture.componentInstance.grid;
                 setupGridScrollDetection(fixture, grid);
             }));
+
             it(`Should jump from first editable columns to overlay buttons`, (async () => {
                 const targetCell = fixture.componentInstance.getCell(0, 'Downloads');
                 targetCell.nativeElement.focus();
@@ -2437,6 +2438,30 @@ describe('IgxGrid Component Tests', () => {
                 expect(gridAPI.escape_editMode).toHaveBeenCalled();
                 expect(gridAPI.escape_editMode).toHaveBeenCalledWith();
                 expect(cell.inEditMode).toBeFalsy();
+            }));
+
+            fit(`Should exit row editing AND COMMIT on displayDensity change`, fakeAsync(() => {
+                const fix = TestBed.createComponent(IgxGridRowEditingComponent);
+                fix.detectChanges();
+                tick(DEBOUNCETIME);
+
+                const grid = fix.componentInstance.grid;
+                grid.displayDensity = DisplayDensity.comfortable;
+                fix.detectChanges();
+                tick(DEBOUNCETIME);
+
+                const cell = grid.getCellByColumn(0, 'ProductName');
+                cell.setEditMode(true);
+                fix.detectChanges();
+                tick(DEBOUNCETIME);
+
+                expect(cell.editMode).toBeTruthy();
+
+                grid.displayDensity = DisplayDensity.cosy;
+                fix.detectChanges();
+                tick(DEBOUNCETIME);
+
+                expect(cell.editMode).toBeFalsy();
             }));
 
             it(`Should NOT exit row editing on click on non-editable cell in same row`, fakeAsync(() => {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -2455,12 +2455,16 @@ describe('IgxGrid Component Tests', () => {
                 fix.detectChanges();
                 tick(DEBOUNCETIME);
 
+                let overlayContent: HTMLElement = document.getElementsByClassName(EDIT_OVERLAY_CONTENT)[0] as HTMLElement;
+                expect(overlayContent).toBeTruthy();
                 expect(cell.editMode).toBeTruthy();
 
                 grid.displayDensity = DisplayDensity.cosy;
                 fix.detectChanges();
                 tick(DEBOUNCETIME);
 
+                overlayContent = document.getElementsByClassName(EDIT_OVERLAY_CONTENT)[0] as HTMLElement;
+                expect(overlayContent).toBeFalsy();
                 expect(cell.editMode).toBeFalsy();
             }));
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -2440,7 +2440,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(cell.inEditMode).toBeFalsy();
             }));
 
-            fit(`Should exit row editing AND COMMIT on displayDensity change`, fakeAsync(() => {
+            it(`Should exit row editing AND COMMIT on displayDensity change`, fakeAsync(() => {
                 const fix = TestBed.createComponent(IgxGridRowEditingComponent);
                 fix.detectChanges();
                 tick(DEBOUNCETIME);


### PR DESCRIPTION
Row edit should be completed on density change. Otherwise we may go into situation where customer changes the density from compact to comfortable. In this case, if customer is editing the last row, this row will go out of view and we should scroll the grid.

Closes #5261

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 