### PR TITLE
Refactor tree grid pinning - unify logic between grid and tree grid.

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-common.module.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-common.module.ts
@@ -29,6 +29,7 @@ import { IgxGridColumnModule } from './columns/column.module';
 import { IgxGridHeadersModule } from './headers/headers.module';
 import { IgxGridFilteringModule } from './filtering/base/filtering.module';
 import { IgxRowDirective } from './row.directive';
+import { IgxGridRowPinningPipe } from './grid/grid.pipes';
 /**
  * @hidden
  */
@@ -43,7 +44,8 @@ import { IgxRowDirective } from './row.directive';
         IgxRowEditTabStopDirective,
         IgxGridBodyDirective,
         IgxGridFooterComponent,
-        IgxAdvancedFilteringDialogComponent
+        IgxAdvancedFilteringDialogComponent,
+        IgxGridRowPinningPipe
     ],
     entryComponents: [
         IgxAdvancedFilteringDialogComponent
@@ -71,7 +73,8 @@ import { IgxRowDirective } from './row.directive';
         IgxGridSummaryModule,
         IgxGridToolbarModule,
         IgxAdvancedFilteringDialogComponent,
-        IgxGridSharedModules
+        IgxGridSharedModules,
+        IgxGridRowPinningPipe
     ],
     imports: [
         IgxGridColumnModule,

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.module.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.module.ts
@@ -42,7 +42,6 @@ import { IgxGridExpandableCellComponent } from './expandable-cell.component';
     IgxGridPagingPipe,
     IgxGridSortingPipe,
     IgxGridFilteringPipe,
-    IgxGridRowPinningPipe,
     IgxGridSummaryPipe,
     IgxGridDetailsPipe,
     IgxGridExpandableCellComponent
@@ -63,7 +62,6 @@ import { IgxGridExpandableCellComponent } from './expandable-cell.component';
     IgxGridPagingPipe,
     IgxGridSortingPipe,
     IgxGridFilteringPipe,
-    IgxGridRowPinningPipe,
     IgxGridSummaryPipe,
     IgxGridDetailsPipe,
     IgxGridCommonModule

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-integration.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-integration.spec.ts
@@ -1536,7 +1536,7 @@ describe('IgxTreeGrid - Integration #tGrid', () => {
             const gridFilterData = treeGrid.filteredData;
             expect(gridFilterData.length).toBe(2);
             expect(gridFilterData[0].ID).toBe(147);
-            expect(gridFilterData[1].recordRef.ID).toBe(147);
+            expect(gridFilterData[1].ID).toBe(147);
         });
 
         it('should apply sorting to both pinned and unpinned rows', () => {

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-row.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-row.component.ts
@@ -32,46 +32,8 @@ export class IgxTreeGridRowComponent extends IgxRowDirective<IgxTreeGridComponen
     public set treeRow(value: ITreeGridRecord) {
         if (this._treeRow !== value) {
             this._treeRow = value;
-            this.rowData = this.grid.isGhostRecord(this._treeRow.data) ?
-                            this._treeRow.data.recordRef :
-                            this._treeRow.data;
+            this.rowData = this._treeRow.data;
         }
-    }
-
-    /**
-     * Gets whether the row is pinned.
-     *
-     * @example
-     * ```typescript
-     * let pinned = row.pinned;
-     * ```
-     */
-    public get pinned(): boolean {
-        return this.grid.isRecordPinned(this.rowData);
-    }
-
-    /**
-     * Sets whether the row is pinned.
-     * Default value is `false`.
-     * ```typescript
-     * this.grid.selectedRows[0].pinned = true;
-     * ```
-     */
-    public set pinned(value: boolean) {
-        if (value) {
-            this.grid.pinRow(this.rowID);
-        } else {
-            this.grid.unpinRow(this.rowID);
-        }
-    }
-
-    /**
-     * @hidden
-     */
-    @Input()
-    @HostBinding('attr.aria-selected')
-    get selected(): boolean {
-        return this.selectionService.isRowSelected(this.rowID);
     }
 
     /**

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-row.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-row.component.ts
@@ -36,6 +36,10 @@ export class IgxTreeGridRowComponent extends IgxRowDirective<IgxTreeGridComponen
         }
     }
 
+    public get pinned() {
+        return this.grid.isRecordPinned(this._treeRow);
+    }
+
     /**
      * Returns a value indicating whether the row component is expanded.
      *

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.html
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.html
@@ -76,8 +76,10 @@
             class="igx-grid__scroll-on-drag-pinned" [style.left.px]="pinnedWidth"></span>
         <ng-template #pinnedRecordsTemplate>
             <ng-container *ngIf='data
+            | treeGridTransaction:id:pipeTrigger
             | visibleColumns:hasVisibleColumns
-            | treeGridRowPinning:id:pipeTrigger
+            | treeGridNormalizeRecord:id:pipeTrigger
+            | gridRowPinning:id:true:pipeTrigger
             | treeGridFiltering:filteringExpressionsTree:filterStrategy:advancedFilteringExpressionsTree:id:pipeTrigger:filteringPipeTrigger:true
             | treeGridSorting:sortingExpressions:sortStrategy:id:pipeTrigger:true as pinnedData'>
                 <div #pinContainer *ngIf='pinnedData.length > 0' 
@@ -98,12 +100,12 @@
         | treeGridTransaction:id:pipeTrigger
         | visibleColumns:hasVisibleColumns
         | treeGridHierarchizing:primaryKey:foreignKey:childDataKey:id:pipeTrigger
-        | treeGridShadowRows:id:pipeTrigger
         | treeGridFiltering:filteringExpressionsTree:filterStrategy:advancedFilteringExpressionsTree:id:pipeTrigger:filteringPipeTrigger
         | treeGridSorting:sortingExpressions:sortStrategy:id:pipeTrigger
         | treeGridFlattening:id:expansionDepth:expansionStates:pipeTrigger
         | treeGridPaging:page:perPage:id:pipeTrigger
-        | treeGridSummary:hasSummarizedColumns:summaryCalculationMode:summaryPosition:id:pipeTrigger:summaryPipeTrigger"
+        | treeGridSummary:hasSummarizedColumns:summaryCalculationMode:summaryPosition:id:pipeTrigger:summaryPipeTrigger
+        | gridRowPinning:id:false:pipeTrigger"
             let-rowIndex="index" [igxForScrollOrientation]="'vertical'" [igxForScrollContainer]='verticalScroll'
             [igxForContainerSize]='calcHeight' [igxForItemSize]="renderedRowHeight" #verticalScrollContainer
             (onChunkPreload)="dataLoading($event)">

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.html
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.html
@@ -78,7 +78,7 @@
             <ng-container *ngIf='data
             | treeGridTransaction:id:pipeTrigger
             | visibleColumns:hasVisibleColumns
-            | treeGridNormalizeRecord:id:pipeTrigger
+            | treeGridNormalizeRecord:pipeTrigger
             | treeGridFiltering:filteringExpressionsTree:filterStrategy:advancedFilteringExpressionsTree:id:pipeTrigger:filteringPipeTrigger:true
             | treeGridSorting:sortingExpressions:sortStrategy:id:pipeTrigger:true
             | gridRowPinning:id:true:pipeTrigger as pinnedData'>

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.html
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.html
@@ -79,9 +79,9 @@
             | treeGridTransaction:id:pipeTrigger
             | visibleColumns:hasVisibleColumns
             | treeGridNormalizeRecord:id:pipeTrigger
-            | gridRowPinning:id:true:pipeTrigger
             | treeGridFiltering:filteringExpressionsTree:filterStrategy:advancedFilteringExpressionsTree:id:pipeTrigger:filteringPipeTrigger:true
-            | treeGridSorting:sortingExpressions:sortStrategy:id:pipeTrigger:true as pinnedData'>
+            | treeGridSorting:sortingExpressions:sortStrategy:id:pipeTrigger:true
+            | gridRowPinning:id:true:pipeTrigger as pinnedData'>
                 <div #pinContainer *ngIf='pinnedData.length > 0' 
                     [ngClass]="{
                         'igx-grid__tr--pinned-bottom':  !isRowPinningToTop,

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
@@ -618,7 +618,7 @@ export class IgxTreeGridComponent extends IgxGridBaseDirective implements GridTy
 
     /**
      * @hidden @internal
-     * This is overwritten because tree grid records have special record format - ITreeGridRecord, 
+     * This is overwritten because tree grid records have special record format - ITreeGridRecord,
      * which already has the rowID in the record object.
      */
     public isRecordPinned(rec) {

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
@@ -608,16 +608,22 @@ export class IgxTreeGridComponent extends IgxGridBaseDirective implements GridTy
      * @hidden
      */
     public getContext(rowData: any, rowIndex: number, pinned?: boolean): any {
-        if (pinned && !this.isRowPinningToTop) {
-            rowIndex = rowIndex + this.dataView.length;
-        }
-        rowIndex = !pinned && this.isRowPinningToTop ? rowIndex + this._pinnedRecordIDs.length : rowIndex;
         return {
-            $implicit: rowData,
-            index: rowIndex,
+            $implicit: this.isGhostRecord(rowData) ? rowData.recordRef : rowData,
+            index: this.getRowIndex(rowIndex, pinned),
             templateID: this.isSummaryRow(rowData) ? 'summaryRow' : 'dataRow',
-            disabled: this.isSummaryRow(rowData) ? false : this.isGhostRecord(rowData.data)
+            disabled: this.isGhostRecord(rowData)
         };
+    }
+
+    /**
+     * @hidden @internal
+     * This is overwritten because tree grid records have special record format - ITreeGridRecord, 
+     * which already has the rowID in the record object.
+     */
+    public isRecordPinned(rec) {
+        const id = rec.rowID;
+        return this._pinnedRecordIDs.indexOf(id) !== -1;
     }
 
     /**

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.module.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { IgxTreeGridComponent } from './tree-grid.component';
 import { IgxTreeGridRowComponent } from './tree-grid-row.component';
 import { IgxGridCommonModule } from '../grid-common.module';
-import { IgxTreeGridHierarchizingPipe, IgxTreeGridRowPinningPipe, IgxTreeGridShadowRowsPipe } from './tree-grid.pipes';
+import { IgxTreeGridHierarchizingPipe, IgxTreeGridNormalizeRecordsPipe } from './tree-grid.pipes';
 import { IgxTreeGridFlatteningPipe, IgxTreeGridSortingPipe, IgxTreeGridPagingPipe, IgxTreeGridTransactionPipe } from './tree-grid.pipes';
 import { IgxTreeGridCellComponent } from './tree-cell.component';
 import { IgxTreeGridFilteringPipe } from './tree-grid.filtering.pipe';
@@ -25,8 +25,7 @@ import { IgxRowLoadingIndicatorTemplateDirective } from './tree-grid.directives'
     IgxTreeGridTransactionPipe,
     IgxTreeGridSummaryPipe,
     IgxRowLoadingIndicatorTemplateDirective,
-    IgxTreeGridRowPinningPipe,
-    IgxTreeGridShadowRowsPipe
+    IgxTreeGridNormalizeRecordsPipe
   ],
   exports: [
     IgxTreeGridComponent,

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.pipes.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.pipes.ts
@@ -324,11 +324,14 @@ export class IgxTreeGridNormalizeRecordsPipe implements PipeTransform {
         this.gridAPI = <IgxTreeGridAPIService> gridAPI;
     }
 
-    transform(collection: any[], id: string, pipeTrigger: number): any[] {
-        const primaryKey = this.gridAPI.grid.primaryKey;
-        const res = collection.map(rec =>
+    transform(collection: any[], pipeTrigger: number): any[] {       
+        const grid =  this.gridAPI.grid;
+        const primaryKey = grid.primaryKey;
+        // using flattened data because origin data may be hierarchical.
+        const flatData = grid.flatData;
+        const res = flatData.map(rec =>
             ({
-                    rowID: primaryKey ? rec[primaryKey] : rec,
+                    rowID: grid.primaryKey ? rec[primaryKey] : rec,
                     data: rec,
                     level: 0,
                     children: []

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.pipes.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.pipes.ts
@@ -324,7 +324,7 @@ export class IgxTreeGridNormalizeRecordsPipe implements PipeTransform {
         this.gridAPI = <IgxTreeGridAPIService> gridAPI;
     }
 
-    transform(collection: any[], pipeTrigger: number): any[] {       
+    transform(collection: any[], pipeTrigger: number): any[] {
         const grid =  this.gridAPI.grid;
         const primaryKey = grid.primaryKey;
         // using flattened data because origin data may be hierarchical.

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.pipes.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.pipes.ts
@@ -223,7 +223,7 @@ export class IgxTreeGridSortingPipe implements PipeTransform {
     private flattenTreeGridRecords(records: ITreeGridRecord[], flatData: any[]) {
         if (records && records.length) {
             for (const record of records) {
-                this.gridAPI.grid.isGhostRecord(record) ? flatData.push(record.data.recordRef) : flatData.push(record.data);
+                flatData.push(record.data);
                 this.flattenTreeGridRecords(record.children, flatData);
             }
         }
@@ -332,7 +332,7 @@ export class IgxTreeGridNormalizeRecordsPipe implements PipeTransform {
         const res = flatData.map(rec =>
             ({
                     rowID: grid.primaryKey ? rec[primaryKey] : rec,
-                    data: rec,
+                    data: Object.assign({}, rec),
                     level: 0,
                     children: []
             }));

--- a/src/app/grid-row-pinning/grid-row-pinning.sample.html
+++ b/src/app/grid-row-pinning/grid-row-pinning.sample.html
@@ -4,7 +4,7 @@
     </app-page-header>
     <button (click)="grid1.addRow({'ID': 'TEST', 'CompanyName': 'Test'})">Add Row</button>
     <button (click)="exportButtonHandler()">Export</button>
-        <!-- <div class="sample-column">
+        <div class="sample-column">
             <div>igxGrid</div>
             <div>
                 <input igxButton="raised" type="button" name="Density" (click)="toggleDensity()" value="Density"/>
@@ -77,17 +77,12 @@
                 </igx-row-island>
                 <igx-row-island [key]="'childData2'" [autoGenerate]="true" [allowFiltering]='true'></igx-row-island>
             </igx-hierarchical-grid>
-        </div> -->
-
-        <div class="sample-switches">
-            <igx-switch (change)='onRowChange()' style="padding-left: 10px"> Bottom Row Pinning toggle</igx-switch>
-            <igx-switch (change)='onChange()' style="padding-left: 10px"> Right Column Pinning toggle</igx-switch>
         </div>
-        <input igxButton="raised" type="button" (click)="treegrid.pinRow(0)" value="Pin 0"/>
+
         <div class="sample-column">
             <div>igxTreeGrid</div>
             <igx-tree-grid [pinning]="pinningConfig" #treegrid [allowFiltering]='true' [data]="treeData" primaryKey="employeeID" foreignKey="PID" [rowSelectable]="true"
-            [paging]="true" [width]="'900px'" [height]="'800px'" [showToolbar]="true"
+            [width]="'900px'" [height]="'800px'" [showToolbar]="true"
             [columnHiding]="true" [columnPinning]="true" [exportExcel]="true" [exportCsv]="true" exportText="Export"
            >
            <igx-column width='150px' [filterable]='false'>
@@ -104,7 +99,7 @@
             </igx-column>
 
             <ng-template igxToolbarCustomContent>
-                <app-grid-search-box [grid]="grid1" [style.width]="'530px'"></app-grid-search-box>
+                <app-grid-search-box [grid]="treegrid" [style.width]="'530px'"></app-grid-search-box>
             </ng-template>
         </igx-tree-grid>
         </div>

--- a/src/app/grid-row-pinning/grid-row-pinning.sample.html
+++ b/src/app/grid-row-pinning/grid-row-pinning.sample.html
@@ -79,9 +79,14 @@
             </igx-hierarchical-grid>
         </div> -->
 
+        <div class="sample-switches">
+            <igx-switch (change)='onRowChange()' style="padding-left: 10px"> Bottom Row Pinning toggle</igx-switch>
+            <igx-switch (change)='onChange()' style="padding-left: 10px"> Right Column Pinning toggle</igx-switch>
+        </div>
+        <input igxButton="raised" type="button" (click)="treegrid.pinRow(0)" value="Pin 0"/>
         <div class="sample-column">
             <div>igxTreeGrid</div>
-            <igx-tree-grid #grid1 [allowFiltering]='true' [data]="treeData" primaryKey="employeeID" foreignKey="PID" [rowSelectable]="true"
+            <igx-tree-grid [pinning]="pinningConfig" #treegrid [allowFiltering]='true' [data]="treeData" primaryKey="employeeID" foreignKey="PID" [rowSelectable]="true"
             [paging]="true" [width]="'900px'" [height]="'800px'" [showToolbar]="true"
             [columnHiding]="true" [columnPinning]="true" [exportExcel]="true" [exportCsv]="true" exportText="Export"
            >

--- a/src/app/grid-row-pinning/grid-row-pinning.sample.html
+++ b/src/app/grid-row-pinning/grid-row-pinning.sample.html
@@ -4,7 +4,7 @@
     </app-page-header>
     <button (click)="grid1.addRow({'ID': 'TEST', 'CompanyName': 'Test'})">Add Row</button>
     <button (click)="exportButtonHandler()">Export</button>
-        <div class="sample-column">
+        <!-- <div class="sample-column">
             <div>igxGrid</div>
             <div>
                 <input igxButton="raised" type="button" name="Density" (click)="toggleDensity()" value="Density"/>
@@ -77,7 +77,7 @@
                 </igx-row-island>
                 <igx-row-island [key]="'childData2'" [autoGenerate]="true" [allowFiltering]='true'></igx-row-island>
             </igx-hierarchical-grid>
-        </div>
+        </div> -->
 
         <div class="sample-column">
             <div>igxTreeGrid</div>


### PR DESCRIPTION
Changes include:
- Re-using base grid pinning pipe for tree grid.
    - Base grid pinning pipe is now imported in Grid Common module.
    - Removed redundant TreeGrid pinning pipes.
- Fix pipe order
- Add a simple pipe that maps the original record to ITreeGridRecord, which is the format the tree grid uses.
- Unify way data context is passed to tree grid row object.

Main difference between base grid and tree grid is that tree grid operates on a special data record type (ITreeGridRecord) hence one additional pipe is added for pinned area that maps the original record to the ITreeGridRecord so that all grid rows can operate on the same data object formats.