### PR TITLE
IgxCombo - ensure items trigger change detection when clicked

### DIFF
--- a/projects/igniteui-angular/src/lib/combo/combo-item.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo-item.component.ts
@@ -92,6 +92,7 @@ export class IgxComboItemComponent extends IgxDropDownItemComponent implements D
         if (!this.isSelectable) { return; }
         this.dropDown.navigateItem(this.index);
         this.comboAPI.set_selected_item(this.itemID, event);
+        this.comboAPI.triggerCheck();
     }
 
     /**

--- a/projects/igniteui-angular/src/lib/combo/combo.api.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.api.ts
@@ -10,6 +10,10 @@ export class IgxComboAPIService {
 
     public disableTransitions = false;
 
+    public triggerCheck() {
+        this.combo.triggerCheck();
+    }
+
     public register(combo: IgxComboBase) {
         this.combo = combo;
     }


### PR DESCRIPTION
Closes #7184  

Items being clicked did not properly trigger change detection when the virtualized container was scrolled.

Ensure that the combo's CDR is called when the item is clicked.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 