### PR TITLE
fix(select): Move disabled on the Input elem #6908

### DIFF
--- a/projects/igniteui-angular/src/lib/select/select.component.html
+++ b/projects/igniteui-angular/src/lib/select/select.component.html
@@ -1,4 +1,4 @@
-<igx-input-group #inputGroup class="input-group" [disabled]="disabled" (click)="toggle()" [type]="type" [displayDensity]="displayDensity">
+<igx-input-group #inputGroup class="input-group" (click)="toggle()" [type]="type" [displayDensity]="displayDensity">
     <ng-container ngProjectAs="[igxLabel]">
         <ng-content select="[igxLabel]"></ng-content>
     </ng-container>
@@ -6,6 +6,7 @@
         <ng-content select="igx-prefix,[igxPrefix]"></ng-content>
     </ng-container>
     <input #input class="input" type="text" igxInput [igxSelectItemNavigation]="this"
+        [disabled]="disabled"
         readonly="true"
         [attr.placeholder]="this.placeholder"
         [value]="this.selectionValue"


### PR DESCRIPTION
Closes #6908  

The input will no longer be focusable. Existing test are available in input-group.directive.spec as well.  The input disabled attribute is checked internally in the input-group and the required styling classes applied as well.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 