### PR TITLE
Remove check for wheel listener from block scroll strategy

### DIFF
--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -859,7 +859,6 @@ describe('igxOverlay', () => {
             spyOn(scrollStrat, 'attach').and.callThrough();
             spyOn(scrollStrat, 'detach').and.callThrough();
             const scrollSpy = spyOn<any>(scrollStrat, 'onScroll').and.callThrough();
-            const wheelSpy = spyOn<any>(scrollStrat, 'onWheel').and.callThrough();
             overlay.show(SimpleDynamicComponent, overlaySettings);
             tick();
 
@@ -867,11 +866,8 @@ describe('igxOverlay', () => {
             expect(scrollStrat.initialize).toHaveBeenCalledTimes(1);
             expect(scrollStrat.detach).toHaveBeenCalledTimes(0);
             document.dispatchEvent(new Event('scroll'));
-
             expect(scrollSpy).toHaveBeenCalledTimes(1);
 
-            document.dispatchEvent(new Event('wheel'));
-            expect(wheelSpy).toHaveBeenCalledTimes(1);
             overlay.hide('0');
             tick();
             expect(scrollStrat.detach).toHaveBeenCalledTimes(1);

--- a/projects/igniteui-angular/src/lib/services/overlay/scroll/block-scroll-strategy.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/scroll/block-scroll-strategy.ts
@@ -28,13 +28,11 @@ export class BlockScrollStrategy extends ScrollStrategy {
     /** @inheritdoc */
     public attach(): void {
         this._document.addEventListener('scroll', this.onScroll, true);
-        this._document.addEventListener('wheel', this.onWheel, true);
     }
 
     /** @inheritdoc */
     public detach(): void {
         this._document.removeEventListener('scroll', this.onScroll, true);
-        this._document.removeEventListener('wheel', this.onWheel, true);
         this._sourceElement = null;
         this._initialScrollTop = 0;
         this._initialScrollLeft = 0;
@@ -51,10 +49,5 @@ export class BlockScrollStrategy extends ScrollStrategy {
 
         this._sourceElement.scrollTop = this._initialScrollTop;
         this._sourceElement.scrollLeft = this._initialScrollLeft;
-    }
-
-    private onWheel(ev: WheelEvent) {
-        ev.stopImmediatePropagation();
-        ev.preventDefault();
     }
 }


### PR DESCRIPTION
For some reason there was `wheel` event listener in `BlockScrollStrategy`. As we have `scroll` handler I do not think we need the `wheel` one.

However we need to test this thoroughly 

Closes #6226  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 