### PR TITLE
add templates for carousel indicators

### DIFF
--- a/projects/igniteui-angular/src/lib/carousel/carousel.component.html
+++ b/projects/igniteui-angular/src/lib/carousel/carousel.component.html
@@ -1,13 +1,23 @@
+<ng-template #defaultIndicator let-slide>
+        <div  [class.active]="slide.active" class="default-indicator-item"></div>
+</ng-template>
+
 <div tabindex="0" aria-label="carousel" class="igx-carousel"
         (mouseenter)="stop()"
         (mouseleave)="play()"
         (swipeleft)="next()"
         (swiperight)="prev()"
         (tap)="isPlaying ? stop() : play()">
-    <ul class="igx-carousel__indicators" [hidden]="slides.length <= 1">
-        <li *ngFor="let slide of slides" [attr.aria-label]="setAriaLabel(slide)" [attr.aria-selected]="slide.active" [class.active]="slide.active === true"
-            (click)="select(slide)"></li>
-    </ul>
+
+    <div *ngIf="showIndicators" [ngClass]="indicatorsOrientationClass">
+        <div *ngFor="let slide of slides" class ="carousel-indicator" (click)="select(slide)" [attr.aria-label]="setAriaLabel(slide)" [attr.aria-selected]="slide.active" >
+            <ng-container *ngTemplateOutlet="getIndicatorTemplate; context: {$implicit: slide};"></ng-container>
+        </div>
+    </div>
+
+    <div *ngIf="showIndicatorsLabel" [ngClass]="indicatorsOrientationClass">
+            <span>{{ current + 1 }} of {{ total }}</span>
+    </div>
     <div class="igx-carousel__inner" role="list">
         <ng-content></ng-content>
     </div>

--- a/projects/igniteui-angular/src/lib/carousel/carousel.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/carousel/carousel.component.spec.ts
@@ -50,9 +50,8 @@ describe('Carousel', () => {
         expect(carousel.id).toContain('igx-carousel-');
         expect(domCarousel.id).toContain('igx-carousel-');
         expect(carousel instanceof IgxCarouselComponent).toBe(true);
-        expect(carousel.slides[0] instanceof IgxSlideComponent).toBe(true);
+        expect(carousel.slides.first instanceof IgxSlideComponent).toBe(true);
 
-        expect(carousel.slides instanceof Array).toBe(true);
         expect(carousel.loop).toBe(true);
         expect(carousel.pause).toBe(true);
         expect(carousel.slides.length).toEqual(4);

--- a/projects/igniteui-angular/src/lib/carousel/carousel.component.ts
+++ b/projects/igniteui-angular/src/lib/carousel/carousel.component.ts
@@ -193,7 +193,7 @@ export class IgxCarouselComponent implements OnDestroy, AfterContentInit {
      * ```typescript
      * // Set in typescript
      * const myCustomTemplate: TemplateRef<any> = myComponent.customTemplate;
-     * myComponent.carousel.itemTemplate = myCustomTemplate;
+     * myComponent.carousel.indicatorTemplate = myCustomTemplate;
      * ```
      * ```html
      * <!-- Set in markup -->

--- a/projects/igniteui-angular/src/lib/carousel/carousel.component.ts
+++ b/projects/igniteui-angular/src/lib/carousel/carousel.component.ts
@@ -30,8 +30,6 @@ let NEXT_ID = 0;
 
 export enum Direction { NONE, NEXT, PREV }
 export enum CarouselIndicatorsOrientation {
-    left = 'left',
-    right = 'right',
     bottom = 'bottom',
     top = 'top'
 }
@@ -176,7 +174,8 @@ export class IgxCarouselComponent implements OnDestroy, AfterContentInit {
     @Input() public maximumIndicatorsCount = 5;
 
     /**
-    * Gets/sets the display mode of carousel indicators
+    * Gets/sets the display mode of carousel indicators. It can be top or bottom.
+    * Default value is `bottom`.
     * ```html
     * <igx-carousel indicatorsOrientation=CarouselIndicatorsOrientation.top>
     * <igx-carousel>

--- a/projects/igniteui-angular/src/lib/carousel/carousel.component.ts
+++ b/projects/igniteui-angular/src/lib/carousel/carousel.component.ts
@@ -327,12 +327,9 @@ export class IgxCarouselComponent implements OnDestroy, AfterContentInit {
         requestAnimationFrame(() => {
             if (this._currentSlide) {
                 this._currentSlide.active = true;
-                this.slides.forEach(slide => {
-                    if (slide.active && slide.index !== this._currentSlide.index) {
-                        slide.active = false;
-                    }
-                });
-            } else {
+                const activeSlides = this.slides.filter(slide => slide.active && slide.index !== this._currentSlide.index);
+                activeSlides.forEach(slide => {slide.active = false; } );
+            } else if (this.total) {
                 this.slides.first.active = true;
             }
 
@@ -361,7 +358,7 @@ export class IgxCarouselComponent implements OnDestroy, AfterContentInit {
                 this.onSlideRemoved.emit({ carousel: this, slide });
                 if (slide.active) {
                     slide.active = false;
-                    this._currentSlide = this.get(slide.index);
+                    this._currentSlide = this.get(slide.index < this.total ? slide.index : this.total - 1 );
                 }
             });
 

--- a/projects/igniteui-angular/src/lib/carousel/carousel.component.ts
+++ b/projects/igniteui-angular/src/lib/carousel/carousel.component.ts
@@ -155,6 +155,16 @@ export class IgxCarouselComponent implements OnDestroy, AfterContentInit {
      */
     @Input() public navigation = true;
 
+        /**
+     * Controls whether the carousel should support keyboard navigation.
+     * Default value is `true`.
+     * ```html
+     * <igx-carousel [keyBoardNavigation] = "false"></igx-carousel>
+     * ```
+     * @memberOf IgxCarouselComponent
+     */
+    @Input() public keyBoardNavigation = true;
+
     /**
      * Controls the maximum indexes that can be shown.
      * Default value is `5`.
@@ -397,7 +407,7 @@ export class IgxCarouselComponent implements OnDestroy, AfterContentInit {
     * @memberof IgxCarouselComponent
     */
     public get showIndicators(): boolean {
-        return this.navigation && this.total <= this.maximumIndicatorsCount && this.total > 0;
+        return this.total <= this.maximumIndicatorsCount && this.total > 0;
     }
 
     /**
@@ -405,7 +415,7 @@ export class IgxCarouselComponent implements OnDestroy, AfterContentInit {
     * @memberof IgxCarouselComponent
     */
     public get showIndicatorsLabel(): boolean {
-        return this.navigation && this.total > this.maximumIndicatorsCount;
+        return this.total > this.maximumIndicatorsCount;
     }
     /**
      * Returns the total number of `slides` in the carousel.
@@ -495,7 +505,9 @@ export class IgxCarouselComponent implements OnDestroy, AfterContentInit {
      */
     public remove(slide: IgxSlideComponent) {
         if (slide && slide === this.get(slide.index)) { // check if the requested slide for delete is present in the carousel
-            this.slides.reset(this.slides.toArray().splice(slide.index, 1));
+            const newSlides = this.slides.toArray();
+            newSlides.splice(slide.index, 1);
+            this.slides.reset(newSlides);
             this.slides.notifyOnChanges();
         }
     }
@@ -614,7 +626,7 @@ export class IgxCarouselComponent implements OnDestroy, AfterContentInit {
      */
     @HostListener('keydown.arrowright')
     public onKeydownArrowRight() {
-        if (this.navigation) {
+        if (this.keyBoardNavigation) {
             this.next();
             requestAnimationFrame(() => this.nativeElement.focus());
         }
@@ -624,7 +636,7 @@ export class IgxCarouselComponent implements OnDestroy, AfterContentInit {
      */
     @HostListener('keydown.arrowleft')
     public onKeydownArrowLeft() {
-        if (this.navigation) {
+        if (this.keyBoardNavigation) {
             this.prev();
             requestAnimationFrame(() => this.nativeElement.focus());
         }

--- a/projects/igniteui-angular/src/lib/carousel/carousel.directives.ts
+++ b/projects/igniteui-angular/src/lib/carousel/carousel.directives.ts
@@ -1,0 +1,7 @@
+import { Directive, TemplateRef } from '@angular/core';
+
+@Directive({
+    selector: '[igxCarouselIndicator]'
+})
+export class IgxCarouselIndicatorDirective {
+}

--- a/projects/igniteui-angular/src/lib/core/styles/components/carousel/_carousel-component.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/carousel/_carousel-component.scss
@@ -19,6 +19,16 @@
         @extend %igx-carousel-indicators !optional;
     }
 
+    @include e(indicators, $m: top) {
+        @extend %igx-carousel-indicators !optional;
+        @extend %igx-carousel-indicators--top !optional;
+    }
+
+    @include e(indicators, $m: bottom) {
+        @extend %igx-carousel-indicators !optional;
+        @extend %igx-carousel-indicators--bottom !optional;
+    }
+
     @include e(arrow) {
         @extend %igx-carousel-arrow !optional;
     }

--- a/projects/igniteui-angular/src/lib/core/styles/components/carousel/_carousel-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/carousel/_carousel-theme.scss
@@ -180,12 +180,9 @@
         position: absolute;
         list-style: none;
         z-index: 10;
-        bottom: 0;
-        left: 50%;
-        transform: translateX(-50%);
         padding: $carousel-indicators-padding;
 
-        li {
+        .default-indicator-item {
             margin: $carousel-indicator-margin;
             position: relative;
             width: 12px;
@@ -227,6 +224,23 @@
                 opacity: 1;
             }
         }
+
+        .carousel-indicator {
+            margin: $carousel-indicator-margin;
+            position: relative;
+        }
+    }
+
+    %igx-carousel-indicators--bottom {
+        bottom: 0;
+        left: 50%;
+        transform: translateX(-50%);
+    }
+
+    %igx-carousel-indicators--top {
+        top: 0;
+        left: 50%;
+        transform: translateX(-50%);
     }
 
     %igx-carousel-slide {

--- a/src/app/carousel/carousel.sample.html
+++ b/src/app/carousel/carousel.sample.html
@@ -9,6 +9,7 @@
             <article>
                 <h4 class="sample-title">Desktop</h4>
                 <igx-switch [(ngModel)]="car.navigation">navigation</igx-switch>
+                <igx-switch [(ngModel)]="car.keyBoardNavigation">keyBoardNavigation</igx-switch>
                 <igx-switch [(ngModel)]="loop">loop</igx-switch>
                  <button igxButton="raised" (click)="changeSlides()">Change slides add</button>
                 <button igxButton="raised" (click)="changeSlidesRemove()">Change slides remove</button>

--- a/src/app/carousel/carousel.sample.html
+++ b/src/app/carousel/carousel.sample.html
@@ -1,16 +1,27 @@
 <div class="sample-wrapper">
     <app-page-header title="Carousel">
-        Displays a collection of slides or page-based interfaces. It can be used as a separate full screen element or inside another
+        Displays a collection of slides or page-based interfaces. It can be used as a separate full screen element or
+        inside another
         component.
     </app-page-header>
     <div class="sample-content">
         <section style="width: 100%">
             <article>
                 <h4 class="sample-title">Desktop</h4>
-                <igx-carousel [interval]="interval" [pause]="pause" [loop]="loop">
+                <igx-switch [(ngModel)]="car.navigation">navigation</igx-switch>
+                <igx-switch [(ngModel)]="loop">loop</igx-switch>
+                 <button igxButton="raised" (click)="changeSlides()">Change slides add</button>
+                <button igxButton="raised" (click)="changeSlidesRemove()">Change slides remove</button>
+                 <button igxButton="raised" (click)="changeOrientation()">changeOrientation</button>
+                <igx-carousel #car [interval]="interval" [pause]="pause" [loop]="loop">
                     <igx-slide *ngFor="let slide of slides;" [active]="slide.active">
                         <img [src]="slide.image">
                     </igx-slide>
+
+                    <ng-template igxCarouselIndicator let-slide>
+                        <igx-icon *ngIf="slide.active" fontSet="material">brightness_7</igx-icon>
+                        <igx-icon *ngIf="!slide.active" fontSet="material">brightness_5</igx-icon>
+                    </ng-template>
                 </igx-carousel>
             </article>
         </section>

--- a/src/app/carousel/carousel.sample.ts
+++ b/src/app/carousel/carousel.sample.ts
@@ -19,9 +19,9 @@ export class CarouselSampleComponent {
 
     addNewSlide() {
         this.slides.push(
-            {image: 'assets/images/carousel/slide1@x2.jpg', active: true},
-            {image: 'assets/images/carousel/slide2@x2.jpg', active: true},
-            {image: 'assets/images/carousel/slide3@x2.jpg', active: true}
+            {image: 'assets/images/carousel/slide1@x2.jpg'},
+            {image: 'assets/images/carousel/slide2@x2.jpg'},
+            {image: 'assets/images/carousel/slide3@x2.jpg'}
         );
     }
 

--- a/src/app/carousel/carousel.sample.ts
+++ b/src/app/carousel/carousel.sample.ts
@@ -1,10 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
+import { IgxCarouselComponent, CarouselIndicatorsOrientation } from 'igniteui-angular';
 
 @Component({
     selector: 'app-carousel-sample',
     templateUrl: 'carousel.sample.html'
 })
 export class CarouselSampleComponent {
+    @ViewChild('car', { static: true }) car: IgxCarouselComponent;
 
     slides = [];
     interval = 3000;
@@ -12,15 +14,30 @@ export class CarouselSampleComponent {
     loop = true;
 
     constructor() {
-            this.addNewSlide();
+        this.addNewSlide();
     }
 
     addNewSlide() {
         this.slides.push(
             {image: 'assets/images/carousel/slide1@x2.jpg'},
             {image: 'assets/images/carousel/slide2@x2.jpg'},
-            {image: 'assets/images/carousel/slide3@x2.jpg'},
-            {image: 'assets/images/carousel/slide4@x2.jpg'}
+            {image: 'assets/images/carousel/slide3@x2.jpg', active: true}
         );
+    }
+
+    public changeSlides() {
+        this.slides.push({image: 'assets/images/carousel/slide4@x2.jpg', active: true});
+    }
+
+    public changeSlidesRemove() {
+        this.slides = this.slides.slice(1);
+    }
+
+    changeOrientation() {
+        if (this.car.indicatorsOrientation === CarouselIndicatorsOrientation.top) {
+            this.car.indicatorsOrientation = CarouselIndicatorsOrientation.bottom;
+        } else {
+            this.car.indicatorsOrientation = CarouselIndicatorsOrientation.top;
+        }
     }
 }

--- a/src/app/carousel/carousel.sample.ts
+++ b/src/app/carousel/carousel.sample.ts
@@ -19,14 +19,14 @@ export class CarouselSampleComponent {
 
     addNewSlide() {
         this.slides.push(
-            {image: 'assets/images/carousel/slide1@x2.jpg'},
-            {image: 'assets/images/carousel/slide2@x2.jpg'},
+            {image: 'assets/images/carousel/slide1@x2.jpg', active: true},
+            {image: 'assets/images/carousel/slide2@x2.jpg', active: true},
             {image: 'assets/images/carousel/slide3@x2.jpg', active: true}
         );
     }
 
     public changeSlides() {
-        this.slides.push({image: 'assets/images/carousel/slide4@x2.jpg', active: true});
+        this.slides.push({image: 'assets/images/carousel/slide4@x2.jpg'});
     }
 
     public changeSlidesRemove() {


### PR DESCRIPTION
In this PR:

1. Slides are changed from array to ContentChildren of carousel
2. When change slide input active it is selected in the carousel
3. A template for indicators is added
4. A new input indicatorsOrientation is added in order to change indicators position
5. A new input maximumIndicatorsCount is added, if the slides are more than the maximumIndicatorsCount  only for example '3 of 6' is displayed
6. Add input keyBoardNavigation and it it is false, the keyboard navigation is disabled

### Additional information (check all that apply):
 - [ ] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 