### PR TITLE
fix(igxHierarhicalGrid): Refactor navigateTop and make sure closest s…

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-navigation.service.ts
@@ -128,22 +128,17 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
     public navigateTop(visibleColumnIndex) {
         if (this.grid.parent !== null) {
             // navigating in child
-            const verticalScroll = this.grid.verticalScrollContainer.getVerticalScroll();
-            const cellSelector = this.getCellSelector(visibleColumnIndex);
-
-            if (verticalScroll.scrollTop === 0) {
-                this._focusScrollCellInView(visibleColumnIndex);
+            const childContainer = this.grid.nativeElement.parentNode.parentNode;
+            const diff =
+            childContainer.getBoundingClientRect().top - this.grid.rootGrid.tbody.nativeElement.getBoundingClientRect().top;
+            const topIsVisible = diff >= 0;
+            const scrollable = this.getNextScrollable(this.grid);
+            if (!topIsVisible) {
+                this.scrollGrid(scrollable.grid, diff,
+                    () => super.navigateTop(visibleColumnIndex));
             } else {
-                this.scrollGrid(this.grid, 'top',
-                () => {
-                    const cells = this.grid.nativeElement.querySelectorAll(
-                        `${cellSelector}[data-visibleIndex="${visibleColumnIndex}"]`);
-                    if (cells.length > 0) {
-                        this._focusScrollCellInView(visibleColumnIndex);
-                     }
-                });
+                super.navigateTop(visibleColumnIndex);
             }
-
         } else {
             super.navigateTop(visibleColumnIndex);
         }
@@ -446,27 +441,6 @@ export class IgxHierarchicalGridNavigationService extends IgxGridNavigationServi
                 // move to next cell
                 this.navigateUp(currentRowEl, rowIndex, lastIndex);
             }
-    }
-
-    private _focusScrollCellInView(visibleColumnIndex) {
-        const cellSelector = this.getCellSelector(visibleColumnIndex);
-        const cells = this.grid.nativeElement.querySelectorAll(
-            `${cellSelector}[data-visibleIndex="${visibleColumnIndex}"]`);
-        const cell = cells[0];
-        const childContainer = this.grid.nativeElement.parentNode.parentNode;
-        const scrTop = this.grid.parent.verticalScrollContainer.getVerticalScroll().scrollTop;
-        const maxScroll = this.grid.parent.verticalScrollContainer.getVerticalScroll().scrollHeight - this.grid.parent.calcHeight;
-        const dc = childContainer.parentNode.parentNode;
-        const scrWith = parseInt(dc.style.top, 10);
-        const parentRowOffset = childContainer.parentNode.offsetTop + this.grid.nativeElement.offsetTop +
-            scrWith;
-        if ((scrTop === 0 && parentRowOffset < 0 ) || parentRowOffset === 0 || (scrTop === maxScroll && parentRowOffset > 0)) {
-            // cell is in view
-            cell.focus({preventScroll: true});
-        } else {
-            // scroll parent so that cell is in view
-            this.scrollGrid(this.grid.parent, parentRowOffset, () => cell.focus({ preventScroll: true }));
-        }
     }
 
     private focusNextChild(elem, visibleColumnIndex, grid) {


### PR DESCRIPTION
…crollable grid is used when scrolling to a child cell outside the visible viewport.

Closes #4474  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 