### PR TITLE
chore(*): Mark pinned records in meta data in order to distinguish th…

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -926,7 +926,7 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy {
      */
     public get searchMetadata() {
         const meta = new Map<string, any>();
-        meta.set('dataIndex', this.row.viewIndex);
+        meta.set('pinned', this.grid.isRecordPinnedByIndex(this.row.viewIndex));
         return meta;
     }
 }

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -4346,7 +4346,7 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
                     if (match.column === activeInfo.column &&
                         match.row === activeInfo.row &&
                         match.index === activeInfo.index &&
-                        this.compareMetadata(match, activeInfo)) {
+                        this.compareMetadata(match.metadata, activeInfo)) {
                         this.lastSearchInfo.activeMatchIndex = i;
                     }
                 });
@@ -6015,7 +6015,7 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
                     if (exactMatch) {
                         if (searchValue === searchText) {
                             const metadata = new Map<string, any>();
-                            metadata.set('dataIndex', viewIndex);
+                            metadata.set('pinned', this.isRecordPinnedByIndex(viewIndex));
                             this.lastSearchInfo.matchInfoCache.push({
                                 row: dataRow,
                                 column: c.field,
@@ -6029,7 +6029,7 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
 
                         while (searchIndex !== -1) {
                             const metadata = new Map<string, any>();
-                            metadata.set('dataIndex', viewIndex);
+                            metadata.set('pinned', this.isRecordPinnedByIndex(viewIndex));
                             this.lastSearchInfo.matchInfoCache.push({
                                 row: dataRow,
                                 column: c.field,


### PR DESCRIPTION
…em from their ghosts. Using dataIndex requires to update the cached by search activeMatch index on data operations like filtering/sorting etc., where it is hard to determine the new target index and whether the match used to be a pinned or ghost record.
