### PR TITLE
fix(date-range): allow mix and min value as string #7352

### DIFF
--- a/projects/igniteui-angular/src/lib/date-picker/date-picker.utils.ts
+++ b/projects/igniteui-angular/src/lib/date-picker/date-picker.utils.ts
@@ -252,6 +252,10 @@ export abstract class DatePickerUtil {
      * @returns true if provided value is greater than provided maxValue
      */
     public static greaterThanMaxValue(value: Date, maxValue: Date, includeTime = true, includeDate = true): boolean {
+        // TODO: check if provided dates are valid dates and not Invalid Date
+        // if maxValue is Invalid Date and value is valid date this will return:
+        // - false if includeDate is true
+        // - true if includeDate is false
         if (includeTime && includeDate) {
             return value.getTime() > maxValue.getTime();
         }
@@ -277,6 +281,10 @@ export abstract class DatePickerUtil {
      * @returns true if provided value is less than provided minValue
      */
     public static lessThanMinValue(value: Date, minValue: Date, includeTime = true, includeDate = true): boolean {
+        // TODO: check if provided dates are valid dates and not Invalid Date
+        // if value is Invalid Date and minValue is valid date this will return:
+        // - false if includeDate is true
+        // - true if includeDate is false
         if (includeTime && includeDate) {
             return value.getTime() < minValue.getTime();
         }
@@ -634,6 +642,46 @@ export abstract class DatePickerUtil {
 
     public static daysInMonth(fullYear: number, month: number): number {
         return new Date(fullYear, month + 1, 0).getDate();
+    }
+
+    /**
+     * Parse provided input to Date.
+     * @param value input to parse
+     * @returns Date if parse succeed or null
+     */
+    public static parseDate(value: any): Date | null {
+        if (typeof value === 'number') {
+            return new Date(value);
+        }
+
+        // if value is Invalid Date we should return null
+        if (this.isDate(value)) {
+            return this.isValidDate(value) ? value : null;
+        }
+
+        return value ? new Date(Date.parse(value)) : null;
+    }
+
+    /**
+     * Returns whether provided input is date
+     * @param value input to check
+     * @returns true if provided input is date
+     */
+    public static isDate(value: any): boolean {
+        return Object.prototype.toString.call(value) === '[object Date]';
+    }
+
+    /**
+     * Returns whether the input is valid date
+     * @param value input to check
+     * @returns true if provided input is a valid date
+     */
+    public static isValidDate(value: any): boolean {
+        if (this.isDate(value)) {
+            return !isNaN(value.getTime());
+        }
+
+        return false;
     }
 
     private static getYearFormatType(format: string): string {

--- a/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.spec.ts
@@ -142,7 +142,7 @@ describe('IgxDateRangePicker', () => {
             dateRange.close();
             fixture.detectChanges();
         }
-        fdescribe('Single Input', () => {
+        describe('Single Input', () => {
             let singleInputElement: DebugElement;
             configureTestSuite();
             beforeAll(async(() => {

--- a/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.spec.ts
@@ -12,6 +12,7 @@ import { UIInteractions } from '../test-utils/ui-interactions.spec';
 import { configureTestSuite } from '../test-utils/configure-suite';
 import { HelperTestFunctions } from '../calendar/calendar-helper-utils';
 import { IgxDateTimeEditorModule } from '../directives/date-time-editor';
+import { DateRangeType } from '../core/dates';
 
 // The number of milliseconds in one day
 const ONE_DAY = 1000 * 60 * 60 * 24;
@@ -141,7 +142,7 @@ describe('IgxDateRangePicker', () => {
             dateRange.close();
             fixture.detectChanges();
         }
-        describe('Single Input', () => {
+        fdescribe('Single Input', () => {
             let singleInputElement: DebugElement;
             configureTestSuite();
             beforeAll(async(() => {
@@ -248,6 +249,7 @@ describe('IgxDateRangePicker', () => {
                     fixture.detectChanges();
                     expect(singleInputElement.nativeElement.placeholder).toEqual(placeholder);
                 });
+
                 it('should close the calendar with the "Done" button', fakeAsync(() => {
                     fixture.componentInstance.mode = InteractionMode.Dialog;
                     fixture.detectChanges();
@@ -325,6 +327,46 @@ describe('IgxDateRangePicker', () => {
                     dateRange.toggle();
                     fixture.detectChanges();
                 });
+
+                it('should disable calendar dates when min and/or max values as dates are provided', fakeAsync(() => {
+                    // TODO: move this to unit tests
+                    const minDate = new Date(2000, 10, 1);
+                    const maxDate = new Date(2000, 10, 20);
+                    fixture.componentInstance.minValue = minDate;
+                    fixture.componentInstance.maxValue = maxDate;
+                    fixture.detectChanges();
+
+                    dateRange.open();
+                    tick();
+                    fixture.detectChanges();
+
+                    const calendarComponent: IgxCalendarComponent = calendar.componentInstance;
+                    expect(calendarComponent.disabledDates.length).toEqual(2);
+                    expect(calendarComponent.disabledDates[0].type).toEqual(DateRangeType.Before);
+                    expect(calendarComponent.disabledDates[0].dateRange[0]).toEqual(minDate);
+                    expect(calendarComponent.disabledDates[1].type).toEqual(DateRangeType.After);
+                    expect(calendarComponent.disabledDates[1].dateRange[0]).toEqual(maxDate);
+                }));
+
+                it('should disable calendar dates when min and/or max values as strings are provided', fakeAsync(() => {
+                    // TODO: move this to unit tests
+                    const minDate = '2000/10/1';
+                    const maxDate = '2000/10/30';
+                    fixture.componentInstance.minValue = minDate;
+                    fixture.componentInstance.maxValue = maxDate;
+                    fixture.detectChanges();
+
+                    dateRange.open();
+                    tick();
+                    fixture.detectChanges();
+
+                    const calendarComponent: IgxCalendarComponent = calendar.componentInstance;
+                    expect(calendarComponent.disabledDates.length).toEqual(2);
+                    expect(calendarComponent.disabledDates[0].type).toEqual(DateRangeType.Before);
+                    expect(calendarComponent.disabledDates[0].dateRange[0]).toEqual(new Date(minDate));
+                    expect(calendarComponent.disabledDates[1].type).toEqual(DateRangeType.After);
+                    expect(calendarComponent.disabledDates[1].dateRange[0]).toEqual(new Date(maxDate));
+                }));
 
                 it('should emit open/close events - open/close methods', fakeAsync(() => {
                     spyOn(dateRange.onOpening, 'emit').and.callThrough();
@@ -701,9 +743,9 @@ describe('IgxDateRangePicker', () => {
 
             }));
             it('should render aria attributes properly', fakeAsync(() => {
-                toggleBtn = fixture.debugElement.query(By.css(`.${ CSS_CLASS_TOGGLE_BUTTON}`));
-                calendarElement = fixture.debugElement.query(By.css(`.${ CSS_CLASS_CALENDAR}`));
-                singleInputElement = fixture.debugElement.query(By.css(`.${ CSS_CLASS_INPUT}`));
+                toggleBtn = fixture.debugElement.query(By.css(`.${CSS_CLASS_TOGGLE_BUTTON}`));
+                calendarElement = fixture.debugElement.query(By.css(`.${CSS_CLASS_CALENDAR}`));
+                singleInputElement = fixture.debugElement.query(By.css(`.${CSS_CLASS_INPUT}`));
                 startDate = new Date(2020, 1, 1);
                 endDate = new Date(2020, 1, 4);
                 const expectedLabelID = dateRange.label.id;
@@ -748,6 +790,8 @@ export class DateRangeTestComponent implements OnInit {
     public todayButtonText: string;
     public doneButtonText: string;
     public mode: InteractionMode;
+    public minValue: Date | String;
+    public maxValue: Date | String;
 
     @ViewChild(IgxDateRangePickerComponent, { read: IgxDateRangePickerComponent, static: true })
     public dateRange: IgxDateRangePickerComponent;
@@ -791,11 +835,11 @@ export class DateRangeDefaultCustomLabelComponent extends DateRangeTestComponent
 @Component({
     selector: 'igx-date-range-single-input-test',
     template: `
-    <igx-date-range-picker [mode]="mode">
+    <igx-date-range-picker [mode]="mode" [minValue]="minValue" [maxValue]="maxValue">
     </igx-date-range-picker>
     `
 })
 export class DateRangeDefaultComponent extends DateRangeTestComponent {
     @ViewChild(IgxDateRangePickerComponent)
     public dateRange: IgxDateRangePickerComponent;
- }
+}

--- a/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.ts
+++ b/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.ts
@@ -568,23 +568,29 @@ export class IgxDateRangePickerComponent extends DisplayDensityBase
     }
 
     /** @hidden @internal */
-    public validate(control: AbstractControl): ValidationErrors {
+    public validate(control: AbstractControl): ValidationErrors | null {
         const value: DateRange = control.value;
-        if (this.minValue && value && value.start && DatePickerUtil.lessThanMinValue(value.start, new Date(this.minValue), false)) {
-            return { 'minValue': true };
-        }
-        if (this.minValue && value && value.end && DatePickerUtil.lessThanMinValue(value.end, new Date(this.minValue), false)) {
-            return { 'minValue': true };
-        }
-        if (this.maxValue && value && value.start && DatePickerUtil.greaterThanMaxValue(value.start, new Date(this.maxValue), false)) {
-            return { 'maxValue': true };
-        }
-        if (this.maxValue && value && value.end && DatePickerUtil.greaterThanMaxValue(value.end, new Date(this.maxValue), false)) {
-            return { 'maxValue': true };
+        if (value) {
+            const min = DatePickerUtil.parseDate(this.minValue);
+            const max = DatePickerUtil.parseDate(this.maxValue);
+            const start = DatePickerUtil.parseDate(value.start);
+            const end = DatePickerUtil.parseDate(value.end);
+
+            if (min && start && DatePickerUtil.lessThanMinValue(start, min, false)) {
+                return { 'minValue': true };
+            }
+            if (min && end && DatePickerUtil.lessThanMinValue(end, min, false)) {
+                return { 'minValue': true };
+            }
+            if (max && start && DatePickerUtil.greaterThanMaxValue(start, max, false)) {
+                return { 'maxValue': true };
+            }
+            if (max && end && DatePickerUtil.greaterThanMaxValue(end, max, false)) {
+                return { 'maxValue': true };
+            }
         }
 
-        // TODO: fix what happens on blur and ensure there value is either null or with both start and end filled
-
+        // TODO: fix what happens on blur and ensure on blur the value is either null or with both start and end filled
         return null;
     }
 
@@ -784,26 +790,26 @@ export class IgxDateRangePickerComponent extends DisplayDensityBase
 
     private updateCalendar(): void {
         this.calendar.disabledDates = [];
-        let minValue = this.minValue;
+        let minValue: Date = DatePickerUtil.parseDate(this.minValue);
         if (!minValue && this.hasProjectedInputs) {
             const start = this.projectedInputs.filter(i => i instanceof IgxDateRangeStartComponent)[0];
             if (start) {
-                minValue = start.dateTimeEditor.minValue;
+                minValue = DatePickerUtil.parseDate(start.dateTimeEditor.minValue);
             }
         }
         if (minValue) {
-            this.calendar.disabledDates.push({ type: DateRangeType.Before, dateRange: [new Date(minValue)] });
+            this.calendar.disabledDates.push({ type: DateRangeType.Before, dateRange: [minValue] });
         }
 
-        let maxValue = this.maxValue;
+        let maxValue: Date = DatePickerUtil.parseDate(this.maxValue);
         if (!maxValue && this.hasProjectedInputs) {
             const end = this.projectedInputs.filter(i => i instanceof IgxDateRangeEndComponent)[0];
             if (end) {
-                maxValue = end.dateTimeEditor.maxValue;
+                maxValue = DatePickerUtil.parseDate(end.dateTimeEditor.maxValue);
             }
         }
         if (maxValue) {
-            this.calendar.disabledDates.push({ type: DateRangeType.After, dateRange: [new Date(maxValue)] });
+            this.calendar.disabledDates.push({ type: DateRangeType.After, dateRange: [maxValue] });
         }
 
         const range: Date[] = [];

--- a/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.ts
+++ b/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.ts
@@ -236,12 +236,12 @@ export class IgxDateRangePickerComponent extends DisplayDensityBase
      * <igx-date-range-picker [minValue]="minDate"></igx-date-range-picker>
      */
     @Input()
-    public set minValue(value: Date) {
+    public set minValue(value: Date | string) {
         this._minValue = value;
         this.onValidatorChange();
     }
 
-    public get minValue(): Date {
+    public get minValue(): Date | string {
         return this._minValue;
     }
 
@@ -252,12 +252,12 @@ export class IgxDateRangePickerComponent extends DisplayDensityBase
      * <igx-date-range-picker [maxValue]="maxDate"></igx-date-range-picker>
      */
     @Input()
-    public set maxValue(value: Date) {
+    public set maxValue(value: Date | string) {
         this._maxValue = value;
         this.onValidatorChange();
     }
 
-    public get maxValue(): Date {
+    public get maxValue(): Date | string {
         return this._maxValue;
     }
 
@@ -419,8 +419,8 @@ export class IgxDateRangePickerComponent extends DisplayDensityBase
     private _ngControl: NgControl;
     private _statusChanges$: Subscription;
     private $destroy = new Subject();
-    private _minValue: Date;
-    private _maxValue: Date;
+    private _minValue: Date | string;
+    private _maxValue: Date | string;
     private $toggleClickNotifier = new Subject();
     private _positionSettings: PositionSettings;
     private _dialogOverlaySettings: OverlaySettings = {
@@ -570,16 +570,16 @@ export class IgxDateRangePickerComponent extends DisplayDensityBase
     /** @hidden @internal */
     public validate(control: AbstractControl): ValidationErrors {
         const value: DateRange = control.value;
-        if (this.minValue && value && value.start && DatePickerUtil.lessThanMinValue(value.start, this.minValue, false)) {
+        if (this.minValue && value && value.start && DatePickerUtil.lessThanMinValue(value.start, new Date(this.minValue), false)) {
             return { 'minValue': true };
         }
-        if (this.minValue && value && value.end && DatePickerUtil.lessThanMinValue(value.end, this.minValue, false)) {
+        if (this.minValue && value && value.end && DatePickerUtil.lessThanMinValue(value.end, new Date(this.minValue), false)) {
             return { 'minValue': true };
         }
-        if (this.maxValue && value && value.start && DatePickerUtil.greaterThanMaxValue(value.start, this.maxValue, false)) {
+        if (this.maxValue && value && value.start && DatePickerUtil.greaterThanMaxValue(value.start, new Date(this.maxValue), false)) {
             return { 'maxValue': true };
         }
-        if (this.maxValue && value && value.end && DatePickerUtil.greaterThanMaxValue(value.end, this.maxValue, false)) {
+        if (this.maxValue && value && value.end && DatePickerUtil.greaterThanMaxValue(value.end, new Date(this.maxValue), false)) {
             return { 'maxValue': true };
         }
 
@@ -784,30 +784,26 @@ export class IgxDateRangePickerComponent extends DisplayDensityBase
 
     private updateCalendar(): void {
         this.calendar.disabledDates = [];
-        // TODO: minValue and maxValue type to be Date | String as it is in dateTineEditorDirective
-        // TODO: move isDate and parseDate to utils
         let minValue = this.minValue;
         if (!minValue && this.hasProjectedInputs) {
             const start = this.projectedInputs.filter(i => i instanceof IgxDateRangeStartComponent)[0];
             if (start) {
-                const editor = start.dateTimeEditor;
-                minValue = editor.isDate(editor.minValue) ? editor.minValue : editor.parseDate(editor.minValue);
+                minValue = start.dateTimeEditor.minValue;
             }
         }
         if (minValue) {
-            this.calendar.disabledDates.push({ type: DateRangeType.Before, dateRange: [minValue] });
+            this.calendar.disabledDates.push({ type: DateRangeType.Before, dateRange: [new Date(minValue)] });
         }
 
         let maxValue = this.maxValue;
         if (!maxValue && this.hasProjectedInputs) {
             const end = this.projectedInputs.filter(i => i instanceof IgxDateRangeEndComponent)[0];
             if (end) {
-                const editor = end.dateTimeEditor;
-                maxValue = editor.isDate(editor.maxValue) ? editor.maxValue : editor.parseDate(editor.maxValue);
+                maxValue = end.dateTimeEditor.maxValue;
             }
         }
         if (maxValue) {
-            this.calendar.disabledDates.push({ type: DateRangeType.After, dateRange: [maxValue] });
+            this.calendar.disabledDates.push({ type: DateRangeType.After, dateRange: [new Date(maxValue)] });
         }
 
         const range: Date[] = [];
@@ -822,6 +818,7 @@ export class IgxDateRangePickerComponent extends DisplayDensityBase
 
         if (range.length > 0) {
             this.calendar.selectDate(range);
+            this.calendar.viewDate = range[0];
         } else {
             this.calendar.deselectDate();
         }

--- a/projects/igniteui-angular/src/lib/directives/date-time-editor/date-time-editor.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/date-time-editor/date-time-editor.directive.ts
@@ -421,8 +421,8 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
     return mask;
   }
 
-  /** @hidden @internal */
-  public isDate(value: any): value is Date {
+  // TODO: move isDate to utils
+  private isDate(value: any): value is Date {
     return value instanceof Date && typeof value === 'object';
   }
 
@@ -569,8 +569,8 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
     return date && date.getTime && !isNaN(date.getTime());
   }
 
-  /** @hidden @internal */
-  public parseDate(val: string): Date | null {
+    // TODO: move parseDate to utils
+    public parseDate(val: string): Date | null {
     if (!val) { return null; }
     return DatePickerUtil.parseValueFromMask(val, this._inputDateParts, this.promptChar);
   }

--- a/src/app/date-range/date-range.sample.html
+++ b/src/app/date-range/date-range.sample.html
@@ -18,7 +18,11 @@
                     </igx-date-range-picker>
 
                     <p>Drop down two inputs with prefix</p>
-                    <igx-date-range-picker [mode]="'dropdown'">
+                    <igx-date-range-picker [mode]="'dropdown'"
+                        [value]="range"
+                        [minValue]="'2000/10/1'"
+                        [maxValue]="'some invalid value'"
+                    >
                         <igx-date-range-start>
                             <input igxInput igxDateTimeEditor type="text">
                             <igx-picker-toggle igxPrefix>

--- a/src/app/date-range/date-range.sample.ts
+++ b/src/app/date-range/date-range.sample.ts
@@ -8,6 +8,7 @@ import { IgxDateRangePickerComponent, DateRange, IChangeRadioEventArgs } from 'i
     styleUrls: ['./date-range.sample.scss']
 })
 export class DateRangeSampleComponent {
+    public range: DateRange = { start: new Date('2000,10,1'), end: new Date('2000,10,20') };
     public range1: DateRange = { start: new Date(), end: new Date(new Date().setDate(new Date().getDate() + 5)) };
     public range2: DateRange;
     public range3: DateRange = { start: new Date(), end: new Date(new Date().setDate(new Date().getDate() + 5)) };


### PR DESCRIPTION
Allow setting of `minValue` and `maxValue` of `IgxDateRantePicker` as stirngs.

Closes #7352 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 