### PR TITLE
Retain classes added through markup in IgxNavDrawer 8.1.x

### DIFF
--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
@@ -12,7 +12,7 @@ import { PlatformUtil } from '../core/utils';
 declare var Simulator: any;
 const oldTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
-describe('Navigation Drawer', () => {
+fdescribe('Navigation Drawer', () => {
     let widthSpyOverride: jasmine.Spy;
     // configureTestSuite();
     beforeEach(async(() => {
@@ -571,6 +571,14 @@ describe('Navigation Drawer', () => {
         done();
     });
 
+    it('should retain classes added in markup, fix for #6508', () => {
+        const fix = TestBed.createComponent(TestComponent);
+        fix.detectChanges();
+
+        expect(fix.componentInstance.navDrawer.element.classList.contains('markupClass')).toBeTruthy();
+        expect(fix.componentInstance.navDrawer.element.classList.contains('igx-nav-drawer')).toBeTruthy();
+    });
+
     function swipe(element, posX, posY, duration, deltaX, deltaY) {
         const swipeOptions = {
             deltaX,
@@ -610,7 +618,7 @@ describe('Navigation Drawer', () => {
 
 @Component({
     selector: 'igx-test-cmp',
-    template: '<igx-nav-drawer></igx-nav-drawer>'
+    template: '<igx-nav-drawer class="markupClass"></igx-nav-drawer>'
 })
 class TestComponent {
     @ViewChild(IgxNavigationDrawerComponent, { static: true }) public navDrawer: IgxNavigationDrawerComponent;

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.spec.ts
@@ -12,7 +12,7 @@ import { PlatformUtil } from '../core/utils';
 declare var Simulator: any;
 const oldTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
 
-fdescribe('Navigation Drawer', () => {
+describe('Navigation Drawer', () => {
     let widthSpyOverride: jasmine.Spy;
     // configureTestSuite();
     beforeEach(async(() => {

--- a/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
+++ b/projects/igniteui-angular/src/lib/navigation-drawer/navigation-drawer.component.ts
@@ -62,7 +62,9 @@ export class IgxNavigationDrawerComponent implements
     OnDestroy,
     OnChanges {
 
-    @HostBinding('class') public cssClass = 'igx-nav-drawer';
+    /** @hidden @internal */
+    @HostBinding('class.igx-nav-drawer')
+    public cssClass = true;
 
     /**
      * ID of the component


### PR DESCRIPTION
Host binding of the component class is fixed.

Closes #6508 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 