### PR TITLE
Show correctly calendar in flex container

### DIFF
--- a/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.html
+++ b/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.html
@@ -1,9 +1,10 @@
 <div #toggle="toggle" igxToggle class="igx-date-picker" [class.igx-date-picker--dropdown]="mode === 'dropdown'"
     (onOpening)="handleOpening($event)" (onOpened)="handleOpened()"
     (onClosing)="handleClosing($event)" (onClosed)="handleClosed()"
+    [style.flex-basis]="monthsViewNumber * 320 + 'px'"
     [style.width]="monthsViewNumber * 320 + 'px'"
     [style.max-width]="'90vw'"
-    >
+>
     <!-- TODO: use IgxCalendarContainerComponent instead -->
     <igx-calendar #calendar (keydown)="onKeyDown($event)" selection="range" [weekStart]="weekStart"
         [hideOutsideDays]="hideOutsideDays" [monthsViewNumber]="monthsViewNumber" [locale]="locale"
@@ -48,7 +49,7 @@
             [attr.aria-expanded]="!toggle.collapsed"
             [attr.aria-labelledby]="this.label?.id"
             [value]="this.value | dateRange: this.inputFormat : this.locale"
-            />
+        />
 
         <igx-prefix *ngIf="!this.toggleComponents.length">
             <ng-container *ngTemplateOutlet="defIcon"></ng-container>


### PR DESCRIPTION
When in flex container the `toggle`, where the calendar is put, gets shrunk. As a result when overlay measures its with it is not correct. To fix this `flex-basis` is added to inline style of the `toggle`.

No test for this as this depends on the screen size and we are planning to move from `toggle` to `igxOverlay` service as soon as possible - when done the issue will gone.

Closes #7354 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 