### PR TITLE
fix(grids): set grids z-index to 1, #5674

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
@@ -570,7 +570,7 @@
         overflow: hidden;
         box-shadow: $grid-shadow;
         outline-style: none;
-        z-index: 0;
+        z-index: 1;
 
         %cbx-display {
             min-width: rem(20px);


### PR DESCRIPTION
Set the grid's z-index to 1 instead of 0. This will allow whatever is shown in overlay through grid's outlets to be shown above elements around the grid.
In case anyone set higher z-index to elements around the grid he should set and appropriate z-index to the grid.

Closes #5674 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 