### PR TITLE
Set z-index of row drag ghost to 1 same as the grid one

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
@@ -848,6 +848,7 @@
 
         &%igx-grid__tr--ghost {
             background: --var($theme, 'row-ghost-background');
+            z-index: 1;
         }
     }
 


### PR DESCRIPTION
This will make the z-index of the row drag ghost equal to the one of the grid. This will not fix application scenario where grid is put in stacking container with higher z-index. To fix this drag and drop directive should be able to use outlet where drag ghost should be put in the DOM tree and not as a child of the body.

Closes #5748 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 