### PR TITLE
fix(dropdown): to be as big as its content

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-component.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-component.scss
@@ -11,6 +11,8 @@
     $this: bem--selector-to-string(&);
     @include register-component(str-slice($this, 2, -1));
 
+    @extend %igx-drop-down !optional;
+
     @include e(list) {
         @extend %igx-drop-down__list !optional;
     }

--- a/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-theme.scss
@@ -216,6 +216,10 @@
         compact: 0 rem(8px)
     );
 
+    %igx-drop-down {
+        position: absolute;
+    }
+
     %igx-drop-down__list {
         overflow: hidden;
         border-radius: --var($theme, 'border-radius');
@@ -227,6 +231,7 @@
 
     %igx-drop-down__list-scroll {
         overflow-y: auto;
+        overflow-x: hidden;
         position: relative;
 
         &:empty {


### PR DESCRIPTION
Set "igx-dropdown" position to absolute in order to force it to be as
big as its content despite its parent element display.

Closes #6733, #6734

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 