### PR TITLE
Enhances pinning sample and fixes right pinning offset

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
@@ -1003,9 +1003,9 @@ export class IgxColumnComponent implements AfterContentInit {
     }
 
     get rightPinnedOffset(): string {
-        return this.pinned ?
+        return (this.pinned && !this.grid.isPinningToStart) ?
             - this.grid.pinnedWidth + 'px' :
-            null;
+            this.grid.isPinningToStart ? 0 + 'px' : null;
     }
 
     get gridRowSpan(): number {

--- a/src/app/grid-column-pinning/grid-column-pinning.sample.html
+++ b/src/app/grid-column-pinning/grid-column-pinning.sample.html
@@ -23,6 +23,7 @@
         <div class="sample-switches">
             <igx-switch [(ngModel)]="grid1.showToolbar">Toolbar</igx-switch>
             <igx-switch [(ngModel)]="grid1.columnPinning" style="padding-left: 10px">Column Pinning</igx-switch>
+            <igx-switch *ngIf="grid1.columnPinning" [(ngModel)]="rightPinning" style="padding-left: 10px">Right Pinning</igx-switch>
         </div>
         </div>
     </div>

--- a/src/app/grid-column-pinning/grid-column-pinning.sample.ts
+++ b/src/app/grid-column-pinning/grid-column-pinning.sample.ts
@@ -12,6 +12,16 @@ import { IPinningConfig } from 'projects/igniteui-angular/src/lib/grids/common/g
 export class GridColumnPinningSampleComponent implements OnInit {
 
     public pinningConfig: IPinningConfig = { columns: ColumnPinningPosition.End };
+    public get rightPinning() {
+        return (this.pinningConfig.columns === ColumnPinningPosition.End);
+    }
+    public set rightPinning(rightPinning) {
+        if (this.pinningConfig.columns === ColumnPinningPosition.End) {
+            this.pinningConfig.columns = ColumnPinningPosition.Start;
+        } else {
+            this.pinningConfig.columns = ColumnPinningPosition.End;
+        }
+    }
 
     @ViewChild('grid1', { static: true })
     grid1: IgxGridComponent;


### PR DESCRIPTION
The cell into the column template component relies on the `rightPinnedOffset` method, which can cause trouble while calculating the offset of the column while a left pinning is in action, because it is dedicated to correctly displaying the right pinning.
Furthermore, I made a slight enhancement to the sample showing pinning, by adding an ability to switch between left and right column pinning at runtime.

### Additional information (check all that apply):
 - [x] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [x] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 