### PR TITLE
Combo Ivy Renderer Fix

### DIFF
--- a/projects/igniteui-angular/src/lib/combo/combo-add-item.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo-add-item.component.ts
@@ -1,5 +1,5 @@
 import { IgxComboItemComponent } from './combo-item.component';
-import { Component } from '@angular/core';
+import { Component, HostListener } from '@angular/core';
 
 /**
  * @hidden
@@ -16,8 +16,12 @@ export class IgxComboAddItemComponent extends IgxComboItemComponent {
     set selected(value: boolean) {
     }
 
-    clicked(event?) {
+    @HostListener('click')
+    handleClick() {
         this.comboAPI.disableTransitions = false;
         this.comboAPI.add_custom_item();
+    }
+
+    clicked(event?) {
     }
 }

--- a/projects/igniteui-angular/src/lib/combo/combo-item.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo-item.component.ts
@@ -4,8 +4,7 @@ import {
     HostBinding,
     Inject,
     Input,
-    DoCheck,
-    HostListener
+    DoCheck
 } from '@angular/core';
 import { IgxDropDownItemComponent } from '../drop-down/drop-down-item.component';
 import { IGX_DROPDOWN_BASE, IDropDownBase, Navigate } from '../drop-down/drop-down.common';
@@ -85,7 +84,6 @@ export class IgxComboItemComponent extends IgxDropDownItemComponent implements D
         return rect.y >= parentDiv.y;
     }
 
-    @HostListener('click', ['$event'])
     clicked(event) {
         this.comboAPI.disableTransitions = false;
         if (this.disabled || this.isHeader) {

--- a/projects/igniteui-angular/src/lib/combo/combo.component.html
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.html
@@ -1,3 +1,81 @@
+<igx-input-group #inputGroup [displayDensity]="displayDensity" [type]="type" (click)="onInputClick($event)">
+    <ng-container ngProjectAs="[igxLabel]">
+        <ng-content select="[igxLabel]"></ng-content>
+    </ng-container>
+    <ng-container ngProjectAs="igx-prefix">
+        <ng-content select="igx-prefix"></ng-content>
+    </ng-container>
+    <ng-container ngProjectAs="igx-hint, [igxHint]">
+        <ng-content select="igx-hint, [igxHint]"></ng-content>
+    </ng-container>
+    <input igxInput #comboInput name="comboInput" type="text" [value]="value" readonly [attr.placeholder]="placeholder"
+        [disabled]="disabled" (blur)="onBlur()" />
+    <ng-container ngProjectAs="igx-suffix">
+        <ng-content select="igx-suffix"></ng-content>
+    </ng-container>
+    <igx-suffix *ngIf="value.length" aria-label="Clear Selection" class="igx-combo__clear-button" igxRipple
+        (click)="handleClearItems($event)">
+        <ng-container *ngIf="clearIconTemplate">
+            <ng-container *ngTemplateOutlet="clearIconTemplate"></ng-container>
+        </ng-container>
+        <igx-icon *ngIf="!clearIconTemplate" fontSet="material">clear</igx-icon>
+    </igx-suffix>
+    <igx-suffix igxButton="icon" class="igx-combo__toggle-button" igxRipple>
+        <ng-container *ngIf="toggleIconTemplate">
+            <ng-container *ngTemplateOutlet="toggleIconTemplate; context: {$implicit: this.collapsed}"></ng-container>
+        </ng-container>
+        <igx-icon *ngIf="!toggleIconTemplate" fontSet="material">
+            {{ dropdown.collapsed ? 'arrow_drop_down' : 'arrow_drop_up'}}</igx-icon>
+    </igx-suffix>
+</igx-input-group>
+<igx-combo-drop-down #igxComboDropDown class="igx-combo__drop-down" [displayDensity]="displayDensity"
+    [width]="itemsWidth || '100%'" (onOpening)="handleOpening($event)" (onClosing)="handleClosing($event)"
+    (onOpened)="handleOpened()" (onClosed)="handleClosed()">
+    <igx-input-group *ngIf="displaySearchInput" [displayDensity]="displayDensity" class="igx-combo__search">
+        <input class="igx-combo-input" igxInput #searchInput name="searchInput" autocomplete="off" type="text"
+            [(ngModel)]="searchValue" (ngModelChange)="handleInputChange($event)" (keyup)="handleKeyUp($event)"
+            (keydown)="handleKeyDown($event)" (focus)="dropdown.onBlur($event)" [attr.placeholder]="searchPlaceholder"
+            aria-autocomplete="both" [attr.aria-owns]="dropdown.id" [attr.aria-labelledby]="ariaLabelledBy" />
+    </igx-input-group>
+    <ng-container *ngTemplateOutlet="headerTemplate">
+    </ng-container>
+    <div #dropdownItemContainer class="igx-combo__content" [style.overflow]="'hidden'"
+        [style.maxHeight.px]="itemsMaxHeight" [igxDropDownItemNavigation]="dropdown" (focus)="dropdown.onFocus()"
+        [tabindex]="dropdown.collapsed ? -1 : 0" role="listbox" [attr.id]="dropdown.id">
+        <igx-combo-item *igxFor="let item of data | comboFiltering:filteringExpressions:filteringLogic
+        | comboSorting:sortingExpressions
+        | comboGrouping:groupKey:valueKey;
+        index as rowIndex; containerSize: itemsMaxHeight; scrollOrientation: 'vertical'; itemSize: itemHeight"
+            [itemHeight]='itemHeight' [value]="item" [isHeader]="item.isHeader" role="option" [index]="rowIndex"
+            (onChunkPreload)="dataLoading($event)">
+            <ng-container *ngIf="item.isHeader">
+                <ng-container
+                    *ngTemplateOutlet="headerItemTemplate ? headerItemTemplate : headerItemBase;
+                    context: {$implicit: item, data: data, valueKey: valueKey, groupKey: groupKey, displayKey: displayKey}">
+                </ng-container>
+            </ng-container>
+            <ng-container *ngIf="!item.isHeader">
+                <ng-container #listItem
+                    *ngTemplateOutlet="template; context: {$implicit: item, data: data, valueKey: valueKey, displayKey: displayKey};">
+                </ng-container>
+            </ng-container>
+        </igx-combo-item>
+    </div>
+    <div class="igx-combo__add" *ngIf="filteredData.length === 0 || isAddButtonVisible()">
+        <div class="igx-combo__empty" *ngIf="filteredData.length === 0">
+            <ng-container *ngTemplateOutlet="emptyTemplate ? emptyTemplate : empty">
+            </ng-container>
+        </div>
+        <igx-combo-add-item [itemHeight]='itemHeight' *ngIf="isAddButtonVisible()"
+            [tabindex]="dropdown.collapsed ? -1 : customValueFlag ? 1 : -1" class="igx-combo__add-item" role="button"
+            aria-label="Add Item" [index]="virtualScrollContainer.igxForOf.length">
+            <ng-container *ngTemplateOutlet="addItemTemplate ? addItemTemplate : addItemDefault">
+            </ng-container>
+        </igx-combo-add-item>
+    </div>
+    <ng-container *ngTemplateOutlet="footerTemplate">
+    </ng-container>
+</igx-combo-drop-down>
 <ng-template #complex let-display let-data="data" let-key="displayKey">
     {{display[key]}}
 </ng-template>
@@ -13,72 +91,3 @@
 <ng-template #headerItemBase let-item let-key="valueKey" let-groupKey="groupKey">
     {{ item[key] }}
 </ng-template>
-
-<igx-input-group #inputGroup [displayDensity]="displayDensity" [type]="type" (click)="onInputClick($event)">
-    <ng-container ngProjectAs="[igxLabel]">
-        <ng-content select="[igxLabel]"></ng-content>
-    </ng-container>
-    <ng-container ngProjectAs="igx-prefix">
-        <ng-content select="igx-prefix"></ng-content>
-    </ng-container>
-    <ng-container ngProjectAs="igx-hint, [igxHint]">
-            <ng-content select="igx-hint, [igxHint]"></ng-content>
-        </ng-container>
-    <input igxInput #comboInput name="comboInput" type="text" [value]="value" readonly [attr.placeholder]="placeholder"
-        [disabled]="disabled" (blur)="onBlur()" />
-    <ng-container ngProjectAs="igx-suffix">
-        <ng-content select="igx-suffix"></ng-content>
-    </ng-container>
-    <igx-suffix *ngIf="value.length" aria-label="Clear Selection" class="igx-combo__clear-button" igxRipple (click)="handleClearItems($event)">
-        <ng-container *ngIf="clearIconTemplate">
-            <ng-container *ngTemplateOutlet="clearIconTemplate"></ng-container>
-        </ng-container>
-        <igx-icon *ngIf="!clearIconTemplate" fontSet="material">clear</igx-icon>
-    </igx-suffix>
-    <igx-suffix igxButton="icon" class="igx-combo__toggle-button" igxRipple>
-        <ng-container *ngIf="toggleIconTemplate">
-            <ng-container *ngTemplateOutlet="toggleIconTemplate; context: {$implicit: this.collapsed}"></ng-container>
-        </ng-container>
-        <igx-icon *ngIf="!toggleIconTemplate" fontSet="material">{{ dropdown.collapsed ? 'arrow_drop_down' : 'arrow_drop_up'}}</igx-icon>
-    </igx-suffix>
-</igx-input-group>
-<igx-combo-drop-down #igxComboDropDown class="igx-combo__drop-down" [displayDensity]="displayDensity" [width]="itemsWidth || '100%'" (onOpening)="handleOpening($event)"
-    (onClosing)="handleClosing($event)" (onOpened)="handleOpened()" (onClosed)="handleClosed()">
-    <igx-input-group *ngIf="displaySearchInput" [displayDensity]="displayDensity" class="igx-combo__search">
-        <input class="igx-combo-input" igxInput #searchInput name="searchInput" autocomplete="off" type="text"
-            [(ngModel)]="searchValue" (ngModelChange)="handleInputChange($event)" (keyup)="handleKeyUp($event)"
-            (keydown)="handleKeyDown($event)" (focus)="dropdown.onBlur($event)" [attr.placeholder]="searchPlaceholder"
-            aria-autocomplete="both" [attr.aria-owns]="dropdown.id" [attr.aria-labelledby]="ariaLabelledBy" />
-    </igx-input-group>
-    <ng-container *ngTemplateOutlet="headerTemplate">
-    </ng-container>
-    <div #dropdownItemContainer class="igx-combo__content" [style.overflow]="'hidden'" [style.maxHeight.px]="itemsMaxHeight"
-        [igxDropDownItemNavigation]="dropdown" (focus)="dropdown.onFocus()" [tabindex]="dropdown.collapsed ? -1 : 0"
-        role="listbox" [attr.id]="dropdown.id">
-        <ng-template igxFor let-item let-index="index" [igxForOf]="data | comboFiltering:filteringExpressions:filteringLogic | comboSorting:sortingExpressions | comboGrouping:groupKey"
-            [igxForScrollOrientation]="'vertical'" [igxForContainerSize]="itemsMaxHeight" [igxForItemSize]="itemHeight"
-            (onChunkPreload)="dataLoading($event)">
-            <igx-combo-item  [itemHeight]='itemHeight' [value]="item" [isHeader]="item.isHeader" role="option" [index]="index">
-                <ng-container *ngIf="item.isHeader">
-                    <ng-container *ngTemplateOutlet="headerItemTemplate ? headerItemTemplate : headerItemBase; context: {$implicit: item, data: data, valueKey: valueKey, groupKey: groupKey, displayKey: displayKey}"></ng-container>
-                </ng-container>
-                <ng-container *ngIf="!item.isHeader">
-                    <ng-container #listItem *ngTemplateOutlet="template; context: {$implicit: item, data: data, valueKey: valueKey, displayKey: displayKey};"></ng-container>
-                </ng-container>
-            </igx-combo-item>
-        </ng-template>
-    </div>
-    <div class="igx-combo__add" *ngIf="filteredData.length === 0 || isAddButtonVisible()">
-        <div class="igx-combo__empty" *ngIf="filteredData.length === 0">
-            <ng-container *ngTemplateOutlet="emptyTemplate ? emptyTemplate : empty">
-            </ng-container>
-        </div>
-        <igx-combo-add-item [itemHeight]='itemHeight' *ngIf="isAddButtonVisible()" [tabindex]="dropdown.collapsed ? -1 : customValueFlag ? 1 : -1"
-            class="igx-combo__add-item" role="button" aria-label="Add Item" [index]="virtualScrollContainer.igxForOf.length">
-            <ng-container *ngTemplateOutlet="addItemTemplate ? addItemTemplate : addItemDefault">
-            </ng-container>
-        </igx-combo-add-item>
-    </div>
-    <ng-container *ngTemplateOutlet="footerTemplate">
-    </ng-container>
-</igx-combo-drop-down>

--- a/projects/igniteui-angular/src/lib/combo/combo.component.html
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.html
@@ -42,7 +42,7 @@
     <div #dropdownItemContainer class="igx-combo__content" [style.overflow]="'hidden'"
         [style.maxHeight.px]="itemsMaxHeight" [igxDropDownItemNavigation]="dropdown" (focus)="dropdown.onFocus()"
         [tabindex]="dropdown.collapsed ? -1 : 0" role="listbox" [attr.id]="dropdown.id">
-        <igx-combo-item *igxFor="let item of data | comboFiltering:filteringExpressions:filteringLogic
+        <igx-combo-item *igxFor="let item of data | comboFiltering:searchValue:displayKey
         | comboSorting:sortingExpressions
         | comboGrouping:groupKey:valueKey;
         index as rowIndex; containerSize: itemsMaxHeight; scrollOrientation: 'vertical'; itemSize: itemHeight"

--- a/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
@@ -18,6 +18,7 @@ import { IgxDropDownItemBaseDirective } from '../drop-down/drop-down-item.base';
 import { DisplayDensity, DisplayDensityToken } from '../core/density';
 import { AbsoluteScrollStrategy, ConnectedPositioningStrategy } from '../services/index';
 import { IgxInputState } from '../directives/input/input.directive';
+import { IgxComboFilteringPipe } from './combo.pipes';
 
 const CSS_CLASS_COMBO = 'igx-combo';
 const CSS_CLASS_COMBO_DROPDOWN = 'igx-combo__drop-down';
@@ -2408,12 +2409,12 @@ describe('igxCombo', () => {
             expect(combo.collapsed).toBeFalsy();
             expect(combo.dropdown.headers).toBeDefined();
             expect(combo.dropdown.headers.length).toEqual(2);
-            combo.dropdown.headers[0].clicked(null);
+            (combo.dropdown.headers[0] as IgxComboItemComponent).clicked(null);
             fix.detectChanges();
 
             const mockObj = jasmine.createSpyObj('nativeElement', ['focus']);
             spyOnProperty(combo.dropdown, 'focusedItem', 'get').and.returnValue({ element: { nativeElement: mockObj } });
-            combo.dropdown.headers[0].clicked(null);
+            (combo.dropdown.headers[0] as IgxComboItemComponent).clicked(null);
             fix.detectChanges();
             expect(mockObj.focus).not.toHaveBeenCalled(); // Focus only if `allowItemFocus === true`
 
@@ -2465,12 +2466,12 @@ describe('igxCombo', () => {
             const initialData = [...combo.filteredData];
             let firstFilter;
             expect(combo.searchValue).toEqual('');
-            spyOn(combo, 'filter').and.callThrough();
+            const filterSpy = spyOn(IgxComboFilteringPipe.prototype, 'transform').and.callThrough();
             combo.searchValue = 'New ';
             combo.handleInputChange();
             tick();
             fix.detectChanges();
-            expect(combo.filter).toHaveBeenCalledTimes(1);
+            expect(filterSpy).toHaveBeenCalledTimes(1);
             expect(combo.filteredData.length).toBeLessThan(initialData.length);
             firstFilter = [...combo.filteredData];
             combo.searchValue += '  ';
@@ -2478,19 +2479,19 @@ describe('igxCombo', () => {
             tick();
             fix.detectChanges();
             expect(combo.filteredData.length).toBeLessThan(initialData.length);
-            expect(combo.filter).toHaveBeenCalledTimes(2);
+            expect(filterSpy).toHaveBeenCalledTimes(2);
             combo.searchValue = '';
             combo.handleInputChange();
             tick();
             fix.detectChanges();
             expect(combo.filteredData.length).toEqual(initialData.length);
             expect(combo.filteredData.length).toBeGreaterThan(firstFilter.length);
-            expect(combo.filter).toHaveBeenCalledTimes(3);
+            expect(filterSpy).toHaveBeenCalledTimes(3);
             combo.filteringExpressions = [];
             tick();
             fix.detectChanges();
             expect(combo.filteredData.length).toEqual(initialData.length);
-            expect(combo.filter).toHaveBeenCalledTimes(3);
+            expect(filterSpy).toHaveBeenCalledTimes(3);
         }));
         it('Should properly select/deselect filteredData', fakeAsync(() => {
             const fix = TestBed.createComponent(IgxComboSampleComponent);
@@ -2502,12 +2503,12 @@ describe('igxCombo', () => {
             const initialData = [...combo.filteredData];
 
             expect(combo.searchValue).toEqual('');
-            spyOn(combo, 'filter').and.callThrough();
+            const filterSpy = spyOn(IgxComboFilteringPipe.prototype, 'transform').and.callThrough();
             combo.searchValue = 'New ';
             combo.handleInputChange();
             tick();
             fix.detectChanges();
-            expect(combo.filter).toHaveBeenCalledTimes(1);
+            expect(filterSpy).toHaveBeenCalledTimes(1);
             expect(combo.filteredData.length).toBeLessThan(initialData.length);
             expect(combo.filteredData.length).toEqual(4);
 
@@ -2564,25 +2565,25 @@ describe('igxCombo', () => {
             const fix = TestBed.createComponent(IgxComboSampleComponent);
             fix.detectChanges();
             const combo = fix.componentInstance.combo;
-            spyOn(combo, 'filter');
+            const filterSpy = spyOn(IgxComboFilteringPipe.prototype, 'transform').and.callThrough();
             spyOn(combo.onSearchInput, 'emit');
 
             combo.handleInputChange();
 
             fix.detectChanges();
-            expect(combo.filter).toHaveBeenCalledTimes(1);
+            expect(filterSpy).toHaveBeenCalledTimes(1);
             expect(combo.onSearchInput.emit).toHaveBeenCalledTimes(0);
 
             combo.handleInputChange('Fake');
 
             fix.detectChanges();
-            expect(combo.filter).toHaveBeenCalledTimes(2);
+            expect(filterSpy).toHaveBeenCalledTimes(2);
             expect(combo.onSearchInput.emit).toHaveBeenCalledTimes(1);
             expect(combo.onSearchInput.emit).toHaveBeenCalledWith('Fake');
 
             combo.handleInputChange('');
             fix.detectChanges();
-            expect(combo.filter).toHaveBeenCalledTimes(3);
+            expect(filterSpy).toHaveBeenCalledTimes(3);
             expect(combo.onSearchInput.emit).toHaveBeenCalledTimes(2);
             expect(combo.onSearchInput.emit).toHaveBeenCalledWith('');
 
@@ -2590,7 +2591,7 @@ describe('igxCombo', () => {
             fix.detectChanges();
 
             combo.handleInputChange();
-            expect(combo.filter).toHaveBeenCalledTimes(3);
+            expect(filterSpy).toHaveBeenCalledTimes(3);
             expect(combo.onSearchInput.emit).toHaveBeenCalledTimes(2);
         });
         it('Should properly handle addItemToCollection calls (Complex data)', fakeAsync(() => {

--- a/projects/igniteui-angular/src/lib/combo/combo.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.ts
@@ -30,7 +30,7 @@ import { IgxDropDownModule } from '../drop-down/index';
 import { IgxInputGroupModule, IgxInputGroupComponent } from '../input-group/input-group.component';
 import { IgxComboItemComponent } from './combo-item.component';
 import { IgxComboDropDownComponent } from './combo-dropdown.component';
-import { IgxComboFilterConditionPipe, IgxComboFilteringPipe, IgxComboGroupingPipe, IgxComboSortingPipe } from './combo.pipes';
+import { IgxComboFilteringPipe, IgxComboGroupingPipe, IgxComboSortingPipe } from './combo.pipes';
 import { OverlaySettings, AbsoluteScrollStrategy } from '../services';
 import { Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -1617,7 +1617,7 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
  * @hidden
  */
 @NgModule({
-    declarations: [IgxComboComponent, IgxComboItemComponent, IgxComboFilterConditionPipe, IgxComboGroupingPipe,
+    declarations: [IgxComboComponent, IgxComboItemComponent, IgxComboGroupingPipe,
         IgxComboFilteringPipe, IgxComboSortingPipe, IgxComboDropDownComponent, IgxComboAddItemComponent,
         IgxComboItemDirective,
         IgxComboEmptyDirective,
@@ -1637,6 +1637,6 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
         IgxComboToggleIconDirective,
         IgxComboClearIconDirective],
     imports: [IgxRippleModule, CommonModule, IgxInputGroupModule, FormsModule, ReactiveFormsModule,
-        IgxForOfModule, IgxToggleModule, IgxCheckboxModule, IgxDropDownModule, IgxButtonModule, IgxIconModule],
+        IgxForOfModule, IgxToggleModule, IgxCheckboxModule, IgxDropDownModule, IgxButtonModule, IgxIconModule]
 })
 export class IgxComboModule { }

--- a/projects/igniteui-angular/src/lib/combo/combo.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.ts
@@ -826,18 +826,18 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
      * let valid = this.combo.valid;
      * ```
      * */
-     public get valid(): IgxComboState {
+    public get valid(): IgxComboState {
         return this._valid;
     }
 
-     /**
-     * Sets if control is valid, when used in a form
-     *
-     * ```typescript
-     * // set
-     * this.combo.valid = IgxComboState.INVALID;
-     * ```
-    */
+    /**
+    * Sets if control is valid, when used in a form
+    *
+    * ```typescript
+    * // set
+    * this.combo.valid = IgxComboState.INVALID;
+    * ```
+   */
     public set valid(valid: IgxComboState) {
         this._valid = valid;
         this.comboInput.valid = IgxInputState[IgxComboState[valid]];
@@ -1022,36 +1022,8 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
      * @hidden @internal
      */
     public handleInputChange(event?: string) {
-        let cdrFlag = false;
-        const vContainer = this.virtDir;
-        if (event !== undefined && this._prevInputValue === event) {
-            // Nothing has changed
-            return;
-        } else {
-            this._prevInputValue = event !== undefined ? event : '';
-        }
-        if (event !== undefined) {
-            // Do not scroll if not scrollable
-            if (vContainer.isScrollable()) {
-                vContainer.scrollTo(0);
-            } else {
-                cdrFlag = true;
-            }
-            this.onSearchInput.emit(event);
-        } else {
-            cdrFlag = true;
-        }
+        this.onSearchInput.emit(event);
         if (this.filterable) {
-            this.filter();
-            // If there was no scroll before filtering, check if there is after and detect changes
-            if (cdrFlag) {
-                vContainer.onChunkLoad.pipe(take(1)).subscribe(() => {
-                    if (vContainer.isScrollable()) {
-                        this.cdr.detectChanges();
-                    }
-                });
-            }
-        } else {
             this.checkMatch();
         }
     }
@@ -1195,7 +1167,7 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
         this.customValueFlag = false;
         this.searchInput.nativeElement.focus();
         this.dropdown.focusedItem = null;
-        this.handleInputChange();
+        this.virtDir.scrollTo(0);
     }
 
     /**
@@ -1214,35 +1186,10 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
         }
     }
 
-
-    protected prepare_filtering_expression(searchVal, condition, ignoreCase, fieldName?) {
-        const newArray = [...this.filteringExpressions];
-        const expression = newArray.find((expr) => expr.fieldName === fieldName);
-        const newExpression = { fieldName, searchVal, condition, ignoreCase };
-        if (!expression) {
-            newArray.push(newExpression);
-        } else {
-            Object.assign(expression, newExpression);
-        }
-        if (this.groupKey) {
-            const expression2 = newArray.find((expr) => expr.fieldName === 'isHeader');
-            const headerExpression = {
-                fieldName: 'isHeader', searchVale: '',
-                condition: IgxBooleanFilteringOperand.instance().condition('true'), ignoreCase: true
-            };
-            if (!expression2) {
-                newArray.push(headerExpression);
-            } else {
-                Object.assign(expression2, headerExpression);
-            }
-        }
-        this.filteringExpressions = newArray;
-    }
-
     protected onStatusChanged = () => {
         if ((this.ngControl.control.touched || this.ngControl.control.dirty) &&
             (this.ngControl.control.validator || this.ngControl.control.asyncValidator)) {
-                this.valid = this.ngControl.valid ? IgxComboState.VALID : IgxComboState.INVALID;
+            this.valid = this.ngControl.valid ? IgxComboState.VALID : IgxComboState.INVALID;
         }
         this.manageRequiredAsterisk();
     }
@@ -1262,18 +1209,10 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
         if (this.collapsed) {
             if (this.ngControl && !this.ngControl.valid) {
                 this.valid = IgxComboState.INVALID;
-           } else {
+            } else {
                 this.valid = IgxComboState.INITIAL;
-           }
+            }
         }
-    }
-
-    /**
-     * @hidden @internal
-     */
-    public filter() {
-        this.prepare_filtering_expression(this.searchValue.trim(), IgxStringFilteringOperand.instance().condition('contains'),
-            true, this.dataType === DataTypes.PRIMITIVE ? undefined : this.displayKey);
     }
 
     /**
@@ -1581,7 +1520,6 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
         if (event.cancel) {
             return;
         }
-        this.handleInputChange();
     }
 
     /**

--- a/projects/igniteui-angular/src/lib/combo/combo.pipes.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.pipes.ts
@@ -1,4 +1,4 @@
-import { Inject, Pipe, PipeTransform } from '@angular/core';
+import { Pipe, PipeTransform, Inject } from '@angular/core';
 import { cloneArray } from '../core/utils';
 import { DataUtil } from '../data-operations/data-util';
 import { FilteringLogic, IFilteringExpression } from '../data-operations/filtering-expression.interface';
@@ -16,15 +16,11 @@ import { IGX_COMBO_COMPONENT, IgxComboBase } from './combo.common';
     name: 'comboFiltering'
 })
 export class IgxComboFilteringPipe implements PipeTransform {
-
-    constructor(@Inject(IGX_COMBO_COMPONENT) public combo: IgxComboBase) { }
-
     public transform(collection: any[], expressions: IFilteringExpression[],
                      logic: FilteringLogic) {
         const filteringExpressionsTree =  new FilteringExpressionsTree(logic);
         filteringExpressionsTree.filteringOperands = expressions;
         const state: IFilteringState = { expressionsTree: filteringExpressionsTree, strategy: new SimpleFilteringStrategy()};
-        state.expressionsTree.filteringOperands = this.combo.filteringExpressions;
 
         if (!state.expressionsTree.filteringOperands.length) {
             return collection;
@@ -52,8 +48,6 @@ export class SimpleFilteringStrategy extends FilteringStrategy {
     pure: true
 })
 export class IgxComboSortingPipe implements PipeTransform {
-    constructor() { }
-
     public transform(collection: any[], expressions: ISortingExpression []) {
         if (!expressions.length) {
             return collection;
@@ -73,7 +67,7 @@ export class IgxComboGroupingPipe implements PipeTransform {
 
     constructor(@Inject(IGX_COMBO_COMPONENT) public combo: IgxComboBase) { }
 
-    public transform(collection: any[], groupKey: any) {
+    public transform(collection: any[], groupKey: any, valueKey: any) {
         this.combo.filteredData = collection;
         if ((!groupKey && groupKey !== 0) || !collection.length) {
             return collection;
@@ -89,28 +83,13 @@ export class IgxComboGroupingPipe implements PipeTransform {
             }
             if (insertFlag) {
                 data.splice(i + inserts, 0, {
-                    [this.combo.valueKey]: currentHeader,
-                    [this.combo.groupKey]: currentHeader,
+                    [valueKey]: currentHeader,
+                    [groupKey]: currentHeader,
                     isHeader: true
                 });
                 inserts++;
             }
         }
         return data;
-    }
-}
-
-/**
- * @hidden
- */
-@Pipe({
-    name: 'filterCondition',
-    pure: true
-})
-
-export class IgxComboFilterConditionPipe implements PipeTransform {
-
-    public transform(value: string): string {
-        return value.split(/(?=[A-Z])/).join(' ');
     }
 }

--- a/projects/igniteui-angular/src/lib/combo/combo.pipes.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.pipes.ts
@@ -1,11 +1,9 @@
 import { Pipe, PipeTransform, Inject } from '@angular/core';
 import { cloneArray } from '../core/utils';
 import { DataUtil } from '../data-operations/data-util';
-import { FilteringLogic, IFilteringExpression } from '../data-operations/filtering-expression.interface';
+import { IFilteringExpression } from '../data-operations/filtering-expression.interface';
 import { ISortingExpression } from '../data-operations/sorting-expression.interface';
-import { IFilteringState } from '../data-operations/filtering-state.interface';
 import { FilteringStrategy } from '../data-operations/filtering-strategy';
-import { FilteringExpressionsTree } from '../data-operations/filtering-expressions-tree';
 import { IGX_COMBO_COMPONENT, IgxComboBase } from './combo.common';
 
 
@@ -16,18 +14,20 @@ import { IGX_COMBO_COMPONENT, IgxComboBase } from './combo.common';
     name: 'comboFiltering'
 })
 export class IgxComboFilteringPipe implements PipeTransform {
-    public transform(collection: any[], expressions: IFilteringExpression[],
-                     logic: FilteringLogic) {
-        const filteringExpressionsTree =  new FilteringExpressionsTree(logic);
-        filteringExpressionsTree.filteringOperands = expressions;
-        const state: IFilteringState = { expressionsTree: filteringExpressionsTree, strategy: new SimpleFilteringStrategy()};
-
-        if (!state.expressionsTree.filteringOperands.length) {
-            return collection;
+    public transform(collection: any[], searchValue: any, displayKey: any) {
+        if (!collection) {
+            return [];
         }
-
-        const result = DataUtil.filter(cloneArray(collection), state);
-        return result;
+        if (!searchValue) {
+            return collection;
+        } else {
+            const searchTerm = searchValue.toLowerCase().trim();
+            if (displayKey != null) {
+                return collection.filter(e => e[displayKey].toLowerCase().includes(searchTerm));
+            } else {
+                return collection.filter(e => e.includes(searchTerm));
+            }
+        }
     }
 }
 

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down-item.base.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down-item.base.ts
@@ -317,13 +317,6 @@ export class IgxDropDownItemBaseDirective implements DoCheck {
         @Optional() @Inject(IgxSelectionAPIService) protected selection?: IgxSelectionAPIService
     ) { }
 
-    /**
-     * @hidden @internal
-     */
-    @HostListener('click', ['$event'])
-    clicked(event) {
-    }
-
     ngDoCheck(): void {
         if (this._selected) {
             const dropDownSelectedItem = this.dropDown.selectedItem;


### PR DESCRIPTION
Change combo to work w/ Angular 9 + Ivy Renderer:

1. Remove `HostListeners` in combo item / combo add item as inheritance currently causes them to fire multiple times (https://github.com/angular/angular/issues/33300)
2. Change how filtering pipe works in combo as it was unnecessarily complex
3. Change how virtual scroll is handled (`cdr.detectChanges()` call was causing combo items to not be able to get their providers)
4. Adjust tests

# Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 