### PR TITLE
refactor(schematics): use @igniteui/angular-schematics on ng-add

### DIFF
--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -79,7 +79,7 @@
         "web-animations-js": "^2.3.2"
     },
     "devDependencies": {
-        "igniteui-cli": "~4.2.0"
+        "@igniteui/angular-schematics": "^8.1.500-alpha.0"
     },
     "ng-update": {
         "migrations": "./migrations/migration-collection.json"

--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -79,7 +79,7 @@
         "web-animations-js": "^2.3.2"
     },
     "devDependencies": {
-        "@igniteui/angular-schematics": "^8.1.500-alpha.0"
+        "@igniteui/angular-schematics": "^8.2.500-alpha.3"
     },
     "ng-update": {
         "migrations": "./migrations/migration-collection.json"

--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -79,7 +79,7 @@
         "web-animations-js": "^2.3.2"
     },
     "devDependencies": {
-        "@igniteui/angular-schematics": "^8.2.500-alpha.3"
+        "@igniteui/angular-schematics": "^8.2.500-beta.0"
     },
     "ng-update": {
         "migrations": "./migrations/migration-collection.json"

--- a/projects/igniteui-angular/schematics/ng-add/index.spec.ts
+++ b/projects/igniteui-angular/schematics/ng-add/index.spec.ts
@@ -106,8 +106,8 @@ describe('ng-add schematics', () => {
     runner.runSchematic('ng-add', { normalizeCss: false }, tree);
     const pkgJsonData = JSON.parse(tree.readContent('/package.json'));
 
-    expect(pkgJsonData.devDependencies['igniteui-cli']).toBeTruthy();
-    expect(pkgJsonData.dependencies['igniteui-cli']).toBeFalsy();
+    expect(pkgJsonData.devDependencies['@igniteui/angular-schematics']).toBeTruthy();
+    expect(pkgJsonData.dependencies['@igniteui/angular-schematics']).toBeFalsy();
   });
 
   it('should properly add polyfills', () => {

--- a/projects/igniteui-angular/schematics/utils/dependency-handler.ts
+++ b/projects/igniteui-angular/schematics/utils/dependency-handler.ts
@@ -4,6 +4,8 @@ import { getWorkspace } from '@schematics/angular/utility/config';
 import { Options } from '../interfaces/options';
 import { WorkspaceProject, ProjectType, WorkspaceSchema } from '@schematics/angular/utility/workspace-models';
 
+const schematicsPackage = '@igniteui/angular-schematics';
+
 function logIncludingDependency(context: SchematicContext, pkg: string, version: string): void {
     context.logger.info(`Including ${pkg} - Version: ${version}`);
 }
@@ -65,7 +67,7 @@ export function addDependencies(options: Options): Rule {
             }
         });
 
-        addPackageToPkgJson(tree, 'igniteui-cli', pkgJson.devDependencies['igniteui-cli'], devDependencies);
+        addPackageToPkgJson(tree, schematicsPackage, pkgJson.devDependencies[schematicsPackage], devDependencies);
         return tree;
     };
 }

--- a/projects/igniteui-angular/schematics/utils/package-handler.ts
+++ b/projects/igniteui-angular/schematics/utils/package-handler.ts
@@ -1,7 +1,7 @@
 import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
 import { RunSchematicTask, NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 
-const extSchematicModule = 'igniteui-cli';
+const extSchematicModule = '@igniteui/angular-schematics';
 const schematicName = 'cli-config';
 
 export function installPackageJsonDependencies(options: any): Rule {


### PR DESCRIPTION
ng-add schematic definition is being moved [in another packages](https://github.com/IgniteUI/igniteui-cli/pull/569).

Only install `@igniteui/angular-schematics` instead of the whole `cli` on `ng-add`.
Call `@igniteui/angular-schematics:cli-config` on addition (former `igniteui/cli:cli-config`.

Closes #5928 

### Additional information (check all that apply):
 - [ ] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 