### PR TITLE
fix(grids): set grids z-index to 1, #5674

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
@@ -585,7 +585,7 @@
         overflow: hidden;
         box-shadow: $grid-shadow;
         outline-style: none;
-        z-index: 0;
+        z-index: 1;
 
         %cbx-display {
             min-width: rem(20px);

--- a/src/app/grid-column-moving/grid-column-moving.sample.html
+++ b/src/app/grid-column-moving/grid-column-moving.sample.html
@@ -21,8 +21,7 @@
                 [filterMode]="'excelStyleFilter'"
                 [paging]="false"
                 [width]="'900px'"
-                [height]="'800px'"
-                [style.zIndex]="'1'">
+                [height]="'800px'">
                 <igx-column *ngFor="let c of columns" [field]="c.field"
                                                     [header]="c.field"
                                                     [movable]="c.movable"

--- a/src/app/grid-filter-template/grid-filter-template.sample.html
+++ b/src/app/grid-filter-template/grid-filter-template.sample.html
@@ -12,8 +12,7 @@
                 [rowSelectable]="true"
                 [paging]="false"
                 [width]="'900px'"
-                [height]="'800px'"
-                [style.zIndex]="'1'">
+                [height]="'800px'">
                 <igx-column *ngFor="let c of columns" [field]="c.field"
                                                     [header]="c.field"
                                                     [movable]="c.movable"

--- a/src/app/tree-grid/tree-grid.sample.html
+++ b/src/app/tree-grid/tree-grid.sample.html
@@ -16,7 +16,7 @@
                     rowSelectable="true" [paging]="false" [displayDensity]="density" [width]="'900px'" [height]="'500px'"
                     [showToolbar]="true" [columnHiding]="true" [columnPinning]="true" [exportExcel]="true" [exportCsv]="true"
                     exportText="Export" exportExcelText="Export to Excel" exportCsvText="Export to CSV" [allowFiltering]="true"
-                    [filterMode]="'excelStyleFilter'" [style.zIndex]="'1'">
+                    [filterMode]="'excelStyleFilter'">
                     <igx-column *ngFor="let c of columns" [field]="c.field" [header]="c.field" [pinned]="c.pinned"
                         [movable]="c.movable" [groupable]="false" [resizable]="c.resizable" [width]="c.width"
                         [sortable]="true" [filterable]="true" [editable]="true" [hidden]="c.hidden" [hasSummary]="c.summary"


### PR DESCRIPTION
Set the grid's z-index to 1 instead of 0. This will allow whatever is shown in overlay through grid's outlets to be shown above elements around the grid.
In case anyone set higher z-index to elements around the grid he should set and appropriate z-index to the grid.

Closes #5674 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 