### PR TITLE
Select component now respects a passed DisplayDensityToken and not overriding it.

### DIFF
--- a/projects/igniteui-angular/src/lib/select/select.component.ts
+++ b/projects/igniteui-angular/src/lib/select/select.component.ts
@@ -161,16 +161,6 @@ export class IgxSelectComponent extends IgxDropDownComponent implements IgxSelec
     public type = 'line';
 
     /**
-     * An @Input property that sets what display density to be used for the input group.
-     * The allowed values are `compact`, `cosy` and `comfortable`. The default is `comfortable`.
-     * ```html
-     *<igx-select [displayDensity]="'compact'"></igx-select>
-     * ```
-     */
-    @Input()
-    public displayDensity = 'comfortable';
-
-    /**
      * The custom template, if any, that should be used when rendering the select TOGGLE(open/close) button
      *
      * ```typescript

--- a/src/app/select/select.sample.html
+++ b/src/app/select/select.sample.html
@@ -4,7 +4,7 @@
 
 <div class="sampleWrapper">
     <h4 class="sample-title">Select with ngModel, set items OnInit</h4>
-    <igx-select #select1
+    <igx-select #displayDensitySelect
     [required]="true"
     [placeholder]="'Pick One'"
     [(ngModel)]="value"
@@ -13,7 +13,8 @@
     (onClosing)="testOnClosing($event)"
     (onClosed)="testOnClosed()"
     (onSelection)="testOnSelection($event)"
-    [disabled]="false">
+    [disabled]="false"
+    [displayDensity]="'cosy'">
         <label igxLabel>Sample Label</label>
         <igx-prefix igxPrefix>
             <igx-icon fontSet="material">alarm</igx-icon>
@@ -23,6 +24,13 @@
             {{ item.field }}
         </igx-select-item>
     </igx-select>
+
+    <div>
+        <h4>Display Density</h4>
+        <button igxButton="raised" [disabled]="selectDisplayDensity.displayDensity === compact" (click)="setDensity(compact)">Compact</button>
+        <button igxButton="raised" [disabled]="selectDisplayDensity.displayDensity === cosy" (click)="setDensity(cosy)">Cosy</button>
+        <button igxButton="raised" [disabled]="selectDisplayDensity.displayDensity === comfortable" (click)="setDensity(comfortable)">Comfortable</button>
+    </div>
 
     <h4 class="sample-title">Select - declare items in html template</h4>
     <igx-select #select2

--- a/src/app/select/select.sample.ts
+++ b/src/app/select/select.sample.ts
@@ -4,7 +4,8 @@ import {
     ISelectionEventArgs, CancelableEventArgs, OverlaySettings,
     HorizontalAlignment, VerticalAlignment, scaleInTop, scaleOutBottom, ConnectedPositioningStrategy,
     AbsoluteScrollStrategy,
-    IgxSelectComponent
+    IgxSelectComponent,
+    DisplayDensity
 } from 'igniteui-angular';
 
 @Component({
@@ -19,7 +20,12 @@ export class SelectSampleComponent implements OnInit {
     public select: IgxSelectComponent;
     @ViewChild('model', { read: IgxSelectComponent, static: true })
     public selectFruits: IgxSelectComponent;
+    @ViewChild('displayDensitySelect', { read: IgxSelectComponent, static: true })
+    public selectDisplayDensity: IgxSelectComponent;
 
+    public comfortable = DisplayDensity.comfortable;
+    public cosy = DisplayDensity.cosy;
+    public compact = DisplayDensity.compact;
 
     constructor(fb: FormBuilder) {
         this.reactiveForm = fb.group({
@@ -136,5 +142,9 @@ export class SelectSampleComponent implements OnInit {
             console.log('onOpenCustomOverlaySettings.....................:  customOverlaySettings');
             this.selectComponents.first.open(customOverlaySettings);
         }
+    }
+
+    setDensity(density: DisplayDensity) {
+        this.selectDisplayDensity.displayDensity = density;
     }
 }


### PR DESCRIPTION
Remove displayDensity @Input so the component uses the base `DisplayDensityBase` default one.  
Select component now respects a passed DisplayDensityToken.

Add displayDensity sample under dev samples.

Closes #5843

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 