### PR TITLE
fix(grid): set flex shrink to 0 for all display containers

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/_common/_igx-display-container.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/_common/_igx-display-container.scss
@@ -3,6 +3,7 @@
     position: relative;
     width: 100%;
     overflow: hidden;
+    flex-shrink: 0;
 }
 
 %display-container--inactive {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1342,10 +1342,13 @@ describe('IgxGrid Component Tests', () => {
             fix.detectChanges();
             await wait(16);
             // check UI
+            const rowSelectorHeader =  fix.nativeElement.querySelector('.igx-grid__thead').querySelector('.igx-grid__cbx-selection');
             const header0 = fix.debugElement.queryAll(By.css('igx-grid-header-group'))[0];
             const header1 = fix.debugElement.queryAll(By.css('igx-grid-header-group'))[1];
             const header2 = fix.debugElement.queryAll(By.css('igx-grid-header-group'))[2];
-            expect(header0.nativeElement.offsetWidth).toEqual(Math.round(0.7 * grid.unpinnedWidth));
+            const expectedWidth = Math.round(0.7 * (grid.unpinnedWidth + rowSelectorHeader.offsetWidth));
+            expect(header0.nativeElement.offsetWidth).toBeGreaterThanOrEqual(expectedWidth - 1);
+            expect(header0.nativeElement.offsetWidth).toBeLessThanOrEqual(expectedWidth + 1);
             expect(header1.nativeElement.offsetWidth).toEqual(136);
             expect(header2.nativeElement.offsetWidth).toEqual(136);
             expect(hScroll.nativeElement.hidden).toBe(false);


### PR DESCRIPTION
Disallow display container shrinkage to prevent inner content(cells)
from having different widths when set in fraction values (%).

Closes #3918

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 