### PR TITLE
fix(ng-add): move schematics version to custom igxDevDependencies #6646

### DIFF
--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -78,7 +78,7 @@
         "@angular/forms": "^9.0.0",
         "web-animations-js": "^2.3.2"
     },
-    "devDependencies": {
+    "igxDevDependencies": {
         "@igniteui/angular-schematics": "~9.0.500-rc.3"
     },
     "ng-update": {

--- a/projects/igniteui-angular/schematics/ng-add/index.spec.ts
+++ b/projects/igniteui-angular/schematics/ng-add/index.spec.ts
@@ -108,7 +108,8 @@ describe('ng-add schematics', () => {
     runner.runSchematic('ng-add', { normalizeCss: false }, tree);
     const pkgJsonData = JSON.parse(tree.readContent('/package.json'));
 
-    expect(pkgJsonData.devDependencies['@igniteui/angular-schematics']).toBeTruthy();
+    const version = require('../../package.json')['igxDevDependencies']['@igniteui/angular-schematics'];
+    expect(pkgJsonData.devDependencies['@igniteui/angular-schematics']).toBe(version);
     expect(pkgJsonData.dependencies['@igniteui/angular-schematics']).toBeFalsy();
   });
 

--- a/projects/igniteui-angular/schematics/utils/dependency-handler.ts
+++ b/projects/igniteui-angular/schematics/utils/dependency-handler.ts
@@ -67,7 +67,7 @@ export function addDependencies(options: Options): Rule {
             }
         });
 
-        addPackageToPkgJson(tree, schematicsPackage, pkgJson.devDependencies[schematicsPackage], devDependencies);
+        addPackageToPkgJson(tree, schematicsPackage, pkgJson.igxDevDependencies[schematicsPackage], devDependencies);
         return tree;
     };
 }


### PR DESCRIPTION
Closes #6646

After beta.7 (ng RC10 update) the newer ng-packager included a change that started [removing `devDependencies` ](https://travis-ci.org/IgniteUI/igniteui-angular/builds/648318135#L358) from the dist package.json. Related to https://github.com/ng-packagr/ng-packagr/pull/1438

Since we used that to carry the version of schematics our `ng-add` would use, moved to a custom meta pror named `igxDevDependencies` instead.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 