### PR TITLE
Exit edit mode on collapse/expand, 7.3.x

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid/grid-api.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-api.service.ts
@@ -82,29 +82,19 @@ export class IgxGridAPIService extends GridBaseAPIService<IgxGridComponent> {
 
     public groupBy_toggle_group(groupRow: IGroupByRecord) {
         const grid = this.grid;
-        const expansionState = grid.groupingExpansionState;
-        let toggleRowEditingOverlay: boolean;
-        let isEditRowInGroup = false;
-        if (grid.rowEditable) {
-            const rowState = this.grid.crudService.row;
-
-            // Toggle only row editing overlays that are inside current expanded/collapsed group.
-            isEditRowInGroup = rowState ? this.groupBy_is_row_in_group(groupRow, rowState.id) : false;
+        if (grid.crudService.isInEditMode) {
+            grid.endEdit(true);
         }
+
+        const expansionState = grid.groupingExpansionState;
         const state: IGroupByExpandState = this.groupBy_get_expanded_for_group(groupRow);
         if (state) {
             state.expanded = !state.expanded;
-            if (isEditRowInGroup) {
-                toggleRowEditingOverlay = state.expanded;
-            }
         } else {
             expansionState.push({
                 expanded: !grid.groupsExpanded,
                 hierarchy: DataUtil.getHierarchy(groupRow)
             });
-            if (isEditRowInGroup) {
-                toggleRowEditingOverlay = false;
-            }
         }
         this.grid.groupingExpansionState = expansionState;
         if (grid.rowEditable) {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -3905,8 +3905,8 @@ describe('IgxGrid Component Tests', () => {
             }));
         });
 
-        describe('Row Editing - Grouping', () => {
-            it('Hide/show row editing dialog with group collapsing/expanding', fakeAsync(() => {
+        fdescribe('Row Editing - Grouping', () => {
+            it('Hide row editing dialog with group collapsing/expanding', fakeAsync(() => {
                 const fix = TestBed.createComponent(IgxGridRowEditingWithFeaturesComponent);
                 const grid = fix.componentInstance.instance;
                 grid.primaryKey = 'ID';
@@ -3917,84 +3917,85 @@ describe('IgxGrid Component Tests', () => {
                 });
                 tick();
                 fix.detectChanges();
-                const cell = grid.getCellByColumn(1, 'ProductName');
+
+                let cell = grid.getCellByColumn(6, 'ProductName');
+                expect(grid.crudService.inEditMode).toBeFalsy();
+
+                // set cell in second group in edit mode
                 cell.setEditMode(true);
                 tick();
                 fix.detectChanges();
-                const groupRows = grid.groupsRowList.toArray();
 
-                expect(groupRows[0].expanded).toEqual(true);
+                expect(grid.crudService.inEditMode).toBeTruthy();
+                const groupRows = grid.groupsRowList.toArray();
+                expect(groupRows[0].expanded).toBeTruthy();
+
+                // collapse first group
                 grid.toggleGroup(groupRows[0].groupRow);
                 tick();
                 fix.detectChanges();
-                expect(groupRows[0].expanded).toEqual(false);
-                const overlayContent = grid.rowEditingOverlay.element.parentElement;
-                expect(overlayContent.style.display).toEqual('none');
+
+                expect(groupRows[0].expanded).toBeFalsy();
+                expect(grid.crudService.inEditMode).toBeFalsy();
+
+                // expand first group
                 grid.toggleGroup(groupRows[0].groupRow);
                 tick();
                 fix.detectChanges();
-                expect(groupRows[0].expanded).toEqual(true);
-                expect(overlayContent.style.display).toEqual('');
+
+                expect(groupRows[0].expanded).toBeTruthy();
+                expect(grid.crudService.inEditMode).toBeFalsy();
+
+                // collapse first group
+                grid.toggleGroup(groupRows[0].groupRow);
+                tick(16);
+                fix.detectChanges();
+
+                expect(groupRows[0].expanded).toBeFalsy();
+                expect(grid.crudService.inEditMode).toBeFalsy();
+
+                // set cell in second group in edit mode
+                cell.setEditMode(true);
+                tick(16);
+                fix.detectChanges();
+
+                expect(grid.crudService.inEditMode).toBeTruthy();
+
+                // expand first group
+                grid.toggleGroup(groupRows[0].groupRow);
+                tick(16);
+                fix.detectChanges();
+
+                expect(groupRows[0].expanded).toBeTruthy();
+                expect(grid.crudService.inEditMode).toBeFalsy();
+
+                // set cell in first group in edit mode
+                cell = grid.getCellByColumn(1, 'ProductName');
+                cell.setEditMode(true);
+                tick(16);
+                fix.detectChanges();
+
+                expect(grid.crudService.inEditMode).toBeTruthy();
+                expect(groupRows[0].expanded).toBeTruthy();
+
+                // collapse first group
+                grid.toggleGroup(groupRows[0].groupRow);
+                tick(16);
+                fix.detectChanges();
+
+                expect(groupRows[0].expanded).toBeFalsy();
+                expect(grid.crudService.inEditMode).toBeFalsy();
+
+                // expand first group
+                grid.toggleGroup(groupRows[0].groupRow);
+                tick(16);
+                fix.detectChanges();
+
+                expect(groupRows[0].expanded).toBeTruthy();
+                expect(grid.crudService.inEditMode).toBeFalsy();
             }));
 
-            it('Do not hide/show row editing dialog when another group is collapsing/expanding and check that overlay is moving with row',
-                fakeAsync(() => {
-                    const fix = TestBed.createComponent(IgxGridRowEditingWithFeaturesComponent);
-                    const grid = fix.componentInstance.instance;
-                    grid.primaryKey = 'ID';
-                    fix.detectChanges();
-                    grid.groupBy({
-                        fieldName: 'Released', dir: SortingDirection.Desc, ignoreCase: false,
-                        strategy: DefaultSortingStrategy.instance()
-                    });
-                    tick();
-                    fix.detectChanges();
-                    let row: HTMLElement;
-                    const cell = grid.getCellByColumn(7, 'ProductName');
-                    cell.setEditMode(true);
-                    tick();
-                    fix.detectChanges();
-                    const overlayElem: HTMLElement = document.getElementsByClassName(EDIT_OVERLAY_CONTENT)[0] as HTMLElement;
-                    const groupRows = grid.groupsRowList.toArray();
-
-                    grid.toggleGroup(groupRows[0].groupRow);
-                    tick();
-                    fix.detectChanges();
-                    const overlayContent = grid.rowEditingOverlay.element.parentElement;
-                    expect(overlayContent.style.display).toEqual('');
-
-                    row = grid.getRowByIndex(3).nativeElement;
-                    expect(row.getBoundingClientRect().bottom === overlayElem.getBoundingClientRect().top).toBeTruthy();
-                    grid.toggleGroup(groupRows[0].groupRow);
-                    tick();
-                    fix.detectChanges();
-                    expect(overlayContent.style.display).toEqual('');
-                    row = grid.getRowByIndex(7).nativeElement;
-                    expect(row.getBoundingClientRect().bottom === overlayElem.getBoundingClientRect().top).toBeTruthy();
-
-                    grid.toggleGroup(groupRows[1].groupRow);
-                    tick();
-                    fix.detectChanges();
-                    expect(overlayContent.style.display).toEqual('none');
-
-                    grid.toggleGroup(groupRows[0].groupRow);
-                    tick();
-                    fix.detectChanges();
-                    expect(overlayContent.style.display).toEqual('none');
-                    grid.toggleGroup(groupRows[0].groupRow);
-                    tick();
-                    fix.detectChanges();
-                    expect(overlayContent.style.display).toEqual('none');
-
-                    grid.toggleGroup(groupRows[1].groupRow);
-                    tick();
-                    fix.detectChanges();
-                    expect(overlayContent.style.display).toEqual('');
-                    row = grid.getRowByIndex(7).nativeElement;
-                    expect(row.getBoundingClientRect().bottom === overlayElem.getBoundingClientRect().top).toBeTruthy();
-                }));
-
-            it('Hide/show row editing dialog when hierarchical group is collapsed/expanded',
+            it('Hide row editing dialog when hierarchical group is collapsed/expanded',
                 fakeAsync(() => {
                     const fix = TestBed.createComponent(IgxGridRowEditingWithFeaturesComponent);
                     const grid = fix.componentInstance.instance;
@@ -4012,21 +4013,22 @@ describe('IgxGrid Component Tests', () => {
                     });
                     tick();
                     fix.detectChanges();
+                    expect(grid.crudService.inEditMode).toBeFalsy();
                     const cell = grid.getCellByColumn(2, 'ProductName');
                     cell.setEditMode(true);
                     tick();
                     fix.detectChanges();
+                    expect(grid.crudService.inEditMode).toBeTruthy();
                     const groupRows = grid.groupsRowList.toArray();
 
                     grid.toggleGroup(groupRows[0].groupRow);
                     tick();
                     fix.detectChanges();
-                    const overlayContent = grid.rowEditingOverlay.element.parentElement;
-                    expect(overlayContent.style.display).toEqual('none');
+                    expect(grid.crudService.inEditMode).toBeFalsy();
                     grid.toggleGroup(groupRows[0].groupRow);
                     tick();
                     fix.detectChanges();
-                    expect(overlayContent.style.display).toEqual('');
+                    expect(grid.crudService.inEditMode).toBeFalsy();
                 }));
         });
     });

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -3905,7 +3905,7 @@ describe('IgxGrid Component Tests', () => {
             }));
         });
 
-        fdescribe('Row Editing - Grouping', () => {
+        describe('Row Editing - Grouping', () => {
             it('Hide row editing dialog with group collapsing/expanding', fakeAsync(() => {
                 const fix = TestBed.createComponent(IgxGridRowEditingWithFeaturesComponent);
                 const grid = fix.componentInstance.instance;

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.spec.ts
@@ -103,6 +103,7 @@ describe('Basic IgxHierarchicalGrid', () => {
         expect(icon.getActive).toBe(false);
         expect(hierarchicalGrid.hierarchicalState.length).toEqual(0);
     }));
+
     it('should allow applying initial expansions state for certain rows through hierarchicalState option', () => {
         // set first row as expanded.
         hierarchicalGrid.hierarchicalState = [{rowID: fixture.componentInstance.data[0]}];
@@ -332,6 +333,55 @@ describe('Basic IgxHierarchicalGrid', () => {
         UIInteractions.clickElement(row.expander);
         fixture.detectChanges();
         expect(childGrid.calcWidth - 170).toBeLessThan(3);
+    });
+
+    it('should exit edit mode on row expand/collapse through the UI', async() => {
+        hierarchicalGrid.primaryKey = 'ID';
+        hierarchicalGrid.rowEditable = true;
+        fixture.detectChanges();
+        wait();
+
+        const masterGridFirstRow = hierarchicalGrid.getRowByIndex(0) as IgxHierarchicalRowComponent;
+        expect(masterGridFirstRow.expanded).toBeFalsy();
+
+        const masterGridSecondCell = masterGridFirstRow.cells.find(c => c.columnIndex === 1);
+        expect(masterGridSecondCell.editMode).toBeFalsy();
+
+        masterGridSecondCell.setEditMode(true);
+        fixture.detectChanges();
+        wait();
+
+        expect(masterGridSecondCell.editMode).toBeTruthy();
+
+        UIInteractions.clickElement(masterGridFirstRow.expander);
+        fixture.detectChanges();
+        wait();
+
+        expect(masterGridFirstRow.expanded).toBeTruthy();
+        expect(masterGridSecondCell.editMode).toBeFalsy();
+
+        const childGrid = hierarchicalGrid.hgridAPI.getChildGrids(false)[0] as IgxHierarchicalGridComponent;
+        expect(childGrid).toBeDefined();
+
+        childGrid.columnList.find(c => c.index === 1).editable = true;
+        const childGridSecondRow = childGrid.getRowByIndex(1) as IgxHierarchicalRowComponent;
+        expect(childGridSecondRow.expanded).toBeFalsy();
+
+        const childGridSecondCell = childGridSecondRow.cells.find(c => c.columnIndex === 1);
+        expect(childGridSecondCell.editMode).toBeFalsy();
+
+        childGridSecondCell.setEditMode(true);
+        fixture.detectChanges();
+        wait();
+
+        expect(childGridSecondCell.editMode).toBeTruthy();
+
+        UIInteractions.clickElement(masterGridFirstRow.expander);
+        fixture.detectChanges();
+        wait();
+
+        expect(childGrid.crudService.inEditMode).toBeFalsy();
+        expect(childGridSecondRow.inEditMode).toBeFalsy();
     });
 });
 

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-row.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-row.component.ts
@@ -78,6 +78,7 @@ export class IgxHierarchicalRowComponent extends IgxRowComponent<IgxHierarchical
             return;
         }
         const grid = this.gridAPI.grid;
+        this.endEdit(grid);
         const state = this.gridAPI.grid.hierarchicalState;
         if (!this.expanded) {
             state.push({ rowID: this.rowID });
@@ -91,6 +92,20 @@ export class IgxHierarchicalRowComponent extends IgxRowComponent<IgxHierarchical
         requestAnimationFrame(() => {
             grid.reflow();
         });
+    }
+
+    private endEdit(grid: IgxHierarchicalGridComponent) {
+        while (grid.parent) {
+            grid = grid.parent;
+        }
+
+        if (grid.crudService.inEditMode) {
+            grid.endEdit();
+        }
+        grid.hgridAPI.getChildGrids(true).forEach(g => {
+            if (g.crudService.inEditMode) {
+            g.endEdit();
+        }});
     }
 
     constructor(public gridAPI: GridBaseAPIService<IgxHierarchicalGridComponent>,

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-row.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-row.component.ts
@@ -78,7 +78,7 @@ export class IgxHierarchicalRowComponent extends IgxRowComponent<IgxHierarchical
             return;
         }
         const grid = this.gridAPI.grid;
-        this.endEdit(grid);
+        this.endEdit(grid.rootGrid);
         const state = this.gridAPI.grid.hierarchicalState;
         if (!this.expanded) {
             state.push({ rowID: this.rowID });
@@ -95,10 +95,6 @@ export class IgxHierarchicalRowComponent extends IgxRowComponent<IgxHierarchical
     }
 
     private endEdit(grid: IgxHierarchicalGridComponent) {
-        while (grid.parent) {
-            grid = grid.parent;
-        }
-
         if (grid.crudService.inEditMode) {
             grid.endEdit();
         }


### PR DESCRIPTION
When hierarchical/grouped grid expand or collapse its rows we should exit edit mode.

Closes #4761
Closes #5044

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 