### PR TITLE
End edit on rowEditable change 8.0.x

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -602,10 +602,12 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
     * @memberof IgxGridBaseComponent
     */
     set rowEditable(val: boolean) {
-        this._rowEditable = val;
         if (this.gridAPI.grid) {
             this.refreshGridState();
+            requestAnimationFrame(() => this._pipeTrigger++);
         }
+        this._rowEditable = val;
+        this.cdr.markForCheck();
     }
 
     /**

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -604,7 +604,6 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
     set rowEditable(val: boolean) {
         if (this.gridAPI.grid) {
             this.refreshGridState();
-            requestAnimationFrame(() => this._pipeTrigger++);
         }
         this._rowEditable = val;
         this.cdr.markForCheck();

--- a/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
@@ -298,7 +298,7 @@ describe('IgxGrid - Cell component', () => {
                 expect(cell.value).toBe(87);
             });
 
-            it('edit template should be accourding column data type -- number', () => {
+            it('edit template should be according column data type -- number', () => {
                 const cell = grid.getCellByColumn(0, 'age');
                 const cellDomNumber = fixture.debugElement.queryAll(By.css(CELL_CSS_CLASS))[1];
 
@@ -352,7 +352,7 @@ describe('IgxGrid - Cell component', () => {
                 expect(parseFloat(cell.value)).toBe(expectedValue);
             });
 
-            it('edit template should be accourding column data type -- boolean', () => {
+            it('edit template should be according column data type -- boolean', () => {
                 const cell = grid.getCellByColumn(0, 'isActive');
                 const cellDomBoolean = fixture.debugElement.queryAll(By.css(CELL_CSS_CLASS))[2];
 
@@ -375,7 +375,7 @@ describe('IgxGrid - Cell component', () => {
                 expect(cell.value).toBe(false);
             });
 
-            it('edit template should be accourding column data type -- date', () => {
+            it('edit template should be according column data type -- date', () => {
                 const cell = grid.getCellByColumn(0, 'birthday');
                 const cellDomDate = fixture.debugElement.queryAll(By.css(CELL_CSS_CLASS))[3];
                 const selectedDate = new Date('04/12/2017');
@@ -545,7 +545,6 @@ describe('IgxGrid - Cell component', () => {
                 expect(cell.inEditMode).toBe(false);
                 expect(cell.value).toBe(cellValue);
             }));
-
 
             it('edit mode - leaves cell in edit mode on scroll', (async () => {
                 const cell = grid.getCellByColumn(0, 'firstName');
@@ -728,6 +727,25 @@ describe('IgxGrid - Cell component', () => {
                 expect(4).toBe(editCellID.columnID);
                 expect(1).toBe(editCellID.rowIndex);
             }));
+        });
+
+        fit(`Should exit edit mode when rowEditable changes`, () => {
+            const fixture = TestBed.createComponent(CellEditingTestComponent);
+            fixture.detectChanges();
+            const grid = fixture.componentInstance.grid;
+
+            const cell = grid.getCellByColumn(0, 'personNumber');
+            expect(cell.editMode).toBeFalsy();
+
+            cell.setEditMode(true);
+            fixture.detectChanges();
+
+            expect(cell.editMode).toBeTruthy();
+
+            grid.rowEditable = true;
+            fixture.detectChanges();
+
+            expect(cell.editMode).toBeFalsy();
         });
     });
 

--- a/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
@@ -729,7 +729,7 @@ describe('IgxGrid - Cell component', () => {
             }));
         });
 
-        fit(`Should exit edit mode when rowEditable changes`, () => {
+        it(`Should exit edit mode when rowEditable changes`, () => {
             const fixture = TestBed.createComponent(CellEditingTestComponent);
             fixture.detectChanges();
             const grid = fixture.componentInstance.grid;


### PR DESCRIPTION
First update the grid state then change the `rowEditable`. Finally call `markForCheck` in order to update the grid UI.

Closes #5233

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 