### PR TITLE
Pager: Total pages issue "0 of n" on remote paging

### DIFF
--- a/projects/igniteui-angular/src/lib/paginator/paginator.component.ts
+++ b/projects/igniteui-angular/src/lib/paginator/paginator.component.ts
@@ -83,8 +83,8 @@ export class IgxPaginatorComponent extends DisplayDensityBase {
         this.perPageChange.emit(this._perPage);
         this._selectOptions = this.sortUniqueOptions(this.defaultSelectValues, this._perPage);
         this.totalPages = Math.ceil(this.totalRecords / this._perPage);
-        if (this._page >= this.totalPages) {
-            this._page = this.totalPages - 1;
+        if (this.totalPages !== 0 && this.page >= this.totalPages) {
+            this.page = this.totalPages - 1;
         }
     }
 

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -248,6 +248,11 @@ export class AppComponent implements OnInit {
             name: 'Grid Remote Virtualization'
         },
         {
+            link: '/gridRemotePaging',
+            icon: 'view_column',
+            name: 'Grid Remote Paging'
+        },
+        {
             link: '/gridRowEdit',
             icon: 'view_column',
             name: 'Grid Row Editing'

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -71,6 +71,7 @@ import { GridColumnPinningSampleComponent } from './grid-column-pinning/grid-col
 import { GridColumnResizingSampleComponent } from './grid-column-resizing/grid-column-resizing.sample';
 import { GridSummaryComponent } from './grid-summaries/grid-summaries.sample';
 import { GridPerformanceSampleComponent } from './grid-performance/grid-performance.sample';
+import { GridRemotePagingSampleComponent } from './grid-remote-paging/grid-remote-paging.sample';
 import { GridSelectionComponent } from './grid-selection/grid-selection.sample';
 import { GridRowDraggableComponent } from './grid-row-draggable/grid-row-draggable.sample';
 import { GridToolbarSampleComponent } from './grid-toolbar/grid-toolbar.sample';
@@ -238,7 +239,8 @@ const components = [
     GridSaveStateComponent,
     AboutComponent,
     ReactiveFormSampleComponent,
-    DateRangeSampleComponent
+    DateRangeSampleComponent,
+    GridRemotePagingSampleComponent
 ];
 
 @NgModule({

--- a/src/app/app.routing.ts
+++ b/src/app/app.routing.ts
@@ -44,6 +44,7 @@ import { GridColumnPinningSampleComponent } from './grid-column-pinning/grid-col
 import { GridColumnResizingSampleComponent } from './grid-column-resizing/grid-column-resizing.sample';
 import { GridSummaryComponent } from './grid-summaries/grid-summaries.sample';
 import { GridPerformanceSampleComponent } from './grid-performance/grid-performance.sample';
+import { GridRemotePagingSampleComponent } from './grid-remote-paging/grid-remote-paging.sample';
 import { GridSelectionComponent } from './grid-selection/grid-selection.sample';
 import { GridRowDraggableComponent } from './grid-row-draggable/grid-row-draggable.sample';
 import { GridVirtualizationSampleComponent } from './grid-remote-virtualization/grid-remote-virtualization.sample';
@@ -275,6 +276,10 @@ const appRoutes = [
     {
         path: 'gridPerformance',
         component: GridPerformanceSampleComponent
+    },
+    {
+        path: 'gridRemotePaging',
+        component: GridRemotePagingSampleComponent
     },
     {
         path: 'gridSelection',

--- a/src/app/grid-remote-paging/grid-remote-paging.sample.html
+++ b/src/app/grid-remote-paging/grid-remote-paging.sample.html
@@ -10,11 +10,13 @@
     <ng-template #customPager let-api>
         <igx-paginator #paginator
             [totalRecords]="totalCount"
+            [(page)]="page"
             [(perPage)]="perPage"
             [selectLabel]="'Records per page:'"
             [selectOptions]="selectOptions"
             [displayDensity]="grid1.displayDensity"
-            (pageChange)="paginate($event)">
+            (pageChange)="paginate($event)"
+            (perPageChange)="perPageChange($event)">
         </igx-paginator>
     </ng-template>
 </div>

--- a/src/app/grid-remote-paging/grid-remote-paging.sample.html
+++ b/src/app/grid-remote-paging/grid-remote-paging.sample.html
@@ -1,0 +1,20 @@
+<div class="sample-wrapper dark-grid">
+    <igx-grid igxPreventDocumentScroll #grid1 [data]="data | async" width="100%" height="540px" [paging]="true" [perPage]="perPage" [paginationTemplate]="customPager">
+        <igx-column field="ID"></igx-column>
+        <igx-column field="ProductName"></igx-column>
+        <igx-column field="QuantityPerUnit"></igx-column>
+        <igx-column field="SupplierName"></igx-column>
+        <igx-column field="UnitsInStock"></igx-column>
+        <igx-column field="Rating"></igx-column>
+    </igx-grid>
+    <ng-template #customPager let-api>
+        <igx-paginator #paginator
+            [totalRecords]="totalCount"
+            [(perPage)]="perPage"
+            [selectLabel]="'Records per page:'"
+            [selectOptions]="selectOptions"
+            [displayDensity]="grid1.displayDensity"
+            (pageChange)="paginate($event)">
+        </igx-paginator>
+    </ng-template>
+</div>

--- a/src/app/grid-remote-paging/grid-remote-paging.sample.ts
+++ b/src/app/grid-remote-paging/grid-remote-paging.sample.ts
@@ -1,0 +1,63 @@
+import { AfterViewInit, Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { IgxGridComponent } from 'igniteui-angular';
+import { RemoteService } from '../shared/remote.service';
+import { Observable } from 'rxjs';
+
+@Component({
+    selector: 'app-grid-remote-paging-sample',
+    templateUrl: 'grid-remote-paging.sample.html'
+})
+export class GridRemotePagingSampleComponent implements OnInit, AfterViewInit, OnDestroy {
+
+    public page = 0;
+    public totalCount = 0;
+    public pages = [];
+    public data: Observable<any[]>;
+    public selectOptions = [5, 10, 15, 25, 50];
+
+    @ViewChild('customPager', { read: TemplateRef, static: true }) public remotePager: TemplateRef<any>;
+    @ViewChild('grid1', { static: true }) public grid1: IgxGridComponent;
+
+    private _perPage = 10;
+    private _dataLengthSubscriber;
+
+    constructor(private remoteService: RemoteService) {
+    }
+
+    public get perPage(): number {
+        return this._perPage;
+    }
+
+    public set perPage(val: number) {
+        this._perPage = val;
+        this.paginate(0);
+    }
+
+    public ngOnInit() {
+        this.data = this.remoteService.remotePagingData.asObservable();
+
+        this._dataLengthSubscriber = this.remoteService.getPagingDataLength().subscribe((data) => {
+            this.totalCount = data;
+            this.grid1.isLoading = false;
+        });
+    }
+
+    public ngOnDestroy() {
+        if (this._dataLengthSubscriber) {
+            this._dataLengthSubscriber.unsubscribe();
+        }
+    }
+
+    public ngAfterViewInit() {
+        this.grid1.isLoading = true;
+        this.remoteService.getPagingData(0, this.perPage);
+    }
+
+    public paginate(page: number) {
+        this.page = page;
+        const skip = this.page * this.perPage;
+        const top = this.perPage;
+
+        this.remoteService.getPagingData(skip, top);
+    }
+}

--- a/src/app/grid-remote-paging/grid-remote-paging.sample.ts
+++ b/src/app/grid-remote-paging/grid-remote-paging.sample.ts
@@ -1,8 +1,7 @@
 import { AfterViewInit, Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
-import { IgxGridComponent, IgxPaginatorComponent } from 'igniteui-angular';
+import { IgxGridComponent } from 'igniteui-angular';
 import { RemoteService } from '../shared/remote.service';
 import { Observable } from 'rxjs';
-import { IgxGridPaginatorOptionsPipe } from 'projects/igniteui-angular/src/lib/grids/common/pipes';
 
 @Component({
     selector: 'app-grid-remote-paging-sample',
@@ -63,7 +62,6 @@ export class GridRemotePagingSampleComponent implements OnInit, AfterViewInit, O
     }
 
     public perPageChange(perPage: number) {
-        debugger;
         const skip = this.page * perPage;
         const top = perPage;
 

--- a/src/app/grid-remote-paging/grid-remote-paging.sample.ts
+++ b/src/app/grid-remote-paging/grid-remote-paging.sample.ts
@@ -1,7 +1,8 @@
 import { AfterViewInit, Component, OnDestroy, OnInit, TemplateRef, ViewChild } from '@angular/core';
-import { IgxGridComponent } from 'igniteui-angular';
+import { IgxGridComponent, IgxPaginatorComponent } from 'igniteui-angular';
 import { RemoteService } from '../shared/remote.service';
 import { Observable } from 'rxjs';
+import { IgxGridPaginatorOptionsPipe } from 'projects/igniteui-angular/src/lib/grids/common/pipes';
 
 @Component({
     selector: 'app-grid-remote-paging-sample',
@@ -30,7 +31,7 @@ export class GridRemotePagingSampleComponent implements OnInit, AfterViewInit, O
 
     public set perPage(val: number) {
         this._perPage = val;
-        this.paginate(0);
+        // this.paginate(0);
     }
 
     public ngOnInit() {
@@ -57,6 +58,14 @@ export class GridRemotePagingSampleComponent implements OnInit, AfterViewInit, O
         this.page = page;
         const skip = this.page * this.perPage;
         const top = this.perPage;
+
+        this.remoteService.getPagingData(skip, top);
+    }
+
+    public perPageChange(perPage: number) {
+        debugger;
+        const skip = this.page * perPage;
+        const top = perPage;
 
         this.remoteService.getPagingData(skip, top);
     }

--- a/src/app/routing.ts
+++ b/src/app/routing.ts
@@ -54,6 +54,7 @@ import { GridColumnResizingSampleComponent } from './grid-column-resizing/grid-c
 import { GridGroupBySampleComponent } from './grid-groupby/grid-groupby.sample';
 import { GridSummaryComponent } from './grid-summaries/grid-summaries.sample';
 import { GridPerformanceSampleComponent } from './grid-performance/grid-performance.sample';
+import { GridRemotePagingSampleComponent } from './grid-remote-paging/grid-remote-paging.sample';
 import { GridSelectionComponent } from './grid-selection/grid-selection.sample';
 import { GridRowDraggableComponent } from './grid-row-draggable/grid-row-draggable.sample';
 import { GridToolbarSampleComponent } from './grid-toolbar/grid-toolbar.sample';
@@ -364,6 +365,10 @@ const appRoutes = [
     {
         path: 'gridRowPinning',
         component: GridRowPinningSampleComponent
+    },
+    {
+        path: 'gridRemotePaging',
+        component: GridRemotePagingSampleComponent
     },
     {
         path: 'gridColumnResizing',

--- a/src/app/shared/remote.service.ts
+++ b/src/app/shared/remote.service.ts
@@ -6,6 +6,8 @@ import { HttpClient } from '@angular/common/http';
 @Injectable()
 export class RemoteService {
 
+    public remotePagingData: BehaviorSubject<any[]>;
+    public urlPaging = 'https://www.igniteui.com/api/products';
     totalCount: Observable<number>;
     _totalCount: BehaviorSubject<number>;
     remoteData: Observable<any[]>;
@@ -18,6 +20,7 @@ export class RemoteService {
         this.remoteData = this._remoteData.asObservable();
         this._totalCount = new BehaviorSubject(null);
         this.totalCount = this._totalCount.asObservable();
+        this.remotePagingData = new BehaviorSubject([]);
     }
 
     nullData() {
@@ -44,5 +47,29 @@ export class RemoteService {
 
     buildUrl(dataState: any) {
         return this.urlBuilder(dataState);
+    }
+
+    // Remote paging
+    public getPagingData(index?: number, perPage?: number): any {
+        let qS = '';
+
+        if (perPage) {
+            qS = `?$skip=${index}&$top=${perPage}&$count=true`;
+        }
+
+        this.http
+            .get(`${this.urlPaging + qS}`).pipe(
+                map((data: any) => {
+                    return data;
+                })
+            ).subscribe((data) => this.remotePagingData.next(data));
+    }
+
+    public getPagingDataLength(): any {
+        return this.http.get(this.urlPaging).pipe(
+            map((data: any) => {
+                return data.length;
+            })
+        );
     }
 }


### PR DESCRIPTION
Closes #7247
Related to #6861

This change contains a fix for showing "0 of n" pages when `totalPages` value is 0. This happens when the remote data is not present in the grid.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [x] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 