### PR TITLE
fix(exporter): drop output decorators, revert migration + rename #6227

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@ All notable changes for each version of this project will be documented in this 
     - `IgxRowComponent` -> `IgxRowDirective`
     - `IgxHierarchicalGridBaseComponent` -> `IgxHierarchicalGridBaseDirective`
     - `IgxMonthPickerBase` -> `IgxMonthPickerBaseDirective`
-    - `IgxBaseExporter` -> `IgxBaseExporterDirective`
 
 - `IgxGrid`, `IgxTreeGrid`, `IgxHierarchicalGrid`
     - **Behavioral Change** - Pinning columns is no longer automatically prevented when the pinning area would exceed the size of the grid.

--- a/projects/igniteui-angular/src/lib/grids/common/events.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/events.ts
@@ -1,5 +1,5 @@
 import { IBaseEventArgs, CancelableEventArgs } from '../../core/utils';
-import { IgxBaseExporterDirective, IgxExporterOptionsBase } from '../../services';
+import { IgxBaseExporter, IgxExporterOptionsBase } from '../../services';
 import { GridKeydownTargetType } from './enums';
 import { IgxDragDirective } from '../../directives/drag-drop/drag-drop.directive';
 import { IGridDataBindable } from './grid.interface';
@@ -70,7 +70,7 @@ export interface ISearchInfo {
 
 export interface IGridToolbarExportEventArgs extends IBaseEventArgs {
     grid: IgxGridBaseDirective;
-    exporter: IgxBaseExporterDirective;
+    exporter: IgxBaseExporter;
     options: IgxExporterOptionsBase;
     cancel: boolean;
 }

--- a/projects/igniteui-angular/src/lib/grids/toolbar/grid-toolbar.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/toolbar/grid-toolbar.component.ts
@@ -12,7 +12,7 @@ import {
 import { IDisplayDensityOptions, DisplayDensityToken, DisplayDensityBase } from '../../core/displayDensity';
 import {
     CsvFileTypes,
-    IgxBaseExporterDirective,
+    IgxBaseExporter,
     IgxCsvExporterOptions,
     IgxCsvExporterService,
     IgxExcelExporterOptions,
@@ -309,7 +309,7 @@ export class IgxGridToolbarComponent extends DisplayDensityBase {
         this.performExport(this.csvExporter, 'csv');
     }
 
-    private performExport(exp: IgxBaseExporterDirective, exportType: string) {
+    private performExport(exp: IgxBaseExporter, exportType: string) {
         this.exportClicked();
 
         const fileName = 'ExportedData';

--- a/projects/igniteui-angular/src/lib/services/csv/csv-exporter.ts
+++ b/projects/igniteui-angular/src/lib/services/csv/csv-exporter.ts
@@ -1,5 +1,5 @@
 import { EventEmitter, Injectable, Output } from '@angular/core';
-import { IgxBaseExporterDirective } from '../exporter-common/base-export-service';
+import { IgxBaseExporter } from '../exporter-common/base-export-service';
 import { ExportUtilities } from '../exporter-common/export-utilities';
 import { CharSeparatedValueData } from './char-separated-value-data';
 import { CsvFileTypes, IgxCsvExporterOptions } from './csv-exporter-options';
@@ -32,7 +32,7 @@ export interface ICsvExportEndedEventArgs extends IBaseEventArgs {
  * ```
  */
 @Injectable()
-export class IgxCsvExporterService extends IgxBaseExporterDirective {
+export class IgxCsvExporterService extends IgxBaseExporter {
     private _stringData: string;
 
     /**

--- a/projects/igniteui-angular/src/lib/services/excel/excel-exporter.ts
+++ b/projects/igniteui-angular/src/lib/services/excel/excel-exporter.ts
@@ -5,7 +5,7 @@ import { ExcelElementsFactory } from './excel-elements-factory';
 import { ExcelFolderTypes } from './excel-enums';
 import { IgxExcelExporterOptions } from './excel-exporter-options';
 import { IExcelFolder } from './excel-interfaces';
-import { IgxBaseExporterDirective } from '../exporter-common/base-export-service';
+import { IgxBaseExporter } from '../exporter-common/base-export-service';
 import { ExportUtilities } from '../exporter-common/export-utilities';
 import { WorksheetData } from './worksheet-data';
 import { IBaseEventArgs } from '../../core/utils';
@@ -36,7 +36,7 @@ export interface IExcelExportEndedEventArgs extends IBaseEventArgs {
  * ```
  */
 @Injectable()
-export class IgxExcelExporterService extends IgxBaseExporterDirective {
+export class IgxExcelExporterService extends IgxBaseExporter {
 
     private static ZIP_OPTIONS = { compression: 'DEFLATE', type: 'base64' };
     private _xlsx: JSZip;

--- a/projects/igniteui-angular/src/lib/services/exporter-common/base-export-service.ts
+++ b/projects/igniteui-angular/src/lib/services/exporter-common/base-export-service.ts
@@ -1,4 +1,4 @@
-import { EventEmitter, Output, Directive } from '@angular/core';
+import { EventEmitter } from '@angular/core';
 
 import { cloneValue, IBaseEventArgs } from '../../core/utils';
 import { DataUtil } from '../../data-operations/data-util';
@@ -66,8 +66,7 @@ export interface IColumnExportingEventArgs extends IBaseEventArgs {
     skipFormatter: boolean;
 }
 
-@Directive()
-export abstract class IgxBaseExporterDirective {
+export abstract class IgxBaseExporter {
     private _columnList: any[];
     private flatRecords = [];
 
@@ -84,7 +83,6 @@ export abstract class IgxBaseExporterDirective {
      * ```
      * @memberof IgxBaseExporter
      */
-    @Output()
     public onRowExport = new EventEmitter<IRowExportingEventArgs>();
 
     /**
@@ -96,7 +94,6 @@ export abstract class IgxBaseExporterDirective {
      * ```
      * @memberof IgxBaseExporter
      */
-    @Output()
     public onColumnExport = new EventEmitter<IColumnExportingEventArgs>();
 
     /**

--- a/src/app/grid/grid.sample.ts
+++ b/src/app/grid/grid.sample.ts
@@ -7,7 +7,7 @@ import {
     IgxToastComponent,
     SortingDirection,
     CsvFileTypes,
-    IgxBaseExporterDirective,
+    IgxBaseExporter,
     IgxCsvExporterOptions,
     IgxCsvExporterService,
     IgxExcelExporterOptions,
@@ -250,7 +250,7 @@ export class GridSampleComponent implements OnInit, AfterViewInit {
         this.getExporterService().exportData(this.grid3.data, this.getOptions('Data'));
     }
 
-    private getExporterService(): IgxBaseExporterDirective {
+    private getExporterService(): IgxBaseExporter {
         return this.exportFormat === 'XLSX' ? this.excelExporterService : this.csvExporterService;
     }
 


### PR DESCRIPTION
Closes #6227 
This slipped through the [Angular 9 update](https://github.com/IgniteUI/igniteui-angular/pull/6146). Migrations applied `@Directive` to base classes with any sort of binding and since the `IgxBaseExporter` had emitters decorated with `@Output`, ¯\\_(ツ)_/¯, migrations must've considered it as a component base. Both decorators have been removed.

And since I semi-batch renamed classes with added Directives for lint, I'm rolling back the rename as well. I'll revert docs links if required too.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 