### PR TITLE
Revert sameRow check to use rowID

### DIFF
--- a/projects/igniteui-angular/src/lib/core/grid-selection.ts
+++ b/projects/igniteui-angular/src/lib/core/grid-selection.ts
@@ -105,8 +105,8 @@ export class IgxGridCRUDService {
         return new IgxRow(cell.id.rowID, cell.rowIndex, cell.rowData);
     }
 
-    sameRow(rowIndex): boolean {
-        return this.row && this.row.index === rowIndex;
+    sameRow(rowID): boolean {
+        return this.row && this.row.id === rowID;
     }
 
     sameCell(cell: IgxCell): boolean {
@@ -175,7 +175,7 @@ export class IgxGridCRUDService {
                 return;
             }
 
-            if (this.row && !this.sameRow(this.cell.rowIndex)) {
+            if (this.row && !this.sameRow(this.cell.id.rowID)) {
                 this.grid.endEdit(true);
                 this.cell = this.createCell(cell);
                 this.beginRowEdit();

--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -594,9 +594,9 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy {
             return;
         }
 
-        if (editableCell && crud.sameRow(this.rowIndex)) {
+        if (editableCell && crud.sameRow(this.cellID.rowID)) {
             this.gridAPI.submit_value();
-        } else if (editMode && !crud.sameRow(this.rowIndex)) {
+        } else if (editMode && !crud.sameRow(this.cellID.rowID)) {
             this.grid.endEdit(true);
         }
     }


### PR DESCRIPTION
We should check if same row is edited by ID, not by row index. Collapsing/expanding changes the row indexes and this move editable cell to different row.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 