### PR TITLE
Add placeholder to igxDateRangePicker

### DIFF
--- a/projects/igniteui-angular/src/lib/date-range-picker/README.md
+++ b/projects/igniteui-angular/src/lib/date-range-picker/README.md
@@ -108,14 +108,15 @@ With projected inputs:
 ### Inputs
 | Name             | Type               | Description |
 |:-----------------|:-------------------|:------------|
+| doneButtonText   | string             | Changes the default text of the `done` button. It will show up only in `dialog` mode. Default value is `Done`. |
+| formatter        | function => string | Applies a custom formatter function on the selected or passed date. |
+| hideOutsideDays  | boolean            | Sets whether dates that are not part of the current month will be displayed. Default value is `false`. |
+| locale           | string             | Gets the `locale` of the calendar. Default value is `"en"`. |
+| overlaySettings  | OverlaySettings    | Changes the default overlay settings used by the `IgxDateRangePickerComponent`. | 
 | mode             | InteractionMode    | Sets whether `IgxDateRangePickerComponent` is in dialog or dropdown mode. Default is `dialog` |
 | monthsViewNumber | number             | Sets the number displayed month views. Default is `2`. |
-| hideOutsideDays  | boolean            | Sets whether dates that are not part of the current month will be displayed. Default value is `false`. |
+| placeholder      | string             | Sets the `placeholder` for single-input `IgxDateRangePickerComponent`. |
 | weekStart        | number             | Sets the start day of the week. Can be assigned to a numeric value or to `WEEKDAYS` enum value. |
-| locale           | string             | Gets the `locale` of the calendar. Default value is `"en"`. |
-| formatter        | function => string | Applies a custom formatter function on the selected or passed date. |
-| doneButtonText   | string             | Changes the default text of the `done` button. It will show up only in `dialog` mode. Default value is `Done`. |
-| overlaySettings  | OverlaySettings    | Changes the default overlay settings used by the `IgxDateRangePickerComponent`. | 
 
 ### Outputs
 | Name             | Type                  | Description |

--- a/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.spec.ts
@@ -261,7 +261,16 @@ describe('IgxDateRangePicker', () => {
                 });
             });
 
-            describe('Properties & events tests', () => {
+            fdescribe('Properties & events tests', () => {
+                it('should show date picker with placeholder', () => {
+                    fixture.detectChanges();
+                    expect(singleInputElement.nativeElement.placeholder).toEqual('MM/dd/yyyy - MM/dd/yyyy');
+
+                    const placeholder = 'Some placeholder';
+                    fixture.componentInstance.dateRange.placeholder = placeholder;
+                    fixture.detectChanges();
+                    expect(singleInputElement.nativeElement.placeholder).toEqual(placeholder);
+                });
                 it('should close the calendar with the "Done" button', fakeAsync(() => {
                     fixture.componentInstance.mode = InteractionMode.Dialog;
                     fixture.detectChanges();
@@ -809,4 +818,7 @@ export class DateRangeDefaultCustomLabelComponent extends DateRangeTestComponent
     </igx-date-range-picker>
     `
 })
-export class DateRangeDefaultComponent extends DateRangeTestComponent { }
+export class DateRangeDefaultComponent extends DateRangeTestComponent {
+    @ViewChild(IgxDateRangePickerComponent)
+    public dateRange: IgxDateRangePickerComponent;
+ }

--- a/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.spec.ts
@@ -261,7 +261,7 @@ describe('IgxDateRangePicker', () => {
                 });
             });
 
-            fdescribe('Properties & events tests', () => {
+            describe('Properties & events tests', () => {
                 it('should show date picker with placeholder', () => {
                     fixture.detectChanges();
                     expect(singleInputElement.nativeElement.placeholder).toEqual('MM/dd/yyyy - MM/dd/yyyy');

--- a/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.ts
+++ b/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.ts
@@ -271,6 +271,16 @@ export class IgxDateRangePickerComponent extends DisplayDensityBase
     public disabled: boolean;
 
     /**
+     * Sets the `placeholder` for single-input `IgxDateRangePickerComponent`.
+     *   @example
+     * ```html
+     * <igx-date-range-picker [placeholder]="'Choose your dates'"></igx-date-range-picker>
+     * ```
+     */
+    @Input()
+    public placeholder = '';
+
+    /**
      * Emitted when a range is selected.
      *
      * @example
@@ -369,6 +379,9 @@ export class IgxDateRangePickerComponent extends DisplayDensityBase
             return this.formatter(this.value);
         }
         if (!this.hasProjectedInputs) {
+            if (this.placeholder !== '') {
+                return this.placeholder;
+            }
             // TODO: use displayFormat - see how shortDate, longDate can be defined
             return this.inputFormat
                 ? `${this.inputFormat} - ${this.inputFormat}`


### PR DESCRIPTION
A new @Input `placeholder` is added to `IgxDateRangePicker`. This input allows developer to set `placeholder` for the component when it is in its default read-only single input mode.

Closes #7272

### Additional information (check all that apply):
 - [ ] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [x] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [x] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 