### PR TITLE
Disallow editing or primary column in grid with transactions, 7.3.x

### DIFF
--- a/projects/igniteui-angular/src/lib/core/grid-selection.ts
+++ b/projects/igniteui-angular/src/lib/core/grid-selection.ts
@@ -175,7 +175,7 @@ export class IgxGridCRUDService {
                 return;
             }
 
-            if (this.row && !this.sameRow(this.cell.id.rowIndex)) {
+            if (this.row && !this.sameRow(this.cell.rowIndex)) {
                 this.grid.endEdit(true);
                 this.cell = this.createCell(cell);
                 this.beginRowEdit();

--- a/projects/igniteui-angular/src/lib/core/grid-selection.ts
+++ b/projects/igniteui-angular/src/lib/core/grid-selection.ts
@@ -105,8 +105,8 @@ export class IgxGridCRUDService {
         return new IgxRow(cell.id.rowID, cell.rowIndex, cell.rowData);
     }
 
-    sameRow(rowID): boolean {
-        return this.row && this.row.id === rowID;
+    sameRow(rowIndex): boolean {
+        return this.row && this.row.index === rowIndex;
     }
 
     sameCell(cell: IgxCell): boolean {
@@ -175,7 +175,7 @@ export class IgxGridCRUDService {
                 return;
             }
 
-            if (this.row && !this.sameRow(this.cell.id.rowID)) {
+            if (this.row && !this.sameRow(this.cell.id.rowIndex)) {
                 this.grid.endEdit(true);
                 this.cell = this.createCell(cell);
                 this.beginRowEdit();

--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -594,7 +594,6 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy {
         const editableCell = this.crudService.cell;
         const editMode = !!(crud.row || crud.cell);
 
-
         if (this.editable && editMode && !this.row.deleted) {
             if (editableCell) {
                 this.gridAPI.update_cell(editableCell, editableCell.editValue);
@@ -605,9 +604,9 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy {
             return;
         }
 
-        if (editableCell && crud.sameRow(this.cellID.rowIndex)) {
+        if (editableCell && crud.sameRow(editableCell.rowIndex)) {
             this.gridAPI.submit_value();
-        } else if (editMode && !crud.sameRow(this.cellID.rowIndex)) {
+        } else if (editMode && !crud.sameRow(editableCell.rowIndex)) {
             this.grid.endEdit(true);
         }
     }
@@ -989,14 +988,7 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy {
         }
 
         if (this.editMode) {
-            const v = this.crudService.cell;
-            const args = {
-                cellID: v.id,
-                rowID: v.id.rowID,
-                oldValue: v.value,
-                newValue: v.editValue,
-                cancel: false
-            } as IGridEditEventArgs;
+            const args = this.crudService.cell.createEditEventArgs();
             this.grid.onCellEditCancel.emit(args);
             if (args.cancel) {
                 return;

--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -604,9 +604,9 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy {
             return;
         }
 
-        if (editableCell && crud.sameRow(editableCell.rowIndex)) {
+        if (editableCell && crud.sameRow(this.rowIndex)) {
             this.gridAPI.submit_value();
-        } else if (editMode && !crud.sameRow(editableCell.rowIndex)) {
+        } else if (editMode && !crud.sameRow(this.rowIndex)) {
             this.grid.endEdit(true);
         }
     }

--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -605,9 +605,9 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy {
             return;
         }
 
-        if (editableCell && crud.sameRow(this.cellID.rowID)) {
+        if (editableCell && crud.sameRow(this.cellID.rowIndex)) {
             this.gridAPI.submit_value();
-        } else if (editMode && !crud.sameRow(this.cellID.rowID)) {
+        } else if (editMode && !crud.sameRow(this.cellID.rowIndex)) {
             this.grid.endEdit(true);
         }
     }

--- a/projects/igniteui-angular/src/lib/grids/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/column.component.ts
@@ -116,19 +116,22 @@ export class IgxColumnComponent implements AfterContentInit {
      */
     @Input()
     get editable(): boolean {
-        // if rowEditable is set to true or transaction service is provided grid has transactions
-        const hasTransactions = this.grid && (this.grid.rowEditable || this.grid.transactions.enabled);
+        // Updating the primary key when grid has transactions should not be
+        // allowed. We are aggregating the transactions by primary key. If one
+        // change the primary key the transaction state for the related record
+        // will be corrupted. This is why if this is primary kew column and
+        // grid has transactions we return false here.
+        const hasGrid = this.grid !== undefined;
+        const rowEditable = hasGrid && this.grid.rowEditable;
+        const hasTransactions = hasGrid && this.grid.transactions.enabled;
 
-        if (this.isPrimaryColumn && hasTransactions) {
-            // if this is primary column and grid has transactions column should not be editable,
+        if (this.isPrimaryColumn && (rowEditable || hasTransactions)) {
             return false;
         } else {
-            // if this is not primary column with transactions return what user have set
-            // or if row is editable
             if (this._editable !== undefined) {
                 return this._editable;
             } else {
-                return this.grid && this.grid.rowEditable;
+                return rowEditable;
             }
         }
     }

--- a/projects/igniteui-angular/src/lib/grids/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/column.component.ts
@@ -116,23 +116,19 @@ export class IgxColumnComponent implements AfterContentInit {
      */
     @Input()
     get editable(): boolean {
-        // Updating the primary key when grid has transactions should not be
-        // allowed. We are aggregating the transactions by primary key. If one
-        // change the primary key the transaction state for the related record
-        // will be corrupted. This is why if this is primary kew column and
-        // grid has transactions we return false here.
-        const hasGrid = this.grid !== undefined;
-        const rowEditable = hasGrid && this.grid.rowEditable;
-        const hasTransactions = hasGrid && this.grid.transactions.enabled;
+        // Updating the primary key when grid has transactions (incl. row edit)
+        // should not be allowed, as that can corrupt transaction state.
+        const rowEditable = this.grid && this.grid.rowEditable;
+        const hasTransactions = this.grid && this.grid.transactions.enabled;
 
         if (this.isPrimaryColumn && (rowEditable || hasTransactions)) {
             return false;
+        }
+
+        if (this._editable !== undefined) {
+            return this._editable;
         } else {
-            if (this._editable !== undefined) {
-                return this._editable;
-            } else {
-                return rowEditable;
-            }
+            return rowEditable;
         }
     }
     /**

--- a/projects/igniteui-angular/src/lib/grids/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/column.component.ts
@@ -116,21 +116,21 @@ export class IgxColumnComponent implements AfterContentInit {
      */
     @Input()
     get editable(): boolean {
-        let result = false;
-
         // if rowEditable is set to true or transaction service is provided grid has transactions
         const hasTransactions = this.grid && (this.grid.rowEditable || this.grid.transactions.enabled);
 
-        // if this is primary column and grid has transactions column should not be editable,
-        // result should be false
-        if (!(this.isPrimaryColumn && hasTransactions)) {
+        if (this.isPrimaryColumn && hasTransactions) {
+            // if this is primary column and grid has transactions column should not be editable,
+            return false;
+        } else {
+            // if this is not primary column with transactions return what user have set
+            // or if row is editable
             if (this._editable !== undefined) {
-                result = this._editable;
+                return this._editable;
             } else {
-                result = this.grid && this.grid.rowEditable;
+                return this.grid && this.grid.rowEditable;
             }
         }
-        return result;
     }
     /**
      * Sets whether the column is editable.

--- a/projects/igniteui-angular/src/lib/grids/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/column.component.ts
@@ -1063,7 +1063,7 @@ export class IgxColumnComponent implements AfterContentInit {
      * @hidden
      */
     protected get isPrimaryColumn(): boolean {
-        return this.field !== undefined && this.field === this.grid.primaryKey;
+        return this.field !== undefined && this.grid !== undefined && this.field === this.grid.primaryKey;
     }
     /**
      *@hidden

--- a/projects/igniteui-angular/src/lib/grids/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/column.component.ts
@@ -107,18 +107,44 @@ export class IgxColumnComponent implements AfterContentInit {
     @Input()
     public groupable = false;
     /**
-     * Sets/gets whether the column is editable.
+     * Gets whether the column is editable.
      * Default value is `false`.
      * ```typescript
      * let isEditable = this.column.editable;
+     * ```
+     * @memberof IgxColumnComponent
+     */
+    @Input()
+    get editable(): boolean {
+        let result = false;
+
+        // if rowEditable is set to true or transaction service is provided grid has transactions
+        const hasTransactions = this.grid && (this.grid.rowEditable || this.grid.transactions.enabled);
+
+        // if this is primary column and grid has transactions column should not be editable,
+        // result should be false
+        if (!(this.isPrimaryColumn && hasTransactions)) {
+            if (this._editable !== undefined) {
+                result = this._editable;
+            } else {
+                result = this.grid && this.grid.rowEditable;
+            }
+        }
+        return result;
+    }
+    /**
+     * Sets whether the column is editable.
+     * ```typescript
+     * this.column.editable = true;
      * ```
      * ```html
      * <igx-column [editable] = "true"></igx-column>
      * ```
      * @memberof IgxColumnComponent
      */
-    @Input()
-    public editable = null;
+    set editable(editable: boolean) {
+        this._editable = editable;
+    }
     /**
      * Sets/gets whether the column is filterable.
      * Default value is `true`.
@@ -1029,6 +1055,16 @@ export class IgxColumnComponent implements AfterContentInit {
      *@hidden
      */
     protected _hasSummary = false;
+    /**
+     * @hidden
+     */
+    protected _editable: boolean;
+    /**
+     * @hidden
+     */
+    protected get isPrimaryColumn(): boolean {
+        return this.field !== undefined && this.field === this.grid.primaryKey;
+    }
     /**
      *@hidden
      */

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-mrl-keyboard-nav.spec.ts
@@ -2880,7 +2880,7 @@ describe('IgxGrid Multi Row Layout - Keyboard navigation', () => {
         await wait(100);
         fix.detectChanges();
 
-        targetCell = grid.getCellByColumn(0, 'ID');
+        targetCell = grid.getCellByColumn(0, 'PostalCode');
         expect(targetCell.focused).toBe(true);
     });
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
@@ -711,7 +711,6 @@ describe('IgxGrid - Summaries', () => {
             await wait(30);
             fixture.detectChanges();
             const grid = fixture.componentInstance.grid;
-            grid.getColumnByName('ID').editable = true;
             grid.getColumnByName('ParentID').editable = true;
             fixture.detectChanges();
             grid.rowEditable = true;
@@ -735,9 +734,6 @@ describe('IgxGrid - Summaries', () => {
 
             const editTemplate = fixture.debugElement.query(By.css('input[type=\'number\']'));
             UIInteractions.sendInput(editTemplate, 87);
-            fixture.detectChanges();
-
-            UIInteractions.triggerKeyDownEvtUponElem('tab', cell.nativeElement, true, false, true);
             await wait(50);
             fixture.detectChanges();
 
@@ -745,8 +741,7 @@ describe('IgxGrid - Summaries', () => {
             HelperUtils.verifyColumnSummaries(summaryRow, 1,
                 ['Count', 'Min', 'Max', 'Sum', 'Avg'], ['1', '17', '17', '17', '17']);
 
-            const idCell = grid.getCellByColumn(1, 'ID');
-            UIInteractions.triggerKeyDownEvtUponElem('enter', idCell.nativeElement, true);
+            UIInteractions.triggerKeyDownEvtUponElem('enter', cell.nativeElement, true);
             await wait(50);
             fixture.detectChanges();
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1864,6 +1864,47 @@ describe('IgxGrid Component Tests', () => {
                 expect(cell.value).toEqual('IG');
 
             }));
+
+            fit(`Should not update row when primary key is edited and tab is pressed`, fakeAsync(() => {
+                const fix = TestBed.createComponent(IgxGridRowEditingComponent);
+                const grid = fix.componentInstance.grid;
+                fix.detectChanges();
+                tick();
+
+                spyOn(grid, 'endEdit').and.callThrough();
+                grid.columnList.forEach(c => {
+                    c.editable = true;
+                });
+
+                let cell = grid.getCellByColumn(0, 'ProductID');
+                cell.setEditMode(true);
+                fix.detectChanges();
+                tick();
+
+                expect(grid.crudService.cell).toBeDefined();
+                expect(grid.crudService.cell.id.rowIndex).toBe(0);
+                expect(grid.crudService.cell.id.columnID).toBe(0);
+
+                cell.editValue = 999;
+                UIInteractions.triggerKeyDownEvtUponElem('tab', cell.nativeElement, true);
+                fix.detectChanges();
+                tick();
+
+                expect(grid.crudService.cell).toBeDefined();
+                expect(grid.crudService.cell.id.rowIndex).toBe(0);
+                expect(grid.crudService.cell.id.columnID).toBe(1);
+                expect(grid.endEdit).toHaveBeenCalledTimes(0);
+
+                cell = grid.getCellByColumn(0, grid.crudService.cell.column.field);
+                UIInteractions.triggerKeyDownEvtUponElem('tab', cell.nativeElement, true);
+                fix.detectChanges();
+                tick();
+
+                expect(grid.crudService.cell).toBeDefined();
+                expect(grid.crudService.cell.id.rowIndex).toBe(0);
+                expect(grid.crudService.cell.id.columnID).toBe(2);
+                expect(grid.endEdit).toHaveBeenCalledTimes(0);
+            }));
         });
 
         describe('Row Editing - Navigation - Keyboard', () => {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1545,7 +1545,7 @@ describe('IgxGrid Component Tests', () => {
         it(`Should be able to add a row if another row is in edit mode`, fakeAsync(() => {
             const fixture = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
             fixture.detectChanges();
-            tick();
+            tick(16);
 
             const grid = fixture.componentInstance.grid;
             const rowCount = grid.rowList.length;
@@ -1568,7 +1568,7 @@ describe('IgxGrid Component Tests', () => {
                 OrderDate: new Date()
             });
             fixture.detectChanges();
-            tick();
+            tick(16);
 
             expect(grid.rowList.length).toBeGreaterThan(rowCount);
         }));
@@ -1576,13 +1576,13 @@ describe('IgxGrid Component Tests', () => {
         it(`Should be able to add a row if a cell is in edit mode`, fakeAsync(() => {
             const fixture = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
             fixture.detectChanges();
-            tick();
+            tick(16);
 
             const grid = fixture.componentInstance.grid;
             const rowCount = grid.rowList.length;
             const cell = grid.getCellByColumn(0, 'ProductName');
             cell.setEditMode(true);
-            tick();
+            tick(16);
             fixture.detectChanges();
 
             grid.addRow({
@@ -1593,7 +1593,7 @@ describe('IgxGrid Component Tests', () => {
                 OrderDate: new Date()
             });
             fixture.detectChanges();
-            tick();
+            tick(16);
 
             expect(grid.rowList.length).toBeGreaterThan(rowCount);
         }));

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -2658,8 +2658,9 @@ describe('IgxGrid Component Tests', () => {
                 expect(gridAPI.submit_value).not.toHaveBeenCalled();
                 expect(gridAPI.escape_editMode).toHaveBeenCalled();
             }));
-
-            it(`Should exit row editing when clicking on a cell from a deleted row`, fakeAsync(() => {
+for (let index = 0; index < 100; index++) {
+            fit(`Should exit row editing when clicking on a cell from a deleted row`, fakeAsync(() => {
+                console.log(`test ${index+1}/100`);
                 const fixture = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
                 fixture.detectChanges();
 
@@ -2684,6 +2685,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(targetCell.selected).toBeTruthy();
                 expect(firstCell.selected).toBeFalsy();
             }));
+        }
         });
 
         describe('Row Editing - Paging', () => {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1826,10 +1826,10 @@ describe('IgxGrid Component Tests', () => {
                 expect(editRowTop - bannerBottom).toBeLessThan(2);
             }));
 
-            xit('Should add correct class to the edited row', (async () => {
-                // NOT APPLICABLE, SINCE GRID DOES NOT HAVE TRANSACTIONS
-                const fix = TestBed.createComponent(IgxGridRowEditingComponent);
+            fit('Should add correct class to the edited row', fakeAsync(() => {
+                const fix = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
                 fix.detectChanges();
+                tick();
 
                 const grid = fix.componentInstance.grid;
                 const cell = grid.getCellByColumn(0, 'ProductName');
@@ -1837,11 +1837,13 @@ describe('IgxGrid Component Tests', () => {
                 expect(row.classList).not.toContain('igx-grid__tr--edited');
 
                 cell.setEditMode(true);
-                // expect(rowEditBanned) to be visible
-                cell.update('IG');
-                cell.setEditMode(false);
+                fix.detectChanges();
+                tick();
 
-                await wait(DEBOUNCETIME);
+                cell.editValue = 'IG';
+                grid.endEdit(true);
+                fix.detectChanges();
+                tick();
 
                 expect(row.classList).toContain('igx-grid__tr--edited');
             }));

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1867,45 +1867,52 @@ describe('IgxGrid Component Tests', () => {
 
             }));
 
-            it(`Should not update row when primary key is edited and tab is pressed`, fakeAsync(() => {
+            it(`Should correctly get column.editable for grid with no transactions`, fakeAsync(() => {
                 const fix = TestBed.createComponent(IgxGridRowEditingComponent);
                 const grid = fix.componentInstance.grid;
                 fix.detectChanges();
                 tick();
 
-                spyOn(grid, 'endEdit').and.callThrough();
                 grid.columnList.forEach(c => {
                     c.editable = true;
                 });
 
-                let cell = grid.getCellByColumn(0, 'ProductID');
-                cell.setEditMode(true);
+                const primaryKeyColumn = grid.columnList.find(c => c.field === grid.primaryKey);
+                const nonPrimaryKeyColumn = grid.columnList.find(c => c.field !== grid.primaryKey);
+                expect(primaryKeyColumn).toBeDefined();
+                expect(nonPrimaryKeyColumn).toBeDefined();
+
+                grid.rowEditable = false;
+                expect(primaryKeyColumn.editable).toBeTruthy();
+                expect(nonPrimaryKeyColumn.editable).toBeTruthy();
+
+                grid.rowEditable = true;
+                expect(primaryKeyColumn.editable).toBeFalsy();
+                expect(nonPrimaryKeyColumn.editable).toBeTruthy();
+            }));
+
+            it(`Should correctly get column.editable for grid with transactions`, fakeAsync(() => {
+                const fix = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
+                const grid = fix.componentInstance.grid;
                 fix.detectChanges();
                 tick();
 
-                expect(grid.crudService.cell).toBeDefined();
-                expect(grid.crudService.cell.id.rowIndex).toBe(0);
-                expect(grid.crudService.cell.id.columnID).toBe(0);
+                grid.columnList.forEach(c => {
+                    c.editable = true;
+                });
 
-                cell.editValue = 999;
-                UIInteractions.triggerKeyDownEvtUponElem('tab', cell.nativeElement, true);
-                fix.detectChanges();
-                tick();
+                const primaryKeyColumn = grid.columnList.find(c => c.field === grid.primaryKey);
+                const nonPrimaryKeyColumn = grid.columnList.find(c => c.field !== grid.primaryKey);
+                expect(primaryKeyColumn).toBeDefined();
+                expect(nonPrimaryKeyColumn).toBeDefined();
 
-                expect(grid.crudService.cell).toBeDefined();
-                expect(grid.crudService.cell.id.rowIndex).toBe(0);
-                expect(grid.crudService.cell.id.columnID).toBe(1);
-                expect(grid.endEdit).toHaveBeenCalledTimes(0);
+                grid.rowEditable = false;
+                expect(primaryKeyColumn.editable).toBeFalsy();
+                expect(nonPrimaryKeyColumn.editable).toBeTruthy();
 
-                cell = grid.getCellByColumn(0, grid.crudService.cell.column.field);
-                UIInteractions.triggerKeyDownEvtUponElem('tab', cell.nativeElement, true);
-                fix.detectChanges();
-                tick();
-
-                expect(grid.crudService.cell).toBeDefined();
-                expect(grid.crudService.cell.id.rowIndex).toBe(0);
-                expect(grid.crudService.cell.id.columnID).toBe(2);
-                expect(grid.endEdit).toHaveBeenCalledTimes(0);
+                grid.rowEditable = true;
+                expect(primaryKeyColumn.editable).toBeFalsy();
+                expect(nonPrimaryKeyColumn.editable).toBeTruthy();
             }));
         });
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -2658,8 +2658,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(gridAPI.submit_value).not.toHaveBeenCalled();
                 expect(gridAPI.escape_editMode).toHaveBeenCalled();
             }));
-for (let index = 0; index < 100; index++) {
-            fit(`Should exit row editing when clicking on a cell from a deleted row`, fakeAsync(() => {
+            it(`Should exit row editing when clicking on a cell from a deleted row`, fakeAsync(() => {
                 console.log(`test ${index+1}/100`);
                 const fixture = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
                 fixture.detectChanges();
@@ -2685,7 +2684,6 @@ for (let index = 0; index < 100; index++) {
                 expect(targetCell.selected).toBeTruthy();
                 expect(firstCell.selected).toBeFalsy();
             }));
-        }
         });
 
         describe('Row Editing - Paging', () => {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1826,7 +1826,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(editRowTop - bannerBottom).toBeLessThan(2);
             }));
 
-            fit('Should add correct class to the edited row', fakeAsync(() => {
+            it('Should add correct class to the edited row', fakeAsync(() => {
                 const fix = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
                 fix.detectChanges();
                 tick();
@@ -1867,7 +1867,7 @@ describe('IgxGrid Component Tests', () => {
 
             }));
 
-            fit(`Should not update row when primary key is edited and tab is pressed`, fakeAsync(() => {
+            it(`Should not update row when primary key is edited and tab is pressed`, fakeAsync(() => {
                 const fix = TestBed.createComponent(IgxGridRowEditingComponent);
                 const grid = fix.componentInstance.grid;
                 fix.detectChanges();

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -2659,7 +2659,6 @@ describe('IgxGrid Component Tests', () => {
                 expect(gridAPI.escape_editMode).toHaveBeenCalled();
             }));
             it(`Should exit row editing when clicking on a cell from a deleted row`, fakeAsync(() => {
-                console.log(`test ${index+1}/100`);
                 const fixture = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
                 fixture.detectChanges();
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1545,7 +1545,7 @@ describe('IgxGrid Component Tests', () => {
         it(`Should be able to add a row if another row is in edit mode`, fakeAsync(() => {
             const fixture = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
             fixture.detectChanges();
-            tick(16);
+            tick();
 
             const grid = fixture.componentInstance.grid;
             const rowCount = grid.rowList.length;
@@ -1568,7 +1568,7 @@ describe('IgxGrid Component Tests', () => {
                 OrderDate: new Date()
             });
             fixture.detectChanges();
-            tick(16);
+            tick();
 
             expect(grid.rowList.length).toBeGreaterThan(rowCount);
         }));
@@ -1576,13 +1576,13 @@ describe('IgxGrid Component Tests', () => {
         it(`Should be able to add a row if a cell is in edit mode`, fakeAsync(() => {
             const fixture = TestBed.createComponent(IgxGridRowEditingTransactionComponent);
             fixture.detectChanges();
-            tick(16);
+            tick();
 
             const grid = fixture.componentInstance.grid;
             const rowCount = grid.rowList.length;
             const cell = grid.getCellByColumn(0, 'ProductName');
-            cell.inEditMode = true;
-            tick(16);
+            cell.setEditMode(true);
+            tick();
             fixture.detectChanges();
 
             grid.addRow({
@@ -1593,7 +1593,7 @@ describe('IgxGrid Component Tests', () => {
                 OrderDate: new Date()
             });
             fixture.detectChanges();
-            tick(16);
+            tick();
 
             expect(grid.rowList.length).toBeGreaterThan(rowCount);
         }));
@@ -1761,7 +1761,7 @@ describe('IgxGrid Component Tests', () => {
 
                 const grid = fix.componentInstance.grid;
                 const cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 const editRow = cell.row.nativeElement;
                 const banner = document.getElementsByClassName('igx-overlay__content')[0] as HTMLElement;
                 tick();
@@ -1784,7 +1784,7 @@ describe('IgxGrid Component Tests', () => {
 
                 const grid = fix.componentInstance.grid;
                 const cell = grid.getCellByColumn(lastItemIndex, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 const editRow = cell.row.nativeElement;
                 const banner = document.getElementsByClassName('igx-overlay__content')[0] as HTMLElement;
@@ -1810,7 +1810,7 @@ describe('IgxGrid Component Tests', () => {
                 fix.detectChanges();
 
                 const cell = grid.getCellByColumn(grid.data.length - 1, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 const editRow = cell.row.nativeElement;
                 const banner = document.getElementsByClassName('igx-overlay__content')[0] as HTMLElement;
@@ -1836,10 +1836,10 @@ describe('IgxGrid Component Tests', () => {
                 const row: HTMLElement = grid.getRowByIndex(0).nativeElement;
                 expect(row.classList).not.toContain('igx-grid__tr--edited');
 
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 // expect(rowEditBanned) to be visible
                 cell.update('IG');
-                cell.inEditMode = false;
+                cell.setEditMode(false);
 
                 await wait(DEBOUNCETIME);
 
@@ -1854,13 +1854,13 @@ describe('IgxGrid Component Tests', () => {
                 const cell = grid.getCellByColumn(0, 'ProductName');
                 const row: HTMLElement = grid.getRowByIndex(0).nativeElement;
 
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 cell.update('IG');
-                cell.inEditMode = false;
+                cell.setEditMode(false);
 
                 await wait(DEBOUNCETIME);
 
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 expect(cell.value).toEqual('IG');
 
             }));
@@ -2069,7 +2069,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT focused cell to be 'Released'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Released');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 // from pinned to unpinned
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
@@ -2079,7 +2079,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT focused cell to be 'ReleaseDate'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('ReleaseDate');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 // from unpinned to pinned
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
@@ -2089,7 +2089,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT edited cell to be 'Released'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Released');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
             }));
 
             it(`Should skip non-editable columns when column hiding is enabled`, fakeAsync(() => {
@@ -2107,7 +2107,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT focused cell to be 'Released'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Released');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 // jump over 1 hidden, editable
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
@@ -2117,7 +2117,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT focused cell to be 'Items'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Items');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 // jump over 1 hidden, editable
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
@@ -2127,7 +2127,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT edited cell to be 'Released'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Released');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 // jump over 3 hidden, both editable and not
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
@@ -2137,7 +2137,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT edited cell to be 'Downloads'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Downloads');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
             }));
 
             it(`Should skip non-editable columns when column pinning & hiding is enabled`, fakeAsync(() => {
@@ -2156,7 +2156,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT focused cell to be 'Released'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Released');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 // jump from pinned to unpinned
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
@@ -2166,7 +2166,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT focused cell to be 'Items'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Items');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 // jump back to pinned
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
@@ -2176,7 +2176,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT edited cell to be 'Released'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Released');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 // jump over 1 hidden, pinned
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
@@ -2186,7 +2186,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT edited cell to be 'Downloads'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Downloads');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
             }));
 
             it(`Should skip non-editable columns when column grouping is enabled`, (async () => {
@@ -2203,7 +2203,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT focused cell to be 'Released'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Released');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 // Go forwards, jump over Category and group end
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
@@ -2213,7 +2213,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT focused cell to be 'Items'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Items');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 // Go backwards, jump over group end and return to 'Released'
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
@@ -2222,7 +2222,7 @@ describe('IgxGrid Component Tests', () => {
                 // EXPECT focused cell to be 'Released'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Released');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 await wait(DEBOUNCETIME);
                 // Go to release date
                 editedCell.nativeElement.focus();
@@ -2231,7 +2231,7 @@ describe('IgxGrid Component Tests', () => {
                 fixture.detectChanges();
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('ReleaseDate');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
             }));
 
             it(`Should skip non-editable columns when all column features are enabled`, fakeAsync(() => {
@@ -2250,7 +2250,7 @@ describe('IgxGrid Component Tests', () => {
                 // Move from Downloads over hidden to Released in Column Group
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Released');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
                 fixture.componentInstance.moveNext(false);
@@ -2259,7 +2259,7 @@ describe('IgxGrid Component Tests', () => {
                 // Move from pinned 'Released' (in Column Group) to unpinned 'Items'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Items');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
                 fixture.componentInstance.moveNext(true);
@@ -2268,7 +2268,7 @@ describe('IgxGrid Component Tests', () => {
                 // Move back to pinned 'Released' (in Column Group)
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Released');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
                 editedCell.nativeElement.focus();
                 fixture.detectChanges();
                 fixture.componentInstance.moveNext(true);
@@ -2277,7 +2277,7 @@ describe('IgxGrid Component Tests', () => {
                 // Move back to pinned 'Downloads'
                 editedCell = fixture.componentInstance.getCurrentEditCell();
                 expect(editedCell.column.field).toEqual('Downloads');
-                expect(editedCell.inEditMode).toEqual(true);
+                expect(editedCell.editMode).toEqual(true);
             }));
 
             it(`Should focus last edited cell after click on editable buttons`, (async () => {
@@ -2319,7 +2319,7 @@ describe('IgxGrid Component Tests', () => {
 
                 // put cell in edit mode
                 const cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 fix.detectChanges();
 
@@ -2329,7 +2329,7 @@ describe('IgxGrid Component Tests', () => {
                 doneButtonElement.click();
                 expect(grid.endEdit).toHaveBeenCalled();
 
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 fix.detectChanges();
 
@@ -2349,7 +2349,7 @@ describe('IgxGrid Component Tests', () => {
 
                 // put cell in edit mode
                 const cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
 
                 // 'click' on Done button
@@ -2359,7 +2359,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(grid.endEdit).toHaveBeenCalledWith(true);
                 // expect(gridAPI.escape_editMode).toHaveBeenCalled();
                 // expect(gridAPI.escape_editMode).toHaveBeenCalledWith({ rowID: 1, columnID: 2, rowIndex: 0 });
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
             }));
 
             it(`Should exit row editing AND COMMIT on add row`, fakeAsync(() => {
@@ -2374,7 +2374,7 @@ describe('IgxGrid Component Tests', () => {
 
                 // put cell in edit mode
                 const cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
 
                 grid.addRow({ ProductID: 99, ProductName: 'ADDED', InStock: true, UnitsInStock: 20000, OrderDate: new Date('2018-03-01') });
@@ -2383,7 +2383,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(grid.endEdit).toHaveBeenCalledWith(true);
                 // expect(gridAPI.escape_editMode).toHaveBeenCalled();
                 // expect(gridAPI.escape_editMode).toHaveBeenCalledWith({ rowID: 1, columnID: 2, rowIndex: 0 });
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
             }));
 
             it(`Should exit row editing AND COMMIT on delete row`, fakeAsync(() => {
@@ -2398,7 +2398,7 @@ describe('IgxGrid Component Tests', () => {
 
                 // put cell in edit mode
                 const cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 fix.detectChanges();
                 grid.deleteRow(grid.getRowByIndex(2).rowID);
@@ -2408,7 +2408,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(grid.endEdit).toHaveBeenCalledWith(true);
                 // expect(gridAPI.escape_editMode).toHaveBeenCalled();
                 // expect(gridAPI.escape_editMode).toHaveBeenCalledWith({ rowID: 1, columnID: 2, rowIndex: 0 });
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
             }));
 
             it(`Should not allow editing a deleted row`, fakeAsync(() => {
@@ -2422,10 +2422,10 @@ describe('IgxGrid Component Tests', () => {
                 fix.detectChanges();
 
                 const cell = grid.getCellByColumn(2, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 fix.detectChanges();
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
             }));
 
             it(`Should exit row editing AND DISCARD on filter`, fakeAsync(() => {
@@ -2440,7 +2440,7 @@ describe('IgxGrid Component Tests', () => {
 
                 // put cell in edit mode
                 const cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
 
                 grid.filter('ProductName', 'a', IgxStringFilteringOperand.instance().condition('contains'), true);
@@ -2450,7 +2450,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(gridAPI.submit_value).toHaveBeenCalledWith();
                 expect(gridAPI.escape_editMode).toHaveBeenCalled();
                 expect(gridAPI.escape_editMode).toHaveBeenCalledWith();
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
             }));
 
             it(`Should exit row editing AND DISCARD on sort`, fakeAsync(() => {
@@ -2465,7 +2465,7 @@ describe('IgxGrid Component Tests', () => {
 
                 // put cell in edit mode
                 const cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
 
                 grid.sort({
@@ -2478,7 +2478,7 @@ describe('IgxGrid Component Tests', () => {
                 // expect(gridAPI.submit_value).toHaveBeenCalledWith(grid.id);
                 expect(gridAPI.escape_editMode).toHaveBeenCalled();
                 expect(gridAPI.escape_editMode).toHaveBeenCalledWith();
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
             }));
 
             it(`Should exit row editing AND COMMIT on displayDensity change`, fakeAsync(() => {
@@ -2539,7 +2539,7 @@ describe('IgxGrid Component Tests', () => {
 
                 // put cell in edit mode
                 const cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 fix.detectChanges();
                 const nonEditableCell = grid.getCellByColumn(2, 'ProductID');
@@ -2549,7 +2549,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(grid.endEdit).toHaveBeenCalledWith(true);
                 // expect(gridAPI.escape_editMode).toHaveBeenCalled();
                 // expect(gridAPI.escape_editMode).toHaveBeenCalledWith({ rowID: 1, columnID: 2, rowIndex: 0 });
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
             }));
 
             it(`Should exit row editing AND COMMIT on click on editable cell in other row`, fakeAsync(() => {
@@ -2610,7 +2610,7 @@ describe('IgxGrid Component Tests', () => {
                 const gridAPI: IgxGridAPIService = (<any>grid).gridAPI;
 
                 const targetCell = grid.getCellByColumn(0, 'ProductName');
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 tick();
 
                 spyOn(gridAPI, 'submit_value').and.callThrough();
@@ -2634,7 +2634,7 @@ describe('IgxGrid Component Tests', () => {
                 const gridAPI: IgxGridAPIService = (<any>grid).gridAPI;
 
                 const targetCell = grid.getCellByColumn(0, 'ProductName');
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 tick();
 
                 spyOn(gridAPI, 'submit_value').and.callThrough();
@@ -2660,7 +2660,7 @@ describe('IgxGrid Component Tests', () => {
                 spyOn(grid, 'endRowTransaction');
 
                 const firstCell = grid.getCellByColumn(2, 'ProductName');
-                firstCell.inEditMode = true;
+                firstCell.setEditMode(true);
                 tick();
                 fixture.detectChanges();
                 expect(grid.endRowTransaction).toHaveBeenCalledTimes(0);
@@ -2691,7 +2691,7 @@ describe('IgxGrid Component Tests', () => {
 
                 expect(rowEl.classList).not.toContain('igx-grid__tr--edited');
 
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 cell.editValue = 'IG';
                 tick();
@@ -2720,10 +2720,10 @@ describe('IgxGrid Component Tests', () => {
 
                 expect(rowEl.classList).not.toContain('igx-grid__tr--edited');
 
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 cell.update('IG');
-                cell.inEditMode = false;
+                cell.setEditMode(false);
                 fix.detectChanges();
                 tick();
 
@@ -2748,7 +2748,7 @@ describe('IgxGrid Component Tests', () => {
                 const cell = grid.getCellByColumn(0, 'ProductName');
                 const pagingButtons = gridElement.querySelectorAll('.igx-paginator > button');
 
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 cell.update('IG');
                 tick();
                 // Do not exit edit mode
@@ -2765,7 +2765,7 @@ describe('IgxGrid Component Tests', () => {
                 tick();
                 fix.detectChanges();
 
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
                 expect(cell.value).toBe('IG');
             }));
 
@@ -2777,7 +2777,7 @@ describe('IgxGrid Component Tests', () => {
                 const cell = grid.getCellByColumn(0, 'ProductName');
                 const select = fix.debugElement.query(By.css('.igx-paginator > select'));
 
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 // cell.update('IG');
                 // cell.update exits edit mode of the CELL
                 // Do not exit edit mode
@@ -2796,7 +2796,7 @@ describe('IgxGrid Component Tests', () => {
                 rowEditingBannerElement = document.getElementsByClassName(BANNER);
                 overlayContent = document.getElementsByClassName(EDIT_OVERLAY_CONTENT)[0] as HTMLElement;
 
-                expect(cell.inEditMode).toEqual(false);
+                expect(cell.editMode).toEqual(false);
                 expect(overlayContent).toBeFalsy();
                 // Element is still there in the grid template, but is hidden
                 expect(rowEditingBannerElement[0].parentElement.attributes['aria-hidden']).toBeTruthy();
@@ -2812,7 +2812,7 @@ describe('IgxGrid Component Tests', () => {
                 const select = fix.debugElement.query(By.css('.igx-paginator > select'));
                 const pagingButtons = gridElement.querySelectorAll('.igx-paginator > button');
 
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 (<any>grid).gridAPI.get_cell_inEditMode().editValue = 'IG';
                 // cell.update('IG');
@@ -2840,7 +2840,7 @@ describe('IgxGrid Component Tests', () => {
                 // Refresh collection / banner
                 rowEditingBannerElement = document.getElementsByClassName(BANNER)[0] as HTMLElement;
                 overlayContent = document.getElementsByClassName(EDIT_OVERLAY_CONTENT)[0] as HTMLElement;
-                expect(cell.inEditMode).toEqual(false);
+                expect(cell.editMode).toEqual(false);
                 expect(overlayContent).toBeFalsy();
                 expect(rowEditingBannerElement).toBeTruthy(); // banner is still present in grid template, just not visible
             }));
@@ -2852,7 +2852,7 @@ describe('IgxGrid Component Tests', () => {
                 const row = grid.getRowByKey(0);
                 const targetCell = grid.getCellByKey(0, 'Downloads');
                 spyOn(grid, 'endEdit').and.callThrough();
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 flush();
                 fixture.detectChanges();
                 expect(grid.rowEditingOverlay.collapsed).toBeFalsy();
@@ -2877,7 +2877,7 @@ describe('IgxGrid Component Tests', () => {
                 spyOn(grid, 'endEdit').and.callThrough();
 
                 const targetCell = grid.getCellByColumn(0, targetColumnName);
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 flush();
 
                 // search if the targeted column contains the keyword, ignoring case
@@ -2897,7 +2897,7 @@ describe('IgxGrid Component Tests', () => {
 
                 const grid = fix.componentInstance.grid;
                 const targetCell = grid.getCellByColumn(0, targetColumnName);
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 tick();
                 targetCell.update(newValue);
                 fix.detectChanges();
@@ -2954,7 +2954,7 @@ describe('IgxGrid Component Tests', () => {
                 spyOn(gridAPI, 'escape_editMode').and.callThrough();
 
                 const targetCell = grid.getCellByColumn(0, 'OrderDate');
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 tick();
 
                 grid.groupBy({
@@ -2977,7 +2977,7 @@ describe('IgxGrid Component Tests', () => {
 
                 spyOn(grid, 'endEdit').and.callThrough();
 
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 fix.detectChanges();
                 cell.update(111);
@@ -2990,12 +2990,12 @@ describe('IgxGrid Component Tests', () => {
                 fix.detectChanges();
 
                 cell = grid.getCellByColumn(0, 'Downloads');
-                expect(cell.inEditMode).toBe(false);
+                expect(cell.editMode).toBe(false);
                 expect(cell.value).toBe(110); // SORT does not submit
 
                 expect(grid.endEdit).toHaveBeenCalled();
                 expect(grid.endEdit).toHaveBeenCalledWith(false);
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
             }));
 
             it(`Should NOT include the new value in the results when sorting`, fakeAsync(() => {
@@ -3005,7 +3005,7 @@ describe('IgxGrid Component Tests', () => {
 
                 const grid = fix.componentInstance.grid;
                 const cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 cell.update(newValue);
 
@@ -3040,11 +3040,11 @@ describe('IgxGrid Component Tests', () => {
 
                 // Edit any of the sorted rows so that the row position is changed
                 let cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 // Cell will always be first
                 cell.update('AAAAAAAAAAA Don Juan De Marco');
-                cell.inEditMode = false;
+                cell.setEditMode(false);
                 tick();
                 fix.detectChanges();
 
@@ -3070,7 +3070,7 @@ describe('IgxGrid Component Tests', () => {
                 grid.enableSummaries('OrderDate');
                 const targetCell = grid.getCellByColumn(0, 'OrderDate');
 
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 // Bind to cell editor template value
                 (<any>grid).gridAPI.get_cell_inEditMode().value = newDate;
                 // targetCell.update(newDate);
@@ -3102,16 +3102,16 @@ describe('IgxGrid Component Tests', () => {
 
                 // put cell in edit mode
                 const cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
 
-                expect(cell.inEditMode).toEqual(true);
+                expect(cell.editMode).toEqual(true);
                 expect(grid.rowEditingOverlay.collapsed).toEqual(false);
                 grid.moveColumn(column, targetColumn);
                 tick();
                 fix.detectChanges();
 
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
                 expect(grid.endEdit).toHaveBeenCalled();
                 expect(grid.endEdit).toHaveBeenCalledWith(true);
                 expect(grid.rowEditingOverlay.collapsed).toEqual(true);
@@ -3127,7 +3127,7 @@ describe('IgxGrid Component Tests', () => {
 
                 // put cell in edit mode
                 let cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 grid.pinColumn('ProductName');
                 tick();
@@ -3136,11 +3136,11 @@ describe('IgxGrid Component Tests', () => {
                 expect(grid.endEdit).toHaveBeenCalled();
                 expect(grid.endEdit).toHaveBeenCalledWith(true);
                 expect(grid.endEdit).toHaveBeenCalledTimes(1);
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
 
                 // put cell in edit mode
                 cell = grid.getCellByColumn(2, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
 
                 grid.unpinColumn('ProductName');
@@ -3150,7 +3150,7 @@ describe('IgxGrid Component Tests', () => {
                 expect(grid.endEdit).toHaveBeenCalled();
                 expect(grid.endEdit).toHaveBeenCalledWith(true);
                 expect(grid.endEdit).toHaveBeenCalledTimes(2);
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
             }));
 
             it(`Should exit edit mode when resizing a column`, fakeAsync(() => {
@@ -3163,7 +3163,7 @@ describe('IgxGrid Component Tests', () => {
 
                 // put cell in edit mode
                 const cell = grid.getCellByColumn(3, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
 
                 const column = grid.columnList.filter(c => c.field === 'ProductName')[0];
                 column.resizable = true;
@@ -3181,7 +3181,7 @@ describe('IgxGrid Component Tests', () => {
 
                 expect(grid.endEdit).toHaveBeenCalled();
                 expect(grid.endEdit).toHaveBeenCalledWith(true);
-                expect(cell.inEditMode).toBeFalsy();
+                expect(cell.editMode).toBeFalsy();
             }));
 
             it(`Should exit edit mode when hiding a column`, fakeAsync(() => {
@@ -3192,7 +3192,7 @@ describe('IgxGrid Component Tests', () => {
                 const gridAPI: IgxGridAPIService = (<any>grid).gridAPI;
 
                 const targetCell = grid.getCellByColumn(0, 'ProductName'); // Cell must be editable
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 tick();
                 fix.detectChanges();
                 expect(gridAPI.get_cell_inEditMode()).toBeTruthy(); // check if there is cell in edit mode
@@ -3211,7 +3211,7 @@ describe('IgxGrid Component Tests', () => {
 
                 const grid = fix.componentInstance.grid;
                 const targetCell = grid.getCellByColumn(0, 'ProductName');
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 tick();
                 targetCell.column.hidden = true;
                 fix.detectChanges();
@@ -3225,7 +3225,7 @@ describe('IgxGrid Component Tests', () => {
 
                 const grid = fix.componentInstance.grid;
                 const targetCell = grid.getCellByColumn(0, 'ProductName');
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 tick();
                 targetCell.update('Tea');
 
@@ -3254,7 +3254,7 @@ describe('IgxGrid Component Tests', () => {
 
                 const grid = fix.componentInstance.grid;
                 const targetCell = grid.getCellByColumn(0, 'ProductName');
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 targetCell.column.hidden = true;
 
                 targetCell.update(newValue);
@@ -3286,7 +3286,7 @@ describe('IgxGrid Component Tests', () => {
                 spyOn(grid.onRowEditCancel, 'emit');
                 spyOn(grid.onRowEdit, 'emit');
                 targetCell = fixture.componentInstance.focusGridCell(0, 'Downloads');
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 tick();
                 component.cellInEditMode.editValue = 1337;
                 fixture.detectChanges();
@@ -3314,7 +3314,7 @@ describe('IgxGrid Component Tests', () => {
                 spyOn(grid.onRowEditCancel, 'emit');
                 spyOn(grid.onRowEdit, 'emit');
                 targetCell = fixture.componentInstance.focusGridCell(0, 'Downloads');
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 tick();
                 component.cellInEditMode.editValue = 1337;
                 fixture.detectChanges();
@@ -3341,7 +3341,7 @@ describe('IgxGrid Component Tests', () => {
                 let targetCell: IgxGridCellComponent;
                 spyOn(grid.onRowEdit, 'emit');
                 targetCell = fixture.componentInstance.focusGridCell(0, 'Downloads');
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 tick();
                 component.cellInEditMode.editValue = 1337;
                 fixture.detectChanges();
@@ -3369,7 +3369,7 @@ describe('IgxGrid Component Tests', () => {
                 let targetCell: IgxGridCellComponent;
                 spyOn(grid.onRowEdit, 'emit');
                 targetCell = fixture.componentInstance.focusGridCell(0, 'Downloads');
-                targetCell.inEditMode = true;
+                targetCell.setEditMode(true);
                 tick();
                 component.cellInEditMode.editValue = 1337;
                 fixture.detectChanges();
@@ -3414,39 +3414,39 @@ describe('IgxGrid Component Tests', () => {
                 const grid = fixture.componentInstance.grid;
                 let row: HTMLElement = grid.getRowByIndex(0).nativeElement;
                 let cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
 
                 let overlayContent: HTMLElement = document.getElementsByClassName(EDIT_OVERLAY_CONTENT)[0] as HTMLElement;
                 expect(row.getBoundingClientRect().bottom === overlayContent.getBoundingClientRect().top).toBeTruthy();
-                cell.inEditMode = false;
+                cell.setEditMode(false);
                 tick();
 
                 row = grid.getRowByIndex(2).nativeElement;
                 cell = grid.getCellByColumn(2, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 overlayContent = document.getElementsByClassName(EDIT_OVERLAY_CONTENT)[0] as HTMLElement;
                 expect(row.getBoundingClientRect().bottom === overlayContent.getBoundingClientRect().top).toBeTruthy();
-                cell.inEditMode = false;
+                cell.setEditMode(false);
                 tick();
 
                 row = grid.getRowByIndex(3).nativeElement;
                 cell = grid.getCellByColumn(3, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 overlayContent = document.getElementsByClassName(EDIT_OVERLAY_CONTENT)[0] as HTMLElement;
                 expect(row.getBoundingClientRect().top === overlayContent.getBoundingClientRect().bottom).toBeTruthy();
-                cell.inEditMode = false;
+                cell.setEditMode(false);
                 tick();
 
                 row = grid.getRowByIndex(0).nativeElement;
                 cell = grid.getCellByColumn(0, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 overlayContent = document.getElementsByClassName(EDIT_OVERLAY_CONTENT)[0] as HTMLElement;
                 expect(row.getBoundingClientRect().bottom === overlayContent.getBoundingClientRect().top).toBeTruthy();
-                cell.inEditMode = false;
+                cell.setEditMode(false);
                 tick();
             }));
         });
@@ -3459,7 +3459,7 @@ describe('IgxGrid Component Tests', () => {
                 const grid = fixture.componentInstance.grid;
                 let cell = grid.getCellByColumn(0, 'ProductName');
                 spyOn(grid, 'endEdit').and.callThrough();
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 fixture.detectChanges();
 
@@ -3492,11 +3492,11 @@ describe('IgxGrid Component Tests', () => {
                 productNameCell.triggerEventHandler('keydown', enterEvent);
                 tick();
                 fixture.detectChanges();
-                expect(grid.getCellByKey(1, 'ProductName').inEditMode).toBeTruthy();
+                expect(grid.getCellByKey(1, 'ProductName').editMode).toBeTruthy();
                 productNameCell.triggerEventHandler('keydown', enterEvent);
                 tick();
                 fixture.detectChanges();
-                expect(grid.getCellByKey(1, 'ProductName').inEditMode).toBeFalsy();
+                expect(grid.getCellByKey(1, 'ProductName').editMode).toBeFalsy();
                 grid.deleteRow(2);
                 tick();
                 fixture.detectChanges();
@@ -3512,7 +3512,7 @@ describe('IgxGrid Component Tests', () => {
                 let row = null;
                 let cell = grid.getCellByColumn(0, 'ProductName');
                 let updateValue = 'Chaiiii';
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 cell.editValue = updateValue;
                 tick();
@@ -3523,7 +3523,7 @@ describe('IgxGrid Component Tests', () => {
 
                 cell = grid.getCellByColumn(1, 'ProductName');
                 updateValue = 'Sirop';
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 cell.editValue = updateValue;
                 tick();
@@ -3583,10 +3583,10 @@ describe('IgxGrid Component Tests', () => {
 
                 cell = grid.getCellByColumn(0, 'ProductName');
                 updateValue = 'Chaiwe';
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 cell.update(updateValue);
-                cell.inEditMode = false;
+                cell.setEditMode(false);
                 tick();
                 trans.clear();
                 tick();
@@ -3867,7 +3867,7 @@ describe('IgxGrid Component Tests', () => {
                 tick();
                 fix.detectChanges();
                 const cell = grid.getCellByColumn(1, 'ProductName');
-                cell.inEditMode = true;
+                cell.setEditMode(true);
                 tick();
                 fix.detectChanges();
                 const groupRows = grid.groupsRowList.toArray();
@@ -3900,7 +3900,7 @@ describe('IgxGrid Component Tests', () => {
                     fix.detectChanges();
                     let row: HTMLElement;
                     const cell = grid.getCellByColumn(7, 'ProductName');
-                    cell.inEditMode = true;
+                    cell.setEditMode(true);
                     tick();
                     fix.detectChanges();
                     const overlayElem: HTMLElement = document.getElementsByClassName(EDIT_OVERLAY_CONTENT)[0] as HTMLElement;
@@ -3962,7 +3962,7 @@ describe('IgxGrid Component Tests', () => {
                     tick();
                     fix.detectChanges();
                     const cell = grid.getCellByColumn(2, 'ProductName');
-                    cell.inEditMode = true;
+                    cell.setEditMode(true);
                     tick();
                     fix.detectChanges();
                     const groupRows = grid.groupsRowList.toArray();


### PR DESCRIPTION
Editing of the primary key column should not be possible for grid with transactions.

Closes #5020

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 