### PR TITLE
Should not correctly set undefined or null as input value - 8.2

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/input/input.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/input/input.directive.spec.ts
@@ -18,7 +18,7 @@ const INPUT_GROUP_REQUIRED_CSS_CLASS = 'igx-input-group--required';
 const INPUT_GROUP_VALID_CSS_CLASS = 'igx-input-group--valid';
 const INPUT_GROUP_INVALID_CSS_CLASS = 'igx-input-group--invalid';
 
-fdescribe('IgxInput', () => {
+describe('IgxInput', () => {
     configureTestSuite();
     beforeEach(async(() => {
         TestBed.configureTestingModule({

--- a/projects/igniteui-angular/src/lib/directives/input/input.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/input/input.directive.spec.ts
@@ -18,7 +18,7 @@ const INPUT_GROUP_REQUIRED_CSS_CLASS = 'igx-input-group--required';
 const INPUT_GROUP_VALID_CSS_CLASS = 'igx-input-group--valid';
 const INPUT_GROUP_INVALID_CSS_CLASS = 'igx-input-group--invalid';
 
-describe('IgxInput', () => {
+fdescribe('IgxInput', () => {
     configureTestSuite();
     beforeEach(async(() => {
         TestBed.configureTestingModule({
@@ -602,6 +602,29 @@ describe('IgxInput', () => {
         expect(input.valid).toBe(IgxInputState.INITIAL);
         expect(inputGroup.element.nativeElement.classList.contains(INPUT_GROUP_INVALID_CSS_CLASS)).toBe(false);
         expect(inputGroup.element.nativeElement.classList.contains(INPUT_GROUP_VALID_CSS_CLASS)).toBe(false);
+    });
+
+    it('should not set null or undefined as input value', () => {
+        const fixture = TestBed.createComponent(InputComponent);
+        fixture.detectChanges();
+
+        const igxInput = fixture.componentInstance.igxInput;
+        expect(igxInput.value).toBe('');
+
+        igxInput.value = undefined;
+        expect(igxInput.value).toBe('');
+
+        igxInput.value = null;
+        expect(igxInput.value).toBe('');
+
+        igxInput.value = 0;
+        expect(igxInput.value).toBe('0');
+
+        igxInput.value = false;
+        expect(igxInput.value).toBe('false');
+
+        igxInput.value = 'Test';
+        expect(igxInput.value).toBe('Test');
     });
 });
 

--- a/projects/igniteui-angular/src/lib/directives/input/input.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/input/input.directive.ts
@@ -52,7 +52,7 @@ export class IgxInputDirective implements AfterViewInit, OnDestroy {
      */
     @Input('value')
     set value(value: any) {
-        this.nativeElement.value = value;
+        this.nativeElement.value = value ?? '';
         this.checkValidity();
     }
     /**


### PR DESCRIPTION
If value of `IgxInput` is set to `null` or `undefined` we are setting the inner `input` value to empty string/

Closes #7441 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 