### PR TITLE
fix(igxGrid): Workaround for ivy issue where ContentChildren are re-e…

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
@@ -547,6 +547,7 @@ export class IgxColumnComponent implements AfterContentInit {
             /* No grid/width available at initialization. `initPinning` in the grid
                will re-init the group (if present)
             */
+            this._unpinnedIndex = this.grid.columns.filter(x => !x.pinned).indexOf(this);
             this._pinned = value;
             this.pinnedChange.emit(this._pinned);
         }

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -3748,7 +3748,7 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
 
             if (this.pinnedColumns.indexOf(column) === -1 && this.pinnedColumns.indexOf(dropTarget) === -1) {
                 list = this._unpinnedColumns;
-            } else { 
+            } else {
                 list = this._pinnedColumns;
             }
 

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -3578,9 +3578,8 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
     /**
      * @hidden
      */
-    protected _reorderPinnedColumns(from: IgxColumnComponent, to: IgxColumnComponent, position: DropPosition) {
-        const pinned = this._pinnedColumns;
-        let dropIndex = pinned.indexOf(to);
+    protected _reorderColumns(from: IgxColumnComponent, to: IgxColumnComponent, position: DropPosition, columnCollection: any[]) {
+        let dropIndex = columnCollection.indexOf(to);
 
         if (to.columnGroup) {
             dropIndex += to.allChildren.length;
@@ -3594,9 +3593,8 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
             dropIndex++;
         }
 
-        pinned.splice(dropIndex, 0, ...pinned.splice(pinned.indexOf(from), 1));
+        columnCollection.splice(dropIndex, 0, ...columnCollection.splice(columnCollection.indexOf(from), 1));
     }
-
     /**
      * @hidden
      */
@@ -3649,12 +3647,13 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
         }
 
         if (dropTarget.pinned && column.pinned) {
-            this._reorderPinnedColumns(column, dropTarget, position);
+            this._reorderColumns(column, dropTarget, position, this._pinnedColumns);
         }
 
         if (dropTarget.pinned && !column.pinned) {
             column.pin();
-            this._reorderPinnedColumns(column, dropTarget, position);
+            this._reorderColumns(column, dropTarget, position, this._pinnedColumns);
+
         }
 
         if (!dropTarget.pinned && column.pinned) {
@@ -3671,6 +3670,10 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
             } else {
                 position = DropPosition.None;
             }
+        }
+
+        if (!dropTarget.pinned) {
+            this._reorderColumns(column, dropTarget, position, this._unpinnedColumns);
         }
 
         this._moveColumns(column, dropTarget, position);
@@ -4857,7 +4860,9 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
     protected reinitPinStates() {
         this._pinnedColumns = (this.hasColumnGroups) ? this.columnList.filter((c) => c.pinned) :
             this.columnList.filter((c) => c.pinned).sort((a, b) => this._pinnedColumns.indexOf(a) - this._pinnedColumns.indexOf(b));
-        this._unpinnedColumns = this.columnList.filter((c) => !c.pinned);
+        this._unpinnedColumns = this.hasColumnGroups ? this.columnList.filter((c) => !c.pinned) :
+        this.columnList.filter((c) => !c.pinned)
+        .sort((a, b) => this._unpinnedColumns.indexOf(a) - this._unpinnedColumns.indexOf(b));
     }
 
     /**

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -3724,8 +3724,14 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
 
         if (!dropTarget.pinned && column.pinned) {
             column.unpin();
+            let list = [];
 
-            const list = this.columnList.toArray();
+            if (this.pinnedColumns.indexOf(column) === -1 && this.pinnedColumns.indexOf(dropTarget) === -1) {
+                list = this._unpinnedColumns;
+            } else { 
+                list = this._pinnedColumns;
+            }
+
             const fi = list.indexOf(column);
             const ti = list.indexOf(dropTarget);
 


### PR DESCRIPTION
…valuated  after rendering an inner template, resulting in the resetting the columns collection in their original order. Workaround is to apply sorting for the internal unpinned cols collection after re-evaliuation, similarly to what's done to the pinned collection, in order to ensure the order is always correct.

Closes #6132   

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 