### PR TITLE
Calculate insertIndexes based on root level columns only.

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
@@ -1606,7 +1606,8 @@ export class IgxColumnComponent implements AfterContentInit {
             }
 
             if (grid._unpinnedColumns.indexOf(this) !== -1) {
-                grid._unpinnedColumns.splice(grid._unpinnedColumns.indexOf(this), 1);
+                const childrenCount = this.allChildren.length;
+                grid._unpinnedColumns.splice(grid._unpinnedColumns.indexOf(this), 1 + childrenCount);
             }
         }
 

--- a/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
@@ -1584,13 +1584,26 @@ export class IgxColumnComponent implements AfterContentInit {
         this._pinned = true;
         this.pinnedChange.emit(this._pinned);
         this._unpinnedIndex = grid._unpinnedColumns.indexOf(this);
-        index = index !== undefined ? index : grid._pinnedColumns.length;
+        const rootPinnedCols = grid._pinnedColumns.filter((c) => c.level === 0);
+        index = index !== undefined ? index : rootPinnedCols.length;
         const targetColumn = grid._pinnedColumns[index];
         const args = { column: this, insertAtIndex: index, isPinned: true };
         grid.onColumnPinning.emit(args);
 
         if (grid._pinnedColumns.indexOf(this) === -1) {
-            grid._pinnedColumns.splice(args.insertAtIndex, 0, this);
+            if (!grid.hasColumnGroups) {
+                grid._pinnedColumns.splice(args.insertAtIndex, 0, this);
+            } else {
+                // insert based only on root collection
+                rootPinnedCols.splice(args.insertAtIndex, 0, this);
+                let allPinned = [];
+                // re-create hierarchy
+                rootPinnedCols.forEach(group => {
+                    allPinned.push(group);
+                    allPinned = allPinned.concat(group.allChildren);
+                });
+                grid._pinnedColumns = allPinned;
+            }
 
             if (grid._unpinnedColumns.indexOf(this) !== -1) {
                 grid._unpinnedColumns.splice(grid._unpinnedColumns.indexOf(this), 1);

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -3765,19 +3765,19 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
     protected _reorderColumns(from: IgxColumnComponent, to: IgxColumnComponent, position: DropPosition, columnCollection: any[]) {
         let dropIndex = columnCollection.indexOf(to);
 
-        if (to.columnGroup) {
+        if (to.columnGroup && position === DropPosition.AfterDropTarget) {
             dropIndex += to.allChildren.length;
         }
 
-        if (position === DropPosition.BeforeDropTarget) {
+        if (position === DropPosition.BeforeDropTarget && dropIndex > 0) {
             dropIndex--;
         }
 
         if (position === DropPosition.AfterDropTarget) {
             dropIndex++;
         }
-
-        columnCollection.splice(dropIndex, 0, ...columnCollection.splice(columnCollection.indexOf(from), 1));
+        const childColumnsCount = from.allChildren.length;
+        columnCollection.splice(dropIndex, 0, ...columnCollection.splice(columnCollection.indexOf(from), childColumnsCount + 1));
     }
     /**
      * @hidden
@@ -5155,9 +5155,8 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
      * @hidden
      */
     protected reinitPinStates() {
-        this._pinnedColumns = (this.hasColumnGroups) ? this.columnList.filter((c) => c.pinned && !c.columnLayoutChild)
-        .sort((a, b) => this._pinnedColumns.indexOf(a) - this._pinnedColumns.indexOf(b)) :
-            this.columnList.filter((c) => c.pinned).sort((a, b) => this._pinnedColumns.indexOf(a) - this._pinnedColumns.indexOf(b));
+        this._pinnedColumns = this.columnList
+        .filter((c) => c.pinned).sort((a, b) => this._pinnedColumns.indexOf(a) - this._pinnedColumns.indexOf(b));
         this._unpinnedColumns = this.hasColumnGroups ? this.columnList.filter((c) => !c.pinned) :
             this.columnList.filter((c) => !c.pinned)
                 .sort((a, b) => this._unpinnedColumns.indexOf(a) - this._unpinnedColumns.indexOf(b));

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -3765,7 +3765,7 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
     protected _reorderColumns(from: IgxColumnComponent, to: IgxColumnComponent, position: DropPosition, columnCollection: any[]) {
         let dropIndex = columnCollection.indexOf(to);
 
-        if (to.columnGroup && position === DropPosition.AfterDropTarget) {
+        if (to.columnGroup && position !== DropPosition.BeforeDropTarget) {
             dropIndex += to.allChildren.length;
         }
 

--- a/projects/igniteui-angular/src/lib/grids/grid/column-group.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/column-group.spec.ts
@@ -779,7 +779,7 @@ describe('IgxGrid - multi-column headers #grid', () => {
         expect(grid.getCellByColumn(0, 'City').value).toEqual('Berlin');
     }));
 
-    fit('Should pin column groups using indexes correctly.', fakeAsync(() => {
+    it('Should pin column groups using indexes correctly.', fakeAsync(() => {
         const fixture = TestBed.createComponent(StegosaurusGridComponent);
         fixture.detectChanges();
 
@@ -799,7 +799,7 @@ describe('IgxGrid - multi-column headers #grid', () => {
         tick();
         fixture.detectChanges();
 
-        testColumnsVisibleIndexes([ci.idCol].concat(ci.genInfoColList)
+        testColumnsVisibleIndexes(ci.genInfoColList.concat(ci.idCol)
             .concat(ci.postalCodeColList).concat(ci.cityColList).concat(ci.countryColList)
             .concat(ci.regionColList).concat(ci.addressColList).concat(ci.phoneColList)
             .concat(ci.faxColList));
@@ -1075,7 +1075,7 @@ describe('IgxGrid - multi-column headers #grid', () => {
         testColumnsOrder(colsOrder);
     }));
 
-    fit('Should move columns and groups. Pinning enabled.', fakeAsync(() => {
+    it('Should move columns and groups. Pinning enabled.', fakeAsync(() => {
         const fixture = TestBed.createComponent(StegosaurusGridComponent);
         fixture.detectChanges();
         const ci = fixture.componentInstance;


### PR DESCRIPTION
 Add handling for moving column groups correctly.

Closes #  

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 