### PR TITLE
Grid with transactions should not update grid's data when updateRow is called in onCellEdtt

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/api.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/api.service.ts
@@ -199,9 +199,9 @@ export class GridBaseAPIService <T extends IgxGridBaseComponent & IGridDataBinda
             row.data = { ...row.data, ...rowInEditMode.transactionState };
         // TODO: Workaround for updating a row in edit mode through the API
         } else if (this.grid.transactions.enabled) {
-            const lastCommitedValue = grid.transactions.getState(row.id) ?
-                grid.transactions.getState(row.id).value : null;
-            row.data = lastCommitedValue ? Object.assign(row.data, lastCommitedValue) : row.data;
+            const state = grid.transactions.getState(row.id);
+            const lastCommittedValue = state ? state.value : null;
+            row.data = Object.assign({}, row.data, lastCommittedValue);
         }
     }
 

--- a/projects/igniteui-angular/src/lib/grids/api.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/api.service.ts
@@ -200,7 +200,6 @@ export class GridBaseAPIService <T extends IgxGridBaseComponent & IGridDataBinda
         // TODO: Workaround for updating a row in edit mode through the API
         } else if (this.grid.transactions.enabled) {
             const state = grid.transactions.getState(row.id);
-            const lastCommittedValue = state ? state.value : null;
             row.data = state ? Object.assign({}, row.data,  state.value) : row.data;
         }
     }

--- a/projects/igniteui-angular/src/lib/grids/api.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/api.service.ts
@@ -201,7 +201,7 @@ export class GridBaseAPIService <T extends IgxGridBaseComponent & IGridDataBinda
         } else if (this.grid.transactions.enabled) {
             const state = grid.transactions.getState(row.id);
             const lastCommittedValue = state ? state.value : null;
-            row.data = Object.assign({}, row.data, lastCommittedValue);
+            row.data = state ? Object.assign({}, row.data,  state.value) : row.data;
         }
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
@@ -895,6 +895,45 @@ describe('IgxGrid - Cell component', () => {
         expect(cell.value).toEqual('New Name');
     });
 
+    it(`Should not update data in grid with transactions, when row is updated in onCellEdit and onCellEdit is canceled`, () => {
+        const fixture = TestBed.createComponent(SelectionWithTransactionsComponent);
+        fixture.detectChanges();
+        const grid = fixture.componentInstance.grid;
+        grid.ngAfterViewInit();
+
+        grid.primaryKey = 'ID';
+        fixture.detectChanges();
+
+        // update the cell value via updateRow and cancel the event
+        grid.onCellEdit.subscribe((e: IGridEditEventArgs) => {
+            const rowIndex: number = e.cellID.rowIndex;
+            const row = grid.getRowByIndex(rowIndex);
+            grid.updateRow({[row.columns[e.cellID.columnID].field]: e.newValue}, row.rowID);
+            e.cancel = true;
+        });
+
+        const cell = grid.getCellByColumn(0, 'Name');
+        const initialValue = cell.value;
+        const firstNewValue = 'New Value';
+        const secondNewValue = 'Very New Value';
+
+        cell.update(firstNewValue);
+        fixture.detectChanges();
+        expect(cell.value).toBe(firstNewValue);
+
+        cell.update(secondNewValue);
+        fixture.detectChanges();
+        expect(cell.value).toBe(secondNewValue);
+
+        grid.transactions.undo();
+        fixture.detectChanges();
+        expect(cell.value).toBe(firstNewValue);
+
+        grid.transactions.undo();
+        fixture.detectChanges();
+        expect(cell.value).toBe(initialValue);
+    });
+
     it('should fit last cell in the available display container when there is vertical scroll.', async(() => {
         const fix = TestBed.createComponent(VirtualGridComponent);
         fix.detectChanges();

--- a/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/cell.spec.ts
@@ -899,7 +899,6 @@ describe('IgxGrid - Cell component', () => {
         const fixture = TestBed.createComponent(SelectionWithTransactionsComponent);
         fixture.detectChanges();
         const grid = fixture.componentInstance.grid;
-        grid.ngAfterViewInit();
 
         grid.primaryKey = 'ID';
         fixture.detectChanges();


### PR DESCRIPTION
In `_update_row` method of `GridBaseAPIService` we were committed value over the grid's data. Now we merge the result in new object. This way we do not change the grid's data.

Closes #5779

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 