### PR TITLE
fix(themes): light/dark mixins don't respect custom colors

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/themes/_index.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/themes/_index.scss
@@ -275,17 +275,22 @@
     $exclude: (),
     $legacy-support: true
 ) {
-    $primary: igx-color($palette, 'primary');
-    $secondary: igx-color($palette, 'secondary');
+    $grays: igx-color($palette, 'grays');
     $surface: igx-color($palette, 'surface');
 
+    $light-palette: igx-palette(
+        $primary: igx-color($palette, 'primary'),
+        $secondary: igx-color($palette, 'secondary'),
+        $info: igx-color($palette, 'info'),
+        $success: igx-color($palette, 'success'),
+        $warn: igx-color($palette, 'warn'),
+        $error: igx-color($palette, 'error'),
+        $surface: if($surface != #fff, $surface, #fff),
+        $grays: if($grays != rgba(0, 0, 0, .38), $grays, #000),
+    );
+
     @include igx-theme(
-        $palette: igx-palette(
-            $primary,
-            $secondary,
-            $surface: if($surface != #fff, $surface, #fff),
-            $grays: #000
-        ),
+        $palette: $light-palette,
         $schema: $light-schema,
         $legacy-support: $legacy-support,
         $exclude: $exclude
@@ -301,17 +306,22 @@
     $exclude: (),
     $legacy-support: true
 ) {
-    $primary: igx-color($palette, 'primary');
-    $secondary: igx-color($palette, 'secondary');
+    $grays: igx-color($palette, 'grays');
     $surface: igx-color($palette, 'surface');
 
+    $dark-palette: igx-palette(
+        $primary: igx-color($palette, 'primary'),
+        $secondary: igx-color($palette, 'secondary'),
+        $info: igx-color($palette, 'info'),
+        $success: igx-color($palette, 'success'),
+        $warn: igx-color($palette, 'warn'),
+        $error: igx-color($palette, 'error'),
+        $surface: if($surface != #fff, $surface, #222),
+        $grays: if($grays != rgba(0, 0, 0, .38), $grays, #fff),
+    );
+
     @include igx-theme(
-        $palette: igx-palette(
-            $primary,
-            $secondary,
-            $surface: if($surface != #fff, $surface, #222),
-            $grays: #fff
-        ),
+        $palette: $dark-palette,
         $schema: $dark-schema,
         $legacy-support: $legacy-support,
         $exclude: $exclude


### PR DESCRIPTION
igx-dark-theme and igx-light-theme mixins don't respect custom success,
error, warn, and info colors

Closes #5372 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 