### PR TITLE
Bypass all calls to browsers' object when not on browser platform

### DIFF
--- a/projects/igniteui-angular/src/lib/core/touch.ts
+++ b/projects/igniteui-angular/src/lib/core/touch.ts
@@ -21,7 +21,7 @@ export class HammerGesturesManager {
     private _hammerManagers: Array<{ element: EventTarget, manager: HammerManager; }> = [];
 
     constructor(private _zone: NgZone, @Inject(DOCUMENT) private doc: any, private platformUtil: PlatformUtil) {
-        this.platformBrowser = this.platformUtil.isPlatformBrowser;
+        this.platformBrowser = this.platformUtil.isBrowser;
         if (this.platformBrowser) {
             this.hammerOptions = {
                 // D.P. #447 Force TouchInput due to PointerEventInput bug (https://github.com/hammerjs/hammer.js/issues/1065)

--- a/projects/igniteui-angular/src/lib/core/touch.ts
+++ b/projects/igniteui-angular/src/lib/core/touch.ts
@@ -1,6 +1,7 @@
-import { Inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
+import { Inject, Injectable, NgZone } from '@angular/core';
 import { ɵgetDOM as getDOM } from '@angular/platform-browser';
-import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { DOCUMENT } from '@angular/common';
+import { PlatformUtil } from './utils';
 
 const EVENT_SUFFIX = 'precise';
 
@@ -19,8 +20,8 @@ export class HammerGesturesManager {
 
     private _hammerManagers: Array<{ element: EventTarget, manager: HammerManager; }> = [];
 
-    constructor(private _zone: NgZone, @Inject(DOCUMENT) private doc: any) {
-        this.platformBrowser = isPlatformBrowser(PLATFORM_ID);
+    constructor(private _zone: NgZone, @Inject(DOCUMENT) private doc: any, private platformUtil: PlatformUtil) {
+        this.platformBrowser = this.platformUtil.isPlatformBrowser();
         if (this.platformBrowser) {
             this.hammerOptions = {
                 // D.P. #447 Force TouchInput due to PointerEventInput bug (https://github.com/hammerjs/hammer.js/issues/1065)

--- a/projects/igniteui-angular/src/lib/core/touch.ts
+++ b/projects/igniteui-angular/src/lib/core/touch.ts
@@ -21,7 +21,7 @@ export class HammerGesturesManager {
     private _hammerManagers: Array<{ element: EventTarget, manager: HammerManager; }> = [];
 
     constructor(private _zone: NgZone, @Inject(DOCUMENT) private doc: any, private platformUtil: PlatformUtil) {
-        this.platformBrowser = this.platformUtil.isPlatformBrowser();
+        this.platformBrowser = this.platformUtil.isPlatformBrowser;
         if (this.platformBrowser) {
             this.hammerOptions = {
                 // D.P. #447 Force TouchInput due to PointerEventInput bug (https://github.com/hammerjs/hammer.js/issues/1065)

--- a/projects/igniteui-angular/src/lib/core/touch.ts
+++ b/projects/igniteui-angular/src/lib/core/touch.ts
@@ -1,6 +1,6 @@
-import { Inject, Injectable, NgZone } from '@angular/core';
+import { Inject, Injectable, NgZone, PLATFORM_ID } from '@angular/core';
 import { ɵgetDOM as getDOM } from '@angular/platform-browser';
-import { DOCUMENT } from '@angular/common';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 
 const EVENT_SUFFIX = 'precise';
 
@@ -11,26 +11,31 @@ const EVENT_SUFFIX = 'precise';
  */
 @Injectable()
 export class HammerGesturesManager {
+    private platformBrowser: boolean;
     /**
      * Event option defaults for each recognizer, see http://hammerjs.github.io/api/ for API listing.
      */
-    protected hammerOptions: HammerOptions = {
-        // D.P. #447 Force TouchInput due to PointerEventInput bug (https://github.com/hammerjs/hammer.js/issues/1065)
-        // see https://github.com/IgniteUI/igniteui-angular/issues/447#issuecomment-324601803
-        inputClass: Hammer.TouchInput,
-        recognizers: [
-            [ Hammer.Pan, { threshold: 0 } ],
-            [ Hammer.Swipe, {
-                direction: Hammer.DIRECTION_HORIZONTAL
-            }],
-            [Hammer.Tap],
-            [Hammer.Tap, { event: 'doubletap', taps: 2 }, ['tap']]
-        ]
-    };
+    protected hammerOptions: HammerOptions = {};
 
     private _hammerManagers: Array<{ element: EventTarget, manager: HammerManager; }> = [];
 
     constructor(private _zone: NgZone, @Inject(DOCUMENT) private doc: any) {
+        this.platformBrowser = isPlatformBrowser(PLATFORM_ID);
+        if (this.platformBrowser) {
+            this.hammerOptions = {
+                // D.P. #447 Force TouchInput due to PointerEventInput bug (https://github.com/hammerjs/hammer.js/issues/1065)
+                // see https://github.com/IgniteUI/igniteui-angular/issues/447#issuecomment-324601803
+                inputClass: Hammer.TouchInput,
+                recognizers: [
+                    [Hammer.Pan, { threshold: 0 }],
+                    [Hammer.Swipe, {
+                        direction: Hammer.DIRECTION_HORIZONTAL
+                    }],
+                    [Hammer.Tap],
+                    [Hammer.Tap, { event: 'doubletap', taps: 2 }, ['tap']]
+                ]
+            };
+        }
     }
 
     public supports(eventName: string): boolean {
@@ -41,10 +46,14 @@ export class HammerGesturesManager {
      * Add listener extended with options for Hammer.js. Will use defaults if none are provided.
      * Modeling after other event plugins for easy future modifications.
      */
-    public addEventListener(element: HTMLElement,
-                            eventName: string,
-                            eventHandler: (eventObj) => void,
-                            options: HammerOptions = null): () => void {
+    public addEventListener(
+        element: HTMLElement,
+        eventName: string,
+        eventHandler: (eventObj) => void,
+        options: HammerOptions = null): () => void {
+        if (!this.platformBrowser) {
+            return;
+        }
 
         // Creating the manager bind events, must be done outside of angular
         return this._zone.runOutsideAngular(() => {
@@ -67,6 +76,10 @@ export class HammerGesturesManager {
      * @param target Can be one of either window, body or document(fallback default).
      */
     public addGlobalEventListener(target: string, eventName: string, eventHandler: (eventObj) => void): () => void {
+        if (!this.platformBrowser) {
+            return;
+        }
+
         const element = this.getGlobalEventTarget(target);
 
         // Creating the manager bind events, must be done outside of angular

--- a/projects/igniteui-angular/src/lib/core/utils.ts
+++ b/projects/igniteui-angular/src/lib/core/utils.ts
@@ -231,7 +231,6 @@ export function isFirefox(): boolean {
 
 /**
  * @hidden
- * TODO: make injectable, check isPlatformBrowser()
  */
 @Injectable({ providedIn: 'root' })
 export class PlatformUtil {
@@ -241,12 +240,12 @@ export class PlatformUtil {
         this.platformBrowser = isPlatformBrowser(this.platformId);
     }
 
-    public isIOS(): boolean {
+    public get isIOS(): boolean {
         const iosBrowser = this.platformBrowser && /iPad|iPhone|iPod/.test(navigator.userAgent) && !('MSStream' in window);
         return iosBrowser;
     }
 
-    public isPlatformBrowser(): boolean {
+    public get isPlatformBrowser(): boolean {
         return this.platformBrowser;
     }
 }

--- a/projects/igniteui-angular/src/lib/core/utils.ts
+++ b/projects/igniteui-angular/src/lib/core/utils.ts
@@ -1,3 +1,6 @@
+import { Injectable, PLATFORM_ID, Inject } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
 /**
  *@hidden
  */
@@ -230,10 +233,21 @@ export function isFirefox(): boolean {
  * @hidden
  * TODO: make injectable, check isPlatformBrowser()
  */
+@Injectable({ providedIn: 'root' })
 export class PlatformUtil {
-    static isIOS(): boolean {
-        const iosBrowser = typeof window !== 'undefined' && /iPad|iPhone|iPod/.test(navigator.userAgent) && !('MSStream' in window);
+    private platformBrowser: boolean;
+
+    constructor(@Inject(PLATFORM_ID) private platformId: Object) {
+        this.platformBrowser = isPlatformBrowser(this.platformId);
+    }
+
+    public isIOS(): boolean {
+        const iosBrowser = this.platformBrowser && /iPad|iPhone|iPod/.test(navigator.userAgent) && !('MSStream' in window);
         return iosBrowser;
+    }
+
+    public isPlatformBrowser(): boolean {
+        return this.platformBrowser;
     }
 }
 
@@ -246,8 +260,21 @@ export function isLeftClick(event: PointerEvent) {
 
 /** @hidden */
 export function isNavigationKey(key: string): boolean {
-    return ['down', 'up', 'left', 'right', 'arrowdown', 'arrowup', 'arrowleft', 'arrowright',
-        'home', 'end', 'space', 'spacebar', ' '].indexOf(key) !== -1;
+    return [
+        'down',
+        'up',
+        'left',
+        'right',
+        'arrowdown',
+        'arrowup',
+        'arrowleft',
+        'arrowright',
+        'home',
+        'end',
+        'space',
+        'spacebar',
+        ' '
+    ].indexOf(key) !== -1;
 }
 
 /**
@@ -285,8 +312,21 @@ export interface CancelableBrowserEventArgs extends CancelableEventArgs {
     event?: Event;
 }
 
-export const NAVIGATION_KEYS = new Set(['down', 'up', 'left', 'right', 'arrowdown', 'arrowup', 'arrowleft', 'arrowright',
-                                'home', 'end', 'space', 'spacebar', ' ']);
+export const NAVIGATION_KEYS = new Set([
+    'down',
+    'up',
+    'left',
+    'right',
+    'arrowdown',
+    'arrowup',
+    'arrowleft',
+    'arrowright',
+    'home',
+    'end',
+    'space',
+    'spacebar',
+    ' '
+]);
 export const ROW_EXPAND_KEYS = new Set('right down arrowright arrowdown'.split(' '));
 export const ROW_COLLAPSE_KEYS = new Set('left up arrowleft arrowup'.split(' '));
 export const SUPPORTED_KEYS = new Set([...Array.from(NAVIGATION_KEYS), 'tab', 'enter', 'f2', 'escape', 'esc']);

--- a/projects/igniteui-angular/src/lib/core/utils.ts
+++ b/projects/igniteui-angular/src/lib/core/utils.ts
@@ -234,19 +234,11 @@ export function isFirefox(): boolean {
  */
 @Injectable({ providedIn: 'root' })
 export class PlatformUtil {
-    private platformBrowser: boolean;
+    public isBrowser: boolean = isPlatformBrowser(this.platformId);
+
+    public isIOS = this.isBrowser && /iPad|iPhone|iPod/.test(navigator.userAgent) && !('MSStream' in window);
 
     constructor(@Inject(PLATFORM_ID) private platformId: Object) {
-        this.platformBrowser = isPlatformBrowser(this.platformId);
-    }
-
-    public get isIOS(): boolean {
-        const iosBrowser = this.platformBrowser && /iPad|iPhone|iPod/.test(navigator.userAgent) && !('MSStream' in window);
-        return iosBrowser;
-    }
-
-    public get isPlatformBrowser(): boolean {
-        return this.platformBrowser;
     }
 }
 

--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -588,7 +588,7 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy {
                 this.nativeElement.addEventListener('compositionend', this.compositionEndHandler);
             }
         });
-        if (this.platformUtil.isIOS()) {
+        if (this.platformUtil.isIOS) {
             this.touchManager.addEventListener(this.nativeElement, 'doubletap', this.onDoubleClick, {
                 cssProps: { } /* don't disable user-select, etc */
             } as HammerOptions);

--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -555,7 +555,8 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy {
         public cdr: ChangeDetectorRef,
         private element: ElementRef,
         protected zone: NgZone,
-        private touchManager: HammerGesturesManager) { }
+        private touchManager: HammerGesturesManager,
+        protected platformUtil: PlatformUtil) { }
 
     private addPointerListeners(selection) {
         if (selection !== GridSelectionMode.multiple) { return; }
@@ -587,7 +588,7 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy {
                 this.nativeElement.addEventListener('compositionend', this.compositionEndHandler);
             }
         });
-        if (PlatformUtil.isIOS()) {
+        if (this.platformUtil.isIOS()) {
             this.touchManager.addEventListener(this.nativeElement, 'doubletap', this.onDoubleClick, {
                 cssProps: { } /* don't disable user-select, etc */
             } as HammerOptions);

--- a/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
@@ -182,14 +182,15 @@ describe('IgxGrid - Cell component #grid', () => {
 
     it('Should not attach doubletap handler for non-iOS', () => {
         const addListenerSpy = spyOn(HammerGesturesManager.prototype, 'addEventListener');
-        spyOn(PlatformUtil, 'isIOS').and.returnValue(false);
+        spyOn(PlatformUtil.prototype, 'isIOS').and.returnValue(false);
         const fix = TestBed.createComponent(DefaultGridComponent);
         fix.detectChanges();
+        expect(addListenerSpy).not.toHaveBeenCalled();
     });
 
     it('Should handle doubletap on iOS, trigger onDoubleClick event', () => {
         const addListenerSpy = spyOn(HammerGesturesManager.prototype, 'addEventListener');
-        spyOn(PlatformUtil, 'isIOS').and.returnValue(true);
+        spyOn(PlatformUtil.prototype, 'isIOS').and.returnValue(true);
         const fix = TestBed.createComponent(DefaultGridComponent);
         fix.detectChanges();
 

--- a/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
@@ -182,7 +182,7 @@ describe('IgxGrid - Cell component #grid', () => {
 
     it('Should not attach doubletap handler for non-iOS', () => {
         const addListenerSpy = spyOn(HammerGesturesManager.prototype, 'addEventListener');
-        spyOn(PlatformUtil.prototype, 'isIOS').and.returnValue(false);
+        spyOnProperty(PlatformUtil.prototype, 'isIOS').and.returnValue(false);
         const fix = TestBed.createComponent(DefaultGridComponent);
         fix.detectChanges();
         expect(addListenerSpy).not.toHaveBeenCalled();
@@ -190,7 +190,7 @@ describe('IgxGrid - Cell component #grid', () => {
 
     it('Should handle doubletap on iOS, trigger onDoubleClick event', () => {
         const addListenerSpy = spyOn(HammerGesturesManager.prototype, 'addEventListener');
-        spyOn(PlatformUtil.prototype, 'isIOS').and.returnValue(true);
+        spyOnProperty(PlatformUtil.prototype, 'isIOS').and.returnValue(true);
         const fix = TestBed.createComponent(DefaultGridComponent);
         fix.detectChanges();
 

--- a/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
@@ -182,20 +182,26 @@ describe('IgxGrid - Cell component #grid', () => {
 
     it('Should not attach doubletap handler for non-iOS', () => {
         const addListenerSpy = spyOn(HammerGesturesManager.prototype, 'addEventListener');
-        spyOnProperty(PlatformUtil.prototype, 'isIOS').and.returnValue(false);
+        const platformUtil: PlatformUtil = TestBed.get(PlatformUtil);
+        const oldIsIOS = platformUtil.isIOS;
+        platformUtil.isIOS = false;
         const fix = TestBed.createComponent(DefaultGridComponent);
         fix.detectChanges();
+        // spyOnProperty(PlatformUtil.prototype, 'isIOS').and.returnValue(false);
         expect(addListenerSpy).not.toHaveBeenCalled();
+
+        platformUtil.isIOS = oldIsIOS;
     });
 
     it('Should handle doubletap on iOS, trigger onDoubleClick event', () => {
         const addListenerSpy = spyOn(HammerGesturesManager.prototype, 'addEventListener');
-        spyOnProperty(PlatformUtil.prototype, 'isIOS').and.returnValue(true);
+        const platformUtil: PlatformUtil = TestBed.get(PlatformUtil);
+        const oldIsIOS = platformUtil.isIOS;
+        platformUtil.isIOS = true;
         const fix = TestBed.createComponent(DefaultGridComponent);
         fix.detectChanges();
 
         const grid = fix.componentInstance.instance;
-        const cellElem = fix.debugElement.query(By.css(CELL_CSS_CLASS));
         const firstCell = grid.getCellByColumn(0, 'index');
 
         // should attach 'doubletap'
@@ -218,6 +224,8 @@ describe('IgxGrid - Cell component #grid', () => {
         expect(event.preventDefault).toHaveBeenCalled();
         expect(grid.onDoubleClick.emit).toHaveBeenCalledWith(args);
         expect(firstCell).toBe(fix.componentInstance.clickedCell);
+
+        platformUtil.isIOS = oldIsIOS;
     });
 
     it('Should blur selected cell when scrolling with mouse wheel', (async () => {

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-cell.component.ts
@@ -6,6 +6,7 @@ import { IgxHierarchicalGridComponent } from './hierarchical-grid.component';
 // import { IgxHierarchicalSelectionAPIService } from './selection';
 import { IgxGridSelectionService, IgxGridCRUDService } from '../../core/grid-selection';
 import { HammerGesturesManager } from '../../core/touch';
+import { PlatformUtil } from '../../core/utils';
 
 @Component({
     changeDetection: ChangeDetectionStrategy.OnPush,
@@ -27,9 +28,10 @@ export class IgxHierarchicalGridCellComponent extends IgxGridCellComponent imple
         public cdr: ChangeDetectorRef,
         private helement: ElementRef,
         protected zone: NgZone,
-        touchManager: HammerGesturesManager
+        touchManager: HammerGesturesManager,
+        protected platformUtil: PlatformUtil
         ) {
-            super(selectionService, crudService, gridAPI, cdr, helement, zone, touchManager);
+            super(selectionService, crudService, gridAPI, cdr, helement, zone, touchManager, platformUtil);
             // this.hSelection = <IgxHierarchicalSelectionAPIService>selection;
          }
 

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-cell.component.ts
@@ -3,7 +3,7 @@ import { Component, ChangeDetectorRef, ElementRef, ViewChild, Inject,
 import { IgxGridCellComponent } from '../cell.component';
 import { IgxTreeGridAPIService } from './tree-grid-api.service';
 import { GridBaseAPIService } from '../api.service';
-import { getNodeSizeViaRange } from '../../core/utils';
+import { getNodeSizeViaRange, PlatformUtil } from '../../core/utils';
 import { DOCUMENT } from '@angular/common';
 import { IgxGridBaseComponent, IGridDataBindable } from '../grid';
 import { IgxGridSelectionService, IgxGridCRUDService } from '../../core/grid-selection';
@@ -26,8 +26,9 @@ export class IgxTreeGridCellComponent extends IgxGridCellComponent implements On
                 element: ElementRef,
                 protected zone: NgZone,
                 touchManager: HammerGesturesManager,
-                @Inject(DOCUMENT) public document) {
-        super(selectionService, crudService, gridAPI, cdr, element, zone, touchManager);
+                @Inject(DOCUMENT) public document,
+                protected platformUtil: PlatformUtil) {
+        super(selectionService, crudService, gridAPI, cdr, element, zone, touchManager, platformUtil);
         this.treeGridAPI = <IgxTreeGridAPIService>gridAPI;
     }
 

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
@@ -525,7 +525,7 @@ describe('Navigation Drawer', () => {
         window.dispatchEvent(new Event('resize'));
 
         // wait for debounce
-        await wait(2000);
+        await wait(200);
         expect(fixture.componentInstance.navDrawer.pin).toBe(false, `Shouldn't change state on resize if window width is the same`);
         expect(fixture.componentInstance.pin).toBe(true, 'Parent component pin remain on resize if window width is the same');
         fixture.componentInstance.pin = true;
@@ -535,7 +535,7 @@ describe('Navigation Drawer', () => {
         window.dispatchEvent(new Event('resize'));
 
         // wait for debounce
-        await wait(2000);
+        await wait(200);
         expect(fixture.componentInstance.navDrawer.pin).toBe(true, 'Should pin on window resize over threshold');
         expect(fixture.componentInstance.pin).toBe(true, 'Parent pin update on window resize over threshold');
 
@@ -543,7 +543,7 @@ describe('Navigation Drawer', () => {
         window.dispatchEvent(new Event('resize'));
 
         // wait for debounce
-        await wait(2000);
+        await wait(200);
         expect(fixture.componentInstance.navDrawer.pin).toBe(false, 'Should un-pin on window resize below threshold');
         expect(fixture.componentInstance.pin).toBe(false, 'Parent pin update on window resize below threshold');
         fixture.componentInstance.pinThreshold = 500;

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
@@ -1,11 +1,4 @@
-import {
-    async,
-    ComponentFixture,
-    fakeAsync,
-    TestBed,
-    tick
-} from '@angular/core/testing';
-
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component, ViewChild, PLATFORM_ID } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { wait } from '../test-utils/ui-interactions.spec';
@@ -44,6 +37,10 @@ describe('Navigation Drawer', () => {
 
     afterEach(() => {
         jasmine.DEFAULT_TIMEOUT_INTERVAL = oldTimeout;
+    });
+
+    afterAll(() => {
+        TestBed.resetTestingModule();
     });
 
     it('should initialize without DI service', async(() => {
@@ -561,6 +558,7 @@ describe('Navigation Drawer', () => {
         const originalWidth = window.innerWidth;
         const platformUtil: PlatformUtil = new PlatformUtil(TestBed.get(PLATFORM_ID));
         const drawer = new IgxNavigationDrawerComponent(null, null, null, null, platformUtil);
+
         // re-enable `getWindowWidth`
         const widthSpy = (widthSpyOverride as jasmine.Spy).and.callThrough();
         let width = widthSpy.call(drawer);

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
@@ -6,19 +6,20 @@ import {
     tick
 } from '@angular/core/testing';
 
-import { Component, ViewChild } from '@angular/core';
+import { Component, ViewChild, PLATFORM_ID } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { wait } from '../test-utils/ui-interactions.spec';
 import { IgxNavigationDrawerModule } from './navigation-drawer.module';
 import { IgxNavigationToggleDirective, IgxNavigationCloseDirective } from '../core/navigation/directives';
 import { IgxNavigationDrawerComponent } from './navigation-drawer.component';
 import { IgxNavigationService } from '../core/navigation/nav.service';
+import { PlatformUtil } from '../core/utils';
 
 // HammerJS simulator from https://github.com/hammerjs/simulator, manual typings TODO
 declare var Simulator: any;
 const oldTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
-describe('Navigation Drawer', () => {
+fdescribe('Navigation Drawer', () => {
     let widthSpyOverride: jasmine.Spy;
     // configureTestSuite();
     beforeEach(async(() => {
@@ -49,9 +50,9 @@ describe('Navigation Drawer', () => {
         TestBed.compileComponents().then(() => {
             const fixture = TestBed.createComponent(TestComponent);
             fixture.detectChanges();
-            expect(fixture.componentInstance.viewChild instanceof
+            expect(fixture.componentInstance.navDrawer instanceof
                 IgxNavigationDrawerComponent).toBeTruthy();
-            expect(fixture.componentInstance.viewChild.state).toBeNull();
+            expect(fixture.componentInstance.navDrawer.state).toBeNull();
         });
     }));
 
@@ -60,10 +61,10 @@ describe('Navigation Drawer', () => {
             const fixture = TestBed.createComponent(TestComponentDIComponent);
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.viewChild).toBeDefined();
-            expect(fixture.componentInstance.viewChild instanceof
+            expect(fixture.componentInstance.navDrawer).toBeDefined();
+            expect(fixture.componentInstance.navDrawer instanceof
                 IgxNavigationDrawerComponent).toBeTruthy();
-            expect(fixture.componentInstance.viewChild.state instanceof IgxNavigationService)
+            expect(fixture.componentInstance.navDrawer.state instanceof IgxNavigationService)
                 .toBeTruthy();
         });
     }));
@@ -75,8 +76,8 @@ describe('Navigation Drawer', () => {
             const fixture = TestBed.createComponent(TestComponent);
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.viewChild).toBeDefined();
-            expect(fixture.componentInstance.viewChild instanceof
+            expect(fixture.componentInstance.navDrawer).toBeDefined();
+            expect(fixture.componentInstance.navDrawer instanceof
                 IgxNavigationDrawerComponent).toBeTruthy();
             expect(() => fixture.destroy()).not.toThrow();
         });
@@ -88,17 +89,17 @@ describe('Navigation Drawer', () => {
             fixture.detectChanges();
             const domNavDrawer = fixture.debugElement.query(By.css('igx-nav-drawer')).nativeElement;
 
-            expect(fixture.componentInstance.viewChild.id).toContain('igx-nav-drawer-');
+            expect(fixture.componentInstance.navDrawer.id).toContain('igx-nav-drawer-');
             expect(domNavDrawer.id).toContain('igx-nav-drawer-');
-            expect(fixture.componentInstance.viewChild.drawer.classList).toContain('igx-nav-drawer__aside');
-            expect(fixture.componentInstance.viewChild.overlay.classList).toContain('igx-nav-drawer__overlay');
-            expect(fixture.componentInstance.viewChild.styleDummy.classList).toContain('igx-nav-drawer__style-dummy');
-            expect(fixture.componentInstance.viewChild.hasAnimateWidth).toBeFalsy();
+            expect(fixture.componentInstance.navDrawer.drawer.classList).toContain('igx-nav-drawer__aside');
+            expect(fixture.componentInstance.navDrawer.overlay.classList).toContain('igx-nav-drawer__overlay');
+            expect(fixture.componentInstance.navDrawer.styleDummy.classList).toContain('igx-nav-drawer__style-dummy');
+            expect(fixture.componentInstance.navDrawer.hasAnimateWidth).toBeFalsy();
 
-            fixture.componentInstance.viewChild.id = 'customNavDrawer';
+            fixture.componentInstance.navDrawer.id = 'customNavDrawer';
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.viewChild.id).toBe('customNavDrawer');
+            expect(fixture.componentInstance.navDrawer.id).toBe('customNavDrawer');
             expect(domNavDrawer.id).toBe('customNavDrawer');
 
         }).catch((reason) => {
@@ -118,8 +119,8 @@ describe('Navigation Drawer', () => {
         TestBed.compileComponents().then(() => {
             const fixture = TestBed.createComponent(TestComponentDIComponent);
             fixture.detectChanges();
-            const state: IgxNavigationService = fixture.componentInstance.viewChild.state;
-            const touchManager = fixture.componentInstance.viewChild.touchManager;
+            const state: IgxNavigationService = fixture.componentInstance.navDrawer.state;
+            const touchManager = fixture.componentInstance.navDrawer.touchManager;
 
             expect(state.get('testNav')).toBeDefined();
             expect(touchManager.getManagerForElement(document) instanceof Hammer.Manager).toBeTruthy();
@@ -137,7 +138,7 @@ describe('Navigation Drawer', () => {
         TestBed.compileComponents().then(() => {
             const fixture = TestBed.createComponent(TestComponentDIComponent);
             fixture.detectChanges();
-            const drawer: IgxNavigationDrawerComponent = fixture.componentInstance.viewChild;
+            const drawer: IgxNavigationDrawerComponent = fixture.componentInstance.navDrawer;
             expect(drawer.isOpen).toBeFalsy();
 
             drawer.open();
@@ -168,7 +169,7 @@ describe('Navigation Drawer', () => {
         TestBed.compileComponents().then(() => {
             fixture = TestBed.createComponent(TestComponentDIComponent);
             fixture.detectChanges();
-            drawer = fixture.componentInstance.viewChild;
+            drawer = fixture.componentInstance.navDrawer;
 
             spyOn(drawer.closing, 'emit');
             spyOn(drawer.closed, 'emit');
@@ -210,7 +211,7 @@ describe('Navigation Drawer', () => {
             const fixture = TestBed.createComponent(TestComponentDIComponent);
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.viewChild.hasAnimateWidth).toBeTruthy();
+            expect(fixture.componentInstance.navDrawer.hasAnimateWidth).toBeTruthy();
             expect(fixture.debugElement.query((x) => x.nativeNode.nodeName === 'ASIDE').nativeElement.classList)
                 .toContain('igx-nav-drawer__aside--mini');
         }).catch((reason) => {
@@ -249,7 +250,7 @@ describe('Navigation Drawer', () => {
             fixture.componentInstance.miniView = true;
             fixture.detectChanges();
 
-            expect(asideElem.styles['width']).toEqual(fixture.componentInstance.viewChild.miniWidth);
+            expect(asideElem.styles['width']).toEqual(fixture.componentInstance.navDrawer.miniWidth);
         }).catch((reason) => {
             return Promise.reject(reason);
         });
@@ -269,15 +270,15 @@ describe('Navigation Drawer', () => {
             const fixture = TestBed.createComponent(TestComponentPin);
             fixture.detectChanges();
 
-            expect(fixture.componentInstance.viewChild.pin).toBeTruthy();
+            expect(fixture.componentInstance.navDrawer.pin).toBeTruthy();
             expect(fixture.debugElement.query((x) => x.nativeNode.nodeName === 'ASIDE').nativeElement.classList)
                 .toContain('igx-nav-drawer__aside--pinned');
 
-            expect(fixture.componentInstance.viewChild.enableGestures).toBe(false);
+            expect(fixture.componentInstance.navDrawer.enableGestures).toBe(false);
 
             fixture.componentInstance.enableGestures = 'true';
             fixture.detectChanges();
-            expect(fixture.componentInstance.viewChild.enableGestures).toBeTruthy();
+            expect(fixture.componentInstance.navDrawer.enableGestures).toBeTruthy();
 
         }).catch((reason) => {
             return Promise.reject(reason);
@@ -326,7 +327,7 @@ describe('Navigation Drawer', () => {
         TestBed.compileComponents()
             .then(() => {
                 const fixture = TestBed.createComponent(TestComponentPin);
-                const drawer = fixture.componentInstance.viewChild;
+                const drawer = fixture.componentInstance.navDrawer;
                 drawer.isOpen = true;
                 fixture.detectChanges();
                 const drawerElem = fixture.debugElement.query((x) => x.nativeNode.nodeName === 'IGX-NAV-DRAWER').nativeElement;
@@ -355,22 +356,22 @@ describe('Navigation Drawer', () => {
         TestBed.compileComponents().then(() => {
             fixture = TestBed.createComponent(TestComponentDIComponent);
             fixture.detectChanges();
-            expect(fixture.componentInstance.viewChild.isOpen).toEqual(false);
+            expect(fixture.componentInstance.navDrawer.isOpen).toEqual(false);
 
             // timeouts are +50 on the gesture to allow the swipe to be detected and triggered after the touches:
             return swipe(document.body, 80, 10, 100, 250, 0);
         })
             .then(() => {
-                expect(fixture.componentInstance.viewChild.isOpen)
+                expect(fixture.componentInstance.navDrawer.isOpen)
                     .toEqual(false, 'should ignore swipes too far away from the edge');
                 return swipe(document.body, 10, 10, 150, 250, 0);
             })
             .then(() => {
-                expect(fixture.componentInstance.viewChild.isOpen).toEqual(true, 'Should accept edge swipe');
+                expect(fixture.componentInstance.navDrawer.isOpen).toEqual(true, 'Should accept edge swipe');
                 return swipe(document.body, 180, 10, 150, -180, 0);
             })
             .then(() => {
-                expect(fixture.componentInstance.viewChild.isOpen).toEqual(false);
+                expect(fixture.componentInstance.navDrawer.isOpen).toEqual(false);
                 done();
             })
             .catch((reason) => {
@@ -386,9 +387,9 @@ describe('Navigation Drawer', () => {
         TestBed.compileComponents().then(() => {
             fixture = TestBed.createComponent(TestComponentDIComponent);
             fixture.detectChanges();
-            navDrawer = fixture.componentInstance.viewChild;
+            navDrawer = fixture.componentInstance.navDrawer;
 
-            expect(fixture.componentInstance.viewChild.isOpen).toEqual(false);
+            expect(fixture.componentInstance.navDrawer.isOpen).toEqual(false);
 
             const listener = navDrawer.renderer.listen(document.body, 'panmove', () => {
 
@@ -443,12 +444,12 @@ describe('Navigation Drawer', () => {
 
             fixture.componentInstance.drawerMiniWidth = 68;
             fixture.detectChanges();
-            expect(fixture.componentInstance.viewChild.maxEdgeZone)
+            expect(fixture.componentInstance.navDrawer.maxEdgeZone)
                 .toBe(fixture.componentInstance.drawerMiniWidth * 1.1);
 
             fixture.componentInstance.drawerMiniWidth = 80;
             fixture.detectChanges();
-            expect(fixture.componentInstance.viewChild.maxEdgeZone)
+            expect(fixture.componentInstance.navDrawer.maxEdgeZone)
                 .toBe(fixture.componentInstance.drawerMiniWidth * 1.1);
 
         }).catch((reason) => {
@@ -456,7 +457,7 @@ describe('Navigation Drawer', () => {
         });
     }));
 
-    it('should update width from css or property', fakeAsync((done) => {
+    fit('should update width from css or property', async(done) => {
         const template = `<igx-nav-drawer [miniWidth]="drawerMiniWidth" [width]="drawerWidth">
                             <ng-template igxDrawer></ng-template>
                             <ng-template igxDrawerMini></ng-template>
@@ -469,41 +470,36 @@ describe('Navigation Drawer', () => {
         });
 
         // compile after overrides, not in before each: https://github.com/angular/angular/issues/10712
-        TestBed.compileComponents().then(() => {
-            fixture = TestBed.createComponent(TestComponentDIComponent);
-            fixture.detectChanges();
-            // const comp: DebugElement = fixture.debugElement.query(By.component(IgxNavbarComponent));
+        await TestBed.compileComponents();
+        fixture = TestBed.createComponent(TestComponentDIComponent);
+        fixture.detectChanges();
+        // const comp: DebugElement = fixture.debugElement.query(By.component(IgxNavbarComponent));
 
-            // defaults:
-            expect(fixture.componentInstance.viewChild.drawer.style.width).toBe('');
-            return fixture.componentInstance.viewChild.open();
-        })
-            .then(() => {
-                expect(fixture.componentInstance.viewChild.drawer.style.width).toBe('');
+        // defaults:
+        expect(fixture.componentInstance.navDrawer.drawer.style.width).toBe('');
+        fixture.componentInstance.navDrawer.open();
+        await wait(200);
 
-                fixture.componentInstance.drawerMiniWidth = '80px';
-                fixture.componentInstance.drawerWidth = '250px';
-                fixture.detectChanges();
-                return fixture.whenStable(); // let changes apply in the meantime
-            })
-            .then(() => {
-                expect(fixture.componentInstance.viewChild.drawer.style.width).toBe('250px');
-                return fixture.componentInstance.viewChild.close();
-            })
-            .then(() => {
-                tick(1000);
-                expect(fixture.componentInstance.viewChild.drawer.style.width).toBe('80px');
-                fixture.componentInstance.drawerWidth = '350px';
-                fixture.detectChanges();
-                return fixture.componentInstance.viewChild.open();
-            })
-            .then(() => {
-                expect(fixture.componentInstance.viewChild.drawer.style.width).toBe('350px');
-                done();
-            }).catch((reason) => {
-                return Promise.reject(reason);
-            });
-    }));
+        expect(fixture.componentInstance.navDrawer.drawer.style.width).toBe('');
+
+        fixture.componentInstance.drawerMiniWidth = '80px';
+        fixture.componentInstance.drawerWidth = '250px';
+        fixture.detectChanges();
+        await wait(200);
+
+        expect(fixture.componentInstance.navDrawer.drawer.style.width).toBe('250px');
+        fixture.componentInstance.navDrawer.close();
+        await wait(200);
+
+        expect(fixture.componentInstance.navDrawer.drawer.style.width).toBe('80px');
+        fixture.componentInstance.drawerWidth = '350px';
+        fixture.detectChanges();
+        fixture.componentInstance.navDrawer.open();
+        await wait(200);
+
+        expect(fixture.componentInstance.navDrawer.drawer.style.width).toBe('350px');
+        done();
+    });
 
     it('should update pin based on window width (pinThreshold)', async (done) => {
         const template = `'<igx-nav-drawer [(pin)]="pin" [pinThreshold]="pinThreshold"></igx-nav-drawer>'`;
@@ -523,7 +519,7 @@ describe('Navigation Drawer', () => {
         await fixture.whenStable();
 
         // defaults:
-        expect(fixture.componentInstance.viewChild.pin).toBe(false, 'Should be initially unpinned');
+        expect(fixture.componentInstance.navDrawer.pin).toBe(false, 'Should be initially unpinned');
         expect(fixture.componentInstance.pin).toBe(false, 'Parent component pin should update initially');
 
         // manual pin override
@@ -532,8 +528,8 @@ describe('Navigation Drawer', () => {
         window.dispatchEvent(new Event('resize'));
 
         // wait for debounce
-        await wait(200);
-        expect(fixture.componentInstance.viewChild.pin).toBe(false, `Shouldn't change state on resize if window width is the same`);
+        await wait(2000);
+        expect(fixture.componentInstance.navDrawer.pin).toBe(false, `Shouldn't change state on resize if window width is the same`);
         expect(fixture.componentInstance.pin).toBe(true, 'Parent component pin remain on resize if window width is the same');
         fixture.componentInstance.pin = true;
         fixture.detectChanges();
@@ -542,33 +538,37 @@ describe('Navigation Drawer', () => {
         window.dispatchEvent(new Event('resize'));
 
         // wait for debounce
-        await wait(200);
-        expect(fixture.componentInstance.viewChild.pin).toBe(true, 'Should pin on window resize over threshold');
+        await wait(2000);
+        expect(fixture.componentInstance.navDrawer.pin).toBe(true, 'Should pin on window resize over threshold');
         expect(fixture.componentInstance.pin).toBe(true, 'Parent pin update on window resize over threshold');
 
         widthSpyOverride.and.returnValue(768);
         window.dispatchEvent(new Event('resize'));
 
         // wait for debounce
-        await wait(200);
-        expect(fixture.componentInstance.viewChild.pin).toBe(false, 'Should un-pin on window resize below threshold');
+        await wait(2000);
+        expect(fixture.componentInstance.navDrawer.pin).toBe(false, 'Should un-pin on window resize below threshold');
         expect(fixture.componentInstance.pin).toBe(false, 'Parent pin update on window resize below threshold');
         fixture.componentInstance.pinThreshold = 500;
         expect(() => fixture.detectChanges()).not.toThrow();
         await fixture.whenStable();
-        expect(fixture.componentInstance.viewChild.pin).toBe(true, 'Should re-pin on window resize over threshold');
+        expect(fixture.componentInstance.navDrawer.pin).toBe(true, 'Should re-pin on window resize over threshold');
         expect(fixture.componentInstance.pin).toBe(true, 'Parent pin update on re-pin');
         done();
     });
 
     it('should get correct window width', (done) => {
         const originalWidth = window.innerWidth;
-
+        const platformUtil: PlatformUtil = new PlatformUtil(TestBed.get(PLATFORM_ID));
+        const drawer = new IgxNavigationDrawerComponent(null, null, null, null, platformUtil);
         // re-enable `getWindowWidth`
         const widthSpy = (widthSpyOverride as jasmine.Spy).and.callThrough();
-        expect(widthSpy.call(null)).toEqual(originalWidth);
+        let width = widthSpy.call(drawer);
+        expect(width).toEqual(originalWidth);
+
         (window as any).innerWidth = 0; // not that readonly in Chrome
-        expect(widthSpy.call(null)).toEqual(screen.width);
+        width = widthSpy.call(drawer);
+        expect(width).toEqual(screen.width);
         (window as any).innerWidth = originalWidth;
         done();
     });
@@ -615,7 +615,7 @@ describe('Navigation Drawer', () => {
     template: '<igx-nav-drawer></igx-nav-drawer>'
 })
 class TestComponent {
-    @ViewChild(IgxNavigationDrawerComponent, { static: true }) public viewChild: IgxNavigationDrawerComponent;
+    @ViewChild(IgxNavigationDrawerComponent, { static: true }) public navDrawer: IgxNavigationDrawerComponent;
 }
 
 @Component({
@@ -626,7 +626,7 @@ class TestComponent {
 class TestComponentDIComponent {
     public drawerMiniWidth: string | number;
     public drawerWidth: string | number;
-    @ViewChild(IgxNavigationDrawerComponent, { static: true }) public viewChild: IgxNavigationDrawerComponent;
+    @ViewChild(IgxNavigationDrawerComponent, { static: true }) public navDrawer: IgxNavigationDrawerComponent;
 }
 
 class TestComponentPin extends TestComponentDIComponent {

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
@@ -19,7 +19,7 @@ import { PlatformUtil } from '../core/utils';
 declare var Simulator: any;
 const oldTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
-fdescribe('Navigation Drawer', () => {
+describe('Navigation Drawer', () => {
     let widthSpyOverride: jasmine.Spy;
     // configureTestSuite();
     beforeEach(async(() => {
@@ -457,7 +457,7 @@ fdescribe('Navigation Drawer', () => {
         });
     }));
 
-    fit('should update width from css or property', async(done) => {
+    it('should update width from css or property', async(done) => {
         const template = `<igx-nav-drawer [miniWidth]="drawerMiniWidth" [width]="drawerWidth">
                             <ng-template igxDrawer></ng-template>
                             <ng-template igxDrawerMini></ng-template>

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
@@ -14,13 +14,15 @@ import {
     Output,
     Renderer,
     SimpleChange,
-    ViewChild
+    ViewChild,
+    PLATFORM_ID
 } from '@angular/core';
 import { fromEvent, interval, Subscription } from 'rxjs';
 import { debounce } from 'rxjs/operators';
 import { IgxNavigationService, IToggleView } from '../core/navigation';
 import { HammerGesturesManager } from '../core/touch';
 import { IgxNavDrawerMiniTemplateDirective, IgxNavDrawerTemplateDirective } from './navigation-drawer.directives';
+import { isPlatformBrowser } from '@angular/common';
 
 let NEXT_ID = 0;
 /**
@@ -612,6 +614,10 @@ export class IgxNavigationDrawerComponent implements
     }
 
     private getWindowWidth() {
+        if (!isPlatformBrowser(PLATFORM_ID)) {
+            return;
+        }
+
         return (window.innerWidth > 0) ? window.innerWidth : screen.width;
     }
 
@@ -619,11 +625,15 @@ export class IgxNavigationDrawerComponent implements
      * Sets the drawer width.
      */
     private setDrawerWidth(width: string) {
-        requestAnimationFrame(() => {
-            if (this.drawer) {
-                this.renderer.setElementStyle(this.drawer, 'width', width);
-            }
-        });
+        if (isPlatformBrowser(PLATFORM_ID)) {
+            requestAnimationFrame(() => {
+                if (this.drawer) {
+                    this.renderer.setElementStyle(this.drawer, 'width', width);
+                }
+            });
+        } else {
+            this.renderer.setElementStyle(this.drawer, 'width', width);
+        }
     }
 
     /**
@@ -649,7 +659,7 @@ export class IgxNavigationDrawerComponent implements
             this._touchManager.addGlobalEventListener('document', 'panmove', this.pan);
             this._touchManager.addGlobalEventListener('document', 'panend', this.panEnd);
         }
-        if (!this._resizeObserver) {
+        if (!this._resizeObserver && isPlatformBrowser(PLATFORM_ID)) {
             this._resizeObserver = fromEvent(window, 'resize').pipe(debounce(() => interval(150)))
                 .subscribe((value) => {
                     this.checkPinThreshold(value);
@@ -805,19 +815,27 @@ export class IgxNavigationDrawerComponent implements
      * @param opacity optional value to apply to the overlay
      */
     private setXSize(x: number, opacity?: string) {
-        // Angular polyfills patches window.requestAnimationFrame, but switch to DomAdapter API (TODO)
-        window.requestAnimationFrame(() => {
-            if (this.hasAnimateWidth) {
-                this.renderer.setElementStyle(this.drawer, 'width', x ? Math.abs(x) + 'px' : '');
-            } else {
-                this.renderer.setElementStyle(this.drawer, 'transform', x ? 'translate3d(' + x + 'px,0,0)' : '');
-                this.renderer.setElementStyle(this.drawer, '-webkit-transform',
-                    x ? 'translate3d(' + x + 'px,0,0)' : '');
-            }
-            if (opacity !== undefined) {
-                this.renderer.setElementStyle(this.overlay, 'opacity', opacity);
-            }
-        });
+        if (isPlatformBrowser(PLATFORM_ID)) {
+            // Angular polyfills patches window.requestAnimationFrame, but switch to DomAdapter API (TODO)
+            window.requestAnimationFrame(() => {
+                this.setXSizeInternal(x, opacity);
+            });
+        } else {
+            this.setXSizeInternal(x, opacity);
+        }
+    }
+
+    private setXSizeInternal(x: number, opacity?: string) {
+        if (this.hasAnimateWidth) {
+            this.renderer.setElementStyle(this.drawer, 'width', x ? Math.abs(x) + 'px' : '');
+        } else {
+            this.renderer.setElementStyle(this.drawer, 'transform', x ? 'translate3d(' + x + 'px,0,0)' : '');
+            this.renderer.setElementStyle(this.drawer, '-webkit-transform',
+                x ? 'translate3d(' + x + 'px,0,0)' : '');
+        }
+        if (opacity !== undefined) {
+            this.renderer.setElementStyle(this.overlay, 'opacity', opacity);
+        }
     }
 
     private toggleOpenedEvent = (evt?) => {

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
@@ -14,15 +14,14 @@ import {
     Output,
     Renderer,
     SimpleChange,
-    ViewChild,
-    PLATFORM_ID
+    ViewChild
 } from '@angular/core';
 import { fromEvent, interval, Subscription } from 'rxjs';
 import { debounce } from 'rxjs/operators';
 import { IgxNavigationService, IToggleView } from '../core/navigation';
 import { HammerGesturesManager } from '../core/touch';
 import { IgxNavDrawerMiniTemplateDirective, IgxNavDrawerTemplateDirective } from './navigation-drawer.directives';
-import { isPlatformBrowser } from '@angular/common';
+import { PlatformUtil } from '../core/utils';
 
 let NEXT_ID = 0;
 /**
@@ -419,7 +418,8 @@ export class IgxNavigationDrawerComponent implements
         @Optional() private _state: IgxNavigationService,
         // private animate: AnimationBuilder, TODO
         protected renderer: Renderer,
-        private _touchManager: HammerGesturesManager) {
+        private _touchManager: HammerGesturesManager,
+        private platformUtil: PlatformUtil) {
     }
 
     /**
@@ -614,7 +614,7 @@ export class IgxNavigationDrawerComponent implements
     }
 
     private getWindowWidth() {
-        if (!isPlatformBrowser(PLATFORM_ID)) {
+        if (!this.platformUtil.isPlatformBrowser()) {
             return;
         }
 
@@ -625,7 +625,7 @@ export class IgxNavigationDrawerComponent implements
      * Sets the drawer width.
      */
     private setDrawerWidth(width: string) {
-        if (isPlatformBrowser(PLATFORM_ID)) {
+        if (this.platformUtil.isPlatformBrowser()) {
             requestAnimationFrame(() => {
                 if (this.drawer) {
                     this.renderer.setElementStyle(this.drawer, 'width', width);
@@ -659,7 +659,7 @@ export class IgxNavigationDrawerComponent implements
             this._touchManager.addGlobalEventListener('document', 'panmove', this.pan);
             this._touchManager.addGlobalEventListener('document', 'panend', this.panEnd);
         }
-        if (!this._resizeObserver && isPlatformBrowser(PLATFORM_ID)) {
+        if (!this._resizeObserver && this.platformUtil.isPlatformBrowser()) {
             this._resizeObserver = fromEvent(window, 'resize').pipe(debounce(() => interval(150)))
                 .subscribe((value) => {
                     this.checkPinThreshold(value);
@@ -815,7 +815,7 @@ export class IgxNavigationDrawerComponent implements
      * @param opacity optional value to apply to the overlay
      */
     private setXSize(x: number, opacity?: string) {
-        if (isPlatformBrowser(PLATFORM_ID)) {
+        if (this.platformUtil.isPlatformBrowser()) {
             // Angular polyfills patches window.requestAnimationFrame, but switch to DomAdapter API (TODO)
             window.requestAnimationFrame(() => {
                 this.setXSizeInternal(x, opacity);

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
@@ -621,7 +621,7 @@ export class IgxNavigationDrawerComponent implements
      * Sets the drawer width.
      */
     private setDrawerWidth(width: string) {
-        if (this.platformUtil.isPlatformBrowser) {
+        if (this.platformUtil.isBrowser) {
             requestAnimationFrame(() => {
                 if (this.drawer) {
                     this.renderer.setElementStyle(this.drawer, 'width', width);
@@ -655,7 +655,7 @@ export class IgxNavigationDrawerComponent implements
             this._touchManager.addGlobalEventListener('document', 'panmove', this.pan);
             this._touchManager.addGlobalEventListener('document', 'panend', this.panEnd);
         }
-        if (!this._resizeObserver && this.platformUtil.isPlatformBrowser) {
+        if (!this._resizeObserver && this.platformUtil.isBrowser) {
             this._resizeObserver = fromEvent(window, 'resize').pipe(debounce(() => interval(150)))
                 .subscribe((value) => {
                     this.checkPinThreshold(value);
@@ -673,7 +673,7 @@ export class IgxNavigationDrawerComponent implements
     }
 
     private checkPinThreshold = (evt?: Event) => {
-        if (!this.platformUtil.isPlatformBrowser) {
+        if (!this.platformUtil.isBrowser) {
             return;
         }
         let windowWidth;

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
@@ -614,10 +614,6 @@ export class IgxNavigationDrawerComponent implements
     }
 
     private getWindowWidth() {
-        if (!this.platformUtil.isPlatformBrowser()) {
-            return;
-        }
-
         return (window.innerWidth > 0) ? window.innerWidth : screen.width;
     }
 
@@ -625,7 +621,7 @@ export class IgxNavigationDrawerComponent implements
      * Sets the drawer width.
      */
     private setDrawerWidth(width: string) {
-        if (this.platformUtil.isPlatformBrowser()) {
+        if (this.platformUtil.isPlatformBrowser) {
             requestAnimationFrame(() => {
                 if (this.drawer) {
                     this.renderer.setElementStyle(this.drawer, 'width', width);
@@ -659,7 +655,7 @@ export class IgxNavigationDrawerComponent implements
             this._touchManager.addGlobalEventListener('document', 'panmove', this.pan);
             this._touchManager.addGlobalEventListener('document', 'panend', this.panEnd);
         }
-        if (!this._resizeObserver && this.platformUtil.isPlatformBrowser()) {
+        if (!this._resizeObserver && this.platformUtil.isPlatformBrowser) {
             this._resizeObserver = fromEvent(window, 'resize').pipe(debounce(() => interval(150)))
                 .subscribe((value) => {
                     this.checkPinThreshold(value);
@@ -677,6 +673,9 @@ export class IgxNavigationDrawerComponent implements
     }
 
     private checkPinThreshold = (evt?: Event) => {
+        if (!this.platformUtil.isPlatformBrowser) {
+            return;
+        }
         let windowWidth;
         if (this.pinThreshold) {
             windowWidth = this.getWindowWidth();
@@ -815,27 +814,19 @@ export class IgxNavigationDrawerComponent implements
      * @param opacity optional value to apply to the overlay
      */
     private setXSize(x: number, opacity?: string) {
-        if (this.platformUtil.isPlatformBrowser()) {
-            // Angular polyfills patches window.requestAnimationFrame, but switch to DomAdapter API (TODO)
-            window.requestAnimationFrame(() => {
-                this.setXSizeInternal(x, opacity);
-            });
-        } else {
-            this.setXSizeInternal(x, opacity);
-        }
-    }
-
-    private setXSizeInternal(x: number, opacity?: string) {
-        if (this.hasAnimateWidth) {
-            this.renderer.setElementStyle(this.drawer, 'width', x ? Math.abs(x) + 'px' : '');
-        } else {
-            this.renderer.setElementStyle(this.drawer, 'transform', x ? 'translate3d(' + x + 'px,0,0)' : '');
-            this.renderer.setElementStyle(this.drawer, '-webkit-transform',
-                x ? 'translate3d(' + x + 'px,0,0)' : '');
-        }
-        if (opacity !== undefined) {
-            this.renderer.setElementStyle(this.overlay, 'opacity', opacity);
-        }
+        // Angular polyfills patches window.requestAnimationFrame, but switch to DomAdapter API (TODO)
+        window.requestAnimationFrame(() => {
+            if (this.hasAnimateWidth) {
+                this.renderer.setElementStyle(this.drawer, 'width', x ? Math.abs(x) + 'px' : '');
+            } else {
+                const transform = x ? 'translate3d(' + x + 'px,0,0)' : '';
+                this.renderer.setElementStyle(this.drawer, 'transform', transform);
+                this.renderer.setElementStyle(this.drawer, '-webkit-transform', transform);
+            }
+            if (opacity !== undefined) {
+                this.renderer.setElementStyle(this.overlay, 'opacity', opacity);
+            }
+        });
     }
 
     private toggleOpenedEvent = (evt?) => {


### PR DESCRIPTION
There were some places in `touch.ts` as well as in `IgxNavDrawer` where we were calling browser related things, like `requestAnimationFrame`. Now we are checking if there platform where build runs is browser platform. If not, e.g. server side rendering, we skip calling browsers' methods.

Closes #4426   

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 