### PR TITLE
refactor(circular-bar): use *ngIf instead of ngClass in progress bar template - 9.0.x

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/progress/_progress-component.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/progress/_progress-component.scss
@@ -115,7 +115,6 @@
 
     @include e(text, $m: hidden) {
         @extend %circular-text !optional;
-        @extend %circular-text--hidden !optional;
     }
 
     @include m(indeterminate) {
@@ -123,10 +122,6 @@
 
         @include e(outer) {
             @extend %circular-outer--indeterminate !optional;
-        }
-
-        @include e(text) {
-            @extend %circular-text--hidden !optional;
         }
     }
 }

--- a/projects/igniteui-angular/src/lib/core/styles/components/progress/_progress-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/progress/_progress-theme.scss
@@ -295,10 +295,6 @@
         fill: --var($theme, 'text-color');
     }
 
-    %circular-text--hidden {
-        visibility: hidden;
-    }
-
     @include keyframes('indeterminate-accordion') {
         from {
             stroke-dashoffset: 578;

--- a/projects/igniteui-angular/src/lib/progressbar/circularbar.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/progressbar/circularbar.component.spec.ts
@@ -322,7 +322,8 @@ describe('IgCircularBar', () => {
 
         componentInstance.progressbar.textVisibility = false;
         fixture.detectChanges();
-        expect(progressBarElem.children[2].classList.value).toMatch(CIRCULAR_HIDDEN_TEXT_CLASS);
+        // Text is not rendered
+        expect(progressBarElem.children[2]).toBeFalsy();
     });
 
     it('When indeterminate mode is on value should not be updated', () => {
@@ -375,8 +376,8 @@ describe('IgCircularBar', () => {
 
             componentInstance.progressbar.textVisibility = false;
             fixture.detectChanges();
-
-            expect(progressBarElem.children[2].classList.value).toMatch(CIRCULAR_HIDDEN_TEXT_CLASS);
+            // Text is not rendered
+            expect(progressBarElem.children[2]).toBeFalsy();
         }));
 
         it('The max representation should respond correctly to passed maximum value', fakeAsync(() => {

--- a/projects/igniteui-angular/src/lib/progressbar/templates/circular-bar.component.html
+++ b/projects/igniteui-angular/src/lib/progressbar/templates/circular-bar.component.html
@@ -7,7 +7,7 @@
     [attr.aria-valuenow]="value">
     <circle class="igx-circular-bar__inner" cx="50" cy="50" r="46" />
     <circle #circle class="igx-circular-bar__outer" cx="50" cy="50" r="46" />
-    <text [class.igx-circular-bar__text--hidden]="!textVisibility" text-anchor="middle" x="50" y="60">
+    <text *ngIf="textVisibility" text-anchor="middle" x="50" y="60">
         <ng-container *ngTemplateOutlet="textTemplate ? textTemplate.template : defaultTextTemplate; context: context">
         </ng-container>
     </text>


### PR DESCRIPTION
Change the progress bar to use `*ngIf` instead of `ngClass` as the latter requires a specific polyfill and package in order to work in IE (`classlist.js`).

# Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 