### PR TITLE
Calculate column editable depending on rowEditable, 7.3.x

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/column.component.ts
@@ -116,8 +116,13 @@ export class IgxColumnComponent implements AfterContentInit {
      */
     @Input()
     get editable(): boolean {
-        const editableInRowEdit = this.grid && this.grid.rowEditable && this.field !== this.grid.primaryKey;
-        return this._editable !== undefined ? this._editable : editableInRowEdit;
+        let result = false;
+        if (this._editable !== undefined) {
+            result = this._editable;
+        } else {
+            result = this.grid && this.grid.rowEditable && this.field !== this.grid.primaryKey;
+        }
+        return result;
     }
     /**
      * Sets whether the column is editable.

--- a/projects/igniteui-angular/src/lib/grids/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/column.component.ts
@@ -107,18 +107,31 @@ export class IgxColumnComponent implements AfterContentInit {
     @Input()
     public groupable = false;
     /**
-     * Sets/gets whether the column is editable.
+     * Gets whether the column is editable.
      * Default value is `false`.
      * ```typescript
      * let isEditable = this.column.editable;
+     * ```
+     * @memberof IgxColumnComponent
+     */
+    @Input()
+    get editable(): boolean {
+        const editableInRowEdit = this.grid && this.grid.rowEditable && this.field !== this.grid.primaryKey;
+        return this._editable !== undefined ? this._editable : editableInRowEdit;
+    }
+    /**
+     * Sets whether the column is editable.
+     * ```typescript
+     * this.column.editable = true;
      * ```
      * ```html
      * <igx-column [editable] = "true"></igx-column>
      * ```
      * @memberof IgxColumnComponent
      */
-    @Input()
-    public editable = null;
+    set editable(editable: boolean) {
+        this._editable = editable;
+    }
     /**
      * Sets/gets whether the column is filterable.
      * Default value is `true`.
@@ -1029,6 +1042,10 @@ export class IgxColumnComponent implements AfterContentInit {
      *@hidden
      */
     protected _hasSummary = false;
+    /**
+     * @hidden
+     */
+    protected _editable: boolean;
     /**
      *@hidden
      */

--- a/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.component.ts
@@ -4459,7 +4459,6 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
         collection.forEach((column: IgxColumnComponent) => {
             column.grid = this;
             column.defaultWidth = this.columnWidth;
-            this.setColumnEditState(column);
 
             if (cb) {
                 cb(column);
@@ -4472,14 +4471,6 @@ export abstract class IgxGridBaseComponent extends DisplayDensityBase implements
             collection.forEach((column: IgxColumnComponent) => {
                 column.populateVisibleIndexes();
             });
-        }
-    }
-
-    private setColumnEditState(column: IgxColumnComponent) {
-        // When rowEditable is true, then all columns, with defined field, excluding priamaryKey, are set to editable by default.
-        if (this.rowEditable && column.editable === null &&
-            column.field && column.field !== this.primaryKey) {
-            column.editable = this.rowEditable;
         }
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -3350,7 +3350,7 @@ describe('IgxGrid Component Tests', () => {
         });
 
         describe('Row Editing - Column editable property', () => {
-            fit('Default column editable value is correct, when row editing is enabled', fakeAsync(() => {
+            it('Default column editable value is correct, when row editing is enabled', fakeAsync(() => {
                 const fixture = TestBed.createComponent(IgxGridRowEditingWithoutEditableColumnsComponent);
                 fixture.detectChanges();
                 tick();
@@ -3381,7 +3381,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(columns[4].editable).toBeFalsy();  // column.editable set to false
             }));
 
-            fit(`Default column editable value is correct, when row edititng is disabled`, fakeAsync(() => {
+            it(`Default column editable value is correct, when row edititng is disabled`, fakeAsync(() => {
                 const fixture = TestBed.createComponent(IgxGridTestComponent);
                 fixture.componentInstance.columns.push({ field: 'ID', header: 'ID', dataType: 'number', width: null, hasSummary: false });
                 fixture.componentInstance.data = [

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1604,6 +1604,7 @@ describe('IgxGrid Component Tests', () => {
         beforeEach(async(() => {
             TestBed.configureTestingModule({
                 declarations: [
+                    IgxGridTestComponent,
                     IgxBasicGridRowEditingComponent,
                     IgxGridRowEditingComponent,
                     IgxGridRowEditingWithoutEditableColumnsComponent,
@@ -3349,19 +3350,61 @@ describe('IgxGrid Component Tests', () => {
         });
 
         describe('Row Editing - Column editable property', () => {
-            it('Default column editable value is true, when row editing is enabled', fakeAsync(() => {
+            fit('Default column editable value is correct, when row editing is enabled', fakeAsync(() => {
                 const fixture = TestBed.createComponent(IgxGridRowEditingWithoutEditableColumnsComponent);
                 fixture.detectChanges();
                 tick();
 
                 const grid = fixture.componentInstance.grid;
 
-                const columns: IgxColumnComponent[] = grid.columnList.toArray();
-                expect(columns[0].editable).toBeFalsy();
-                expect(columns[1].editable).toBeFalsy();
-                expect(columns[2].editable).toBeTruthy();
-                expect(columns[3].editable).toBeTruthy();
-                expect(columns[4].editable).toBeFalsy();
+                let columns: IgxColumnComponent[] = grid.columnList.toArray();
+                expect(columns[0].editable).toBeTruthy(); // column.editable not set
+                expect(columns[1].editable).toBeFalsy(); // column.editable not set. Primary column
+                expect(columns[2].editable).toBeTruthy(); // column.editable set to true
+                expect(columns[3].editable).toBeTruthy(); // column.editable not set
+                expect(columns[4].editable).toBeFalsy();  // column.editable set to false
+
+                grid.rowEditable = false;
+                columns = grid.columnList.toArray();
+                expect(columns[0].editable).toBeFalsy(); // column.editable not set
+                expect(columns[1].editable).toBeFalsy(); // column.editable not set. Primary column
+                expect(columns[2].editable).toBeTruthy(); // column.editable set to true
+                expect(columns[3].editable).toBeFalsy(); // column.editable not set
+                expect(columns[4].editable).toBeFalsy();  // column.editable set to false
+
+                grid.rowEditable = true;
+                columns = grid.columnList.toArray();
+                expect(columns[0].editable).toBeTruthy(); // column.editable not set
+                expect(columns[1].editable).toBeFalsy(); // column.editable not set. Primary column
+                expect(columns[2].editable).toBeTruthy(); // column.editable set to true
+                expect(columns[3].editable).toBeTruthy(); // column.editable not set
+                expect(columns[4].editable).toBeFalsy();  // column.editable set to false
+            }));
+
+            fit(`Default column editable value is correct, when row edititng is disabled`, fakeAsync(() => {
+                const fixture = TestBed.createComponent(IgxGridTestComponent);
+                fixture.componentInstance.columns.push({ field: 'ID', header: 'ID', dataType: 'number', width: null, hasSummary: false });
+                fixture.componentInstance.data = [
+                    { ID: 0, index: 0, value: 0},
+                    { ID: 1, index: 1, value: 1},
+                    { ID: 2, index: 2, value: 2},
+                ];
+                const grid = fixture.componentInstance.grid;
+                grid.primaryKey = 'ID';
+
+                fixture.detectChanges();
+                tick();
+
+                let columns: IgxColumnComponent[] = grid.columnList.toArray();
+                expect(columns[0].editable).toBeFalsy(); // column.editable not set
+                expect(columns[1].editable).toBeFalsy(); // column.editable not set
+                expect(columns[2].editable).toBeFalsy(); // column.editable not set. Primary column
+
+                grid.rowEditable = true;
+                columns = grid.columnList.toArray();
+                expect(columns[0].editable).toBeTruthy(); // column.editable not set
+                expect(columns[1].editable).toBeTruthy(); // column.editable not set
+                expect(columns[2].editable).toBeFalsy();  // column.editable not set. Primary column
             }));
         });
 


### PR DESCRIPTION
Default value of `column.editable` was null. This was not correct. Now default value of inner field is `undefined`. The getter now checks if `editable` is set. If so returns what is set by the developer. If not returns what is set for `rowEditable` (if the column is primary column returns false in this case).

Closes #5022

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 