### PR TITLE
Mvenkov/extend grid edit event args 9.0

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/api.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/api.service.ts
@@ -164,7 +164,6 @@ export class GridBaseAPIService <T extends IgxGridBaseDirective & GridType> {
             (this.grid as any)._pipeTrigger++;
         }
 
-        // TODO
         this.grid.onCellEdit.emit(args);
         return args;
     }

--- a/projects/igniteui-angular/src/lib/grids/api.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/api.service.ts
@@ -139,11 +139,6 @@ export class GridBaseAPIService <T extends IgxGridBaseDirective & GridType> {
         const args = cell.createEditEventArgs();
         args.owner = this.grid;
 
-        this.grid.onCellEdit.emit(args);
-        if (args.cancel) {
-            return args;
-        }
-
         // Cast to number after emit
         // TODO: Clean up this
         args.newValue = cell.castToNumber(args.newValue);
@@ -169,6 +164,8 @@ export class GridBaseAPIService <T extends IgxGridBaseDirective & GridType> {
             (this.grid as any)._pipeTrigger++;
         }
 
+        // TODO
+        this.grid.onCellEdit.emit(args);
         return args;
     }
 

--- a/projects/igniteui-angular/src/lib/grids/api.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/api.service.ts
@@ -137,6 +137,7 @@ export class GridBaseAPIService <T extends IgxGridBaseDirective & GridType> {
         cell.editValue = value;
 
         const args = cell.createEditEventArgs();
+        args.owner = this.grid;
 
         this.grid.onCellEdit.emit(args);
         if (args.cancel) {
@@ -219,6 +220,7 @@ export class GridBaseAPIService <T extends IgxGridBaseDirective & GridType> {
         this._update_row(row, value);
 
         const args = row.createEditEventArgs();
+        args.owner = this.grid;
 
         // If no valid row is found
         if (index === -1) {

--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -1041,6 +1041,7 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy {
 
         if (this.editMode) {
             const args = this.crudService.cell.createEditEventArgs();
+            args.owner = this.grid;
             this.grid.onCellEditCancel.emit(args);
             if (args.cancel) {
                 return;

--- a/projects/igniteui-angular/src/lib/grids/common/events.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/events.ts
@@ -7,6 +7,7 @@ import { IgxGridCellComponent } from '../cell.component';
 import { IgxColumnComponent } from '../columns/column.component';
 import { IgxGridBaseDirective } from '../grid-base.directive';
 import { IgxRowDirective } from '../row.directive';
+import { ColumnType } from './column.interface';
 export { GridSelectionRange } from '../selection/selection.service';
 
 export interface IGridClipboardEvent {
@@ -29,7 +30,7 @@ export interface IGridEditEventArgs extends CancelableEventArgs, IBaseEventArgs 
     oldValue: any;
     newValue?: any;
     event?: Event;
-    columnField?: string;
+    column?: ColumnType;
 }
 
 export interface IPinColumnEventArgs extends IBaseEventArgs {

--- a/projects/igniteui-angular/src/lib/grids/common/events.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/events.ts
@@ -29,6 +29,7 @@ export interface IGridEditEventArgs extends CancelableEventArgs, IBaseEventArgs 
     oldValue: any;
     newValue?: any;
     event?: Event;
+    columnField?: string;
 }
 
 export interface IPinColumnEventArgs extends IBaseEventArgs {

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -5718,6 +5718,7 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
         row.newData = this.transactions.getAggregatedValue(row.id, true);
 
         let args = row.createEditEventArgs();
+        args.owner = this;
 
         if (!commit) {
             this.onRowEditCancel.emit(args);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-cell-editing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-cell-editing.spec.ts
@@ -557,7 +557,15 @@ describe('IgxGrid - Cell Editing #grid', () => {
             cell.nativeElement.dispatchEvent(new MouseEvent('dblclick'));
             fixture.detectChanges();
 
-            let cellArgs: IGridEditEventArgs = { cellID: cell.cellID, rowID: cell.row.rowID, oldValue: 'John Brown', cancel: false };
+            let cellArgs: IGridEditEventArgs = {
+                rowID: cell.row.rowID,
+                cellID: cell.cellID,
+                newValue: 'John Brown',
+                oldValue: 'John Brown',
+                cancel: false,
+                columnField: cell.column.field,
+                owner: grid
+            };
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledTimes(1);
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledWith(cellArgs);
             expect(cell.editMode).toBeTruthy();
@@ -568,7 +576,15 @@ describe('IgxGrid - Cell Editing #grid', () => {
 
             expect(cell.editMode).toBeFalsy();
             cell = grid.getCellByColumn(0, 'age');
-            cellArgs = { cellID: cell.cellID, rowID: cell.row.rowID, oldValue: 20, cancel: false };
+            cellArgs = {
+                cellID: cell.cellID,
+                rowID: cell.row.rowID,
+                oldValue: 20,
+                newValue: 20,
+                cancel: false,
+                columnField: cell.column.field,
+                owner: grid
+            };
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledTimes(2);
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledWith(cellArgs);
             expect(cell.editMode).toBeTruthy();
@@ -585,7 +601,15 @@ describe('IgxGrid - Cell Editing #grid', () => {
             cell.nativeElement.dispatchEvent(new MouseEvent('dblclick'));
             fixture.detectChanges();
 
-            let cellArgs: IGridEditEventArgs = { cellID: cell.cellID, rowID: cell.row.rowID, oldValue: 'John Brown', cancel: true };
+            let cellArgs: IGridEditEventArgs = {
+                cellID: cell.cellID,
+                rowID: cell.row.rowID,
+                newValue: 'John Brown',
+                oldValue: 'John Brown',
+                cancel: true,
+                columnField: cell.column.field,
+                owner: grid
+            };
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledTimes(1);
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledWith(cellArgs);
             expect(cell.editMode).toBeFalsy();
@@ -595,7 +619,15 @@ describe('IgxGrid - Cell Editing #grid', () => {
             UIInteractions.triggerKeyDownEvtUponElem('enter', cell.nativeElement, true);
             fixture.detectChanges();
 
-            cellArgs = { cellID: cell.cellID, rowID: cell.row.rowID, oldValue: 20, cancel: true };
+            cellArgs = {
+                cellID: cell.cellID,
+                rowID: cell.row.rowID,
+                oldValue: 20,
+                newValue: 20,
+                cancel: true,
+                columnField: cell.column.field,
+                owner: grid
+            };
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledTimes(2);
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledWith(cellArgs);
             expect(cell.editMode).toBeFalsy();
@@ -618,7 +650,15 @@ describe('IgxGrid - Cell Editing #grid', () => {
             UIInteractions.triggerKeyDownEvtUponElem('tab', cell.nativeElement, true);
             fixture.detectChanges();
 
-            cellArgs = { cellID: cell.cellID, rowID: cell.row.rowID, oldValue: 'John Brown', newValue: 'New Name', cancel: false };
+            cellArgs = {
+                cellID: cell.cellID,
+                rowID: cell.row.rowID,
+                oldValue: 'John Brown',
+                newValue: 'New Name',
+                cancel: false,
+                columnField: cell.column.field,
+                owner: grid
+            };
             expect(grid.onCellEdit.emit).toHaveBeenCalledTimes(1);
             expect(grid.onCellEdit.emit).toHaveBeenCalledWith(cellArgs);
 
@@ -632,7 +672,15 @@ describe('IgxGrid - Cell Editing #grid', () => {
             UIInteractions.triggerKeyDownEvtUponElem('enter', cell.nativeElement, true);
             fixture.detectChanges();
 
-            cellArgs = { cellID: cell.cellID, rowID: cell.row.rowID, oldValue: 20, newValue: 1, cancel: false };
+            cellArgs = {
+                cellID: cell.cellID,
+                rowID: cell.row.rowID,
+                oldValue: 20,
+                newValue: 1,
+                cancel: false,
+                columnField: cell.column.field,
+                owner: grid
+            };
             expect(grid.onCellEdit.emit).toHaveBeenCalledTimes(2);
             expect(grid.onCellEdit.emit).toHaveBeenCalledWith(cellArgs);
         });
@@ -657,7 +705,15 @@ describe('IgxGrid - Cell Editing #grid', () => {
             UIInteractions.triggerKeyDownEvtUponElem('tab', cell.nativeElement, true);
             fixture.detectChanges();
 
-            cellArgs = { cellID: cell.cellID, rowID: cell.row.rowID, oldValue: 'John Brown', newValue: 'New Name', cancel: true };
+            cellArgs = {
+                cellID: cell.cellID,
+                rowID: cell.row.rowID,
+                oldValue: 'John Brown',
+                newValue: 'New Name',
+                cancel: true,
+                columnField: cell.column.field,
+                owner: grid
+            };
             expect(grid.onCellEdit.emit).toHaveBeenCalledTimes(1);
             expect(grid.onCellEdit.emit).toHaveBeenCalledWith(cellArgs);
 
@@ -674,7 +730,15 @@ describe('IgxGrid - Cell Editing #grid', () => {
             UIInteractions.triggerKeyDownEvtUponElem('enter', cell.nativeElement, true);
             fixture.detectChanges();
 
-            cellArgs = { cellID: cell.cellID, rowID: cell.row.rowID, oldValue: 20, newValue: '1', cancel: true };
+            cellArgs = {
+                cellID: cell.cellID,
+                rowID: cell.row.rowID,
+                oldValue: 20,
+                newValue: '1',
+                cancel: true,
+                columnField: cell.column.field,
+                owner: grid
+            };
             expect(grid.onCellEdit.emit).toHaveBeenCalledTimes(2);
             expect(grid.onCellEdit.emit).toHaveBeenCalledWith(cellArgs);
 
@@ -777,7 +841,12 @@ describe('IgxGrid - Cell Editing #grid', () => {
 
             const cellArgs: IGridEditEventArgs = {
                 cellID: cell.cellID,
-                rowID: cell.row.rowID, oldValue: 'John Brown', newValue: 'New Name', cancel: false
+                rowID: cell.row.rowID,
+                oldValue: 'John Brown',
+                newValue: 'New Name',
+                cancel: false,
+                columnField: cell.column.field,
+                owner: grid
             };
             expect(grid.onCellEditCancel.emit).toHaveBeenCalledTimes(1);
             expect(grid.onCellEditCancel.emit).toHaveBeenCalledWith(cellArgs);
@@ -806,7 +875,12 @@ describe('IgxGrid - Cell Editing #grid', () => {
 
             const cellArgs: IGridEditEventArgs = {
                 cellID: cell.cellID,
-                rowID: cell.row.rowID, oldValue: 'John Brown', newValue: 'New Name', cancel: true
+                rowID: cell.row.rowID,
+                oldValue: 'John Brown',
+                newValue: 'New Name',
+                cancel: true,
+                columnField: cell.column.field,
+                owner: grid
             };
             expect(grid.onCellEditCancel.emit).toHaveBeenCalledTimes(1);
             expect(grid.onCellEditCancel.emit).toHaveBeenCalledWith(cellArgs);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-cell-editing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-cell-editing.spec.ts
@@ -718,7 +718,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
             expect(grid.onCellEdit.emit).toHaveBeenCalledWith(cellArgs);
 
             expect(cell.editMode).toBe(false);
-            expect(cell.value).toBe('John Brown');
+            expect(cell.value).toBe('New Name');
 
             cell = grid.getCellByColumn(0, 'age');
             expect(cell.editMode).toBe(true);
@@ -734,7 +734,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
                 cellID: cell.cellID,
                 rowID: cell.row.rowID,
                 oldValue: 20,
-                newValue: '1',
+                newValue: 1,
                 cancel: true,
                 column: cell.column,
                 owner: grid

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-cell-editing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-cell-editing.spec.ts
@@ -563,7 +563,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
                 newValue: 'John Brown',
                 oldValue: 'John Brown',
                 cancel: false,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledTimes(1);
@@ -582,7 +582,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
                 oldValue: 20,
                 newValue: 20,
                 cancel: false,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledTimes(2);
@@ -607,7 +607,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
                 newValue: 'John Brown',
                 oldValue: 'John Brown',
                 cancel: true,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledTimes(1);
@@ -625,7 +625,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
                 oldValue: 20,
                 newValue: 20,
                 cancel: true,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledTimes(2);
@@ -656,7 +656,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
                 oldValue: 'John Brown',
                 newValue: 'New Name',
                 cancel: false,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             expect(grid.onCellEdit.emit).toHaveBeenCalledTimes(1);
@@ -678,7 +678,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
                 oldValue: 20,
                 newValue: 1,
                 cancel: false,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             expect(grid.onCellEdit.emit).toHaveBeenCalledTimes(2);
@@ -711,7 +711,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
                 oldValue: 'John Brown',
                 newValue: 'New Name',
                 cancel: true,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             expect(grid.onCellEdit.emit).toHaveBeenCalledTimes(1);
@@ -736,7 +736,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
                 oldValue: 20,
                 newValue: '1',
                 cancel: true,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             expect(grid.onCellEdit.emit).toHaveBeenCalledTimes(2);
@@ -845,7 +845,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
                 oldValue: 'John Brown',
                 newValue: 'New Name',
                 cancel: false,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             expect(grid.onCellEditCancel.emit).toHaveBeenCalledTimes(1);
@@ -879,7 +879,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
                 oldValue: 'John Brown',
                 newValue: 'New Name',
                 cancel: true,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             expect(grid.onCellEditCancel.emit).toHaveBeenCalledTimes(1);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-cell-editing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-cell-editing.spec.ts
@@ -785,7 +785,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
             expect(cell.value).toEqual('New Name');
         });
 
-        it(`Should not update data in grid with transactions, when row is updated in onCellEdit and onCellEdit is canceled`, () => {
+        it(`Should update data in grid with transactions, when row is updated in onCellEdit and onCellEdit is canceled`, () => {
             fixture = TestBed.createComponent(SelectionWithTransactionsComponent);
             fixture.detectChanges();
             grid = fixture.componentInstance.grid;
@@ -794,6 +794,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
             fixture.detectChanges();
 
             // update the cell value via updateRow and cancel the event
+            // calling this will push additional transaction
             grid.onCellEdit.subscribe((e: IGridEditEventArgs) => {
                 const rowIndex: number = e.cellID.rowIndex;
                 const row = grid.getRowByIndex(rowIndex);
@@ -815,9 +816,17 @@ describe('IgxGrid - Cell Editing #grid', () => {
             expect(cell.value).toBe(secondNewValue);
 
             grid.transactions.undo();
+            // for some reason in this test we are changing the row value in onCellEdit. This
+            // pushes additional transaction in the transaction log. To restore the state we
+            // should call undo twice
+            grid.transactions.undo();
             fixture.detectChanges();
             expect(cell.value).toBe(firstNewValue);
 
+            grid.transactions.undo();
+            // for some reason in this test we are changing the row value in onCellEdit. This
+            // pushes additional transaction in the transaction log. To restore the state we
+            // should call undo twice
             grid.transactions.undo();
             fixture.detectChanges();
             expect(cell.value).toBe(initialValue);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-row-editing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-row-editing.spec.ts
@@ -1903,6 +1903,9 @@ describe('IgxGrid - Row Editing #grid', () => {
 
         it(`Should properly emit 'onCellEdit' event `, fakeAsync(() => {
             spyOn(grid.onCellEdit, 'emit').and.callThrough();
+            spyOn(grid.onRowEdit, 'emit').and.callThrough();
+
+            let cell = grid.getCellByColumn(0, 'ProductName');
             const cellArgs = {
                 cellID: cell.cellID,
                 rowID: cell.row.rowID,

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-row-editing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-row-editing.spec.ts
@@ -158,7 +158,7 @@ describe('IgxGrid - Row Editing #grid', () => {
                 oldValue: cell.value,
                 newValue: cell.value,
                 cancel: false,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             let rowArgs: IGridEditEventArgs = {
@@ -182,7 +182,7 @@ describe('IgxGrid - Row Editing #grid', () => {
                 oldValue: cell.value,
                 newValue: cell.value,
                 cancel: false,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             // no change, new value is null
@@ -214,7 +214,7 @@ describe('IgxGrid - Row Editing #grid', () => {
                 oldValue: cell.value,
                 newValue: newCellValue,
                 cancel: false,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
             rowArgs = {
@@ -1909,7 +1909,7 @@ describe('IgxGrid - Row Editing #grid', () => {
                 oldValue: 'Chai',
                 newValue: 'New Value',
                 cancel: false,
-                columnField: cell.column.field,
+                column: cell.column,
                 owner: grid
             };
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-row-editing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-row-editing.spec.ts
@@ -152,8 +152,22 @@ describe('IgxGrid - Row Editing #grid', () => {
             fix.detectChanges();
             expect(row.inEditMode).toBe(true);
 
-            let cellArgs: IGridEditEventArgs = { cellID: cell.cellID, rowID: cell.row.rowID, oldValue: cell.value, cancel: false };
-            let rowArgs: IGridEditEventArgs = { rowID: row.rowID, oldValue: row.rowData, cancel: false };
+            let cellArgs: IGridEditEventArgs = {
+                cellID: cell.cellID,
+                rowID: cell.row.rowID,
+                oldValue: cell.value,
+                newValue: cell.value,
+                cancel: false,
+                columnField: cell.column.field,
+                owner: grid
+            };
+            let rowArgs: IGridEditEventArgs = {
+                rowID: row.rowID,
+                oldValue: row.rowData,
+                newValue: undefined,
+                cancel: false,
+                owner: grid
+            };
             expect(grid.onCellEditEnter.emit).toHaveBeenCalledWith(cellArgs);
             expect(grid.onRowEditEnter.emit).toHaveBeenCalledWith(rowArgs);
 
@@ -162,9 +176,23 @@ describe('IgxGrid - Row Editing #grid', () => {
             flush();
 
             expect(row.inEditMode).toBe(false);
-            cellArgs = { cellID: cell.cellID, rowID: cell.row.rowID, oldValue: cell.value, newValue: cell.value, cancel: false };
+            cellArgs = {
+                cellID: cell.cellID,
+                rowID: cell.row.rowID,
+                oldValue: cell.value,
+                newValue: cell.value,
+                cancel: false,
+                columnField: cell.column.field,
+                owner: grid
+            };
             // no change, new value is null
-            rowArgs = { rowID: row.rowID, oldValue: row.rowData, newValue: null, cancel: false };
+            rowArgs = {
+                rowID: row.rowID,
+                oldValue: row.rowData,
+                newValue: null,
+                cancel: false,
+                owner: grid
+            };
             expect(grid.onCellEditCancel.emit).toHaveBeenCalledWith(cellArgs);
             expect(grid.onRowEditCancel.emit).toHaveBeenCalledWith(rowArgs);
 
@@ -180,10 +208,21 @@ describe('IgxGrid - Row Editing #grid', () => {
             flush();
             fix.detectChanges();
 
-            cellArgs = { cellID: cell.cellID, rowID: cell.row.rowID, oldValue: cell.value, newValue: newCellValue, cancel: false };
+            cellArgs = {
+                cellID: cell.cellID,
+                rowID: cell.row.rowID,
+                oldValue: cell.value,
+                newValue: newCellValue,
+                cancel: false,
+                columnField: cell.column.field,
+                owner: grid
+            };
             rowArgs = {
-                rowID: row.rowID, oldValue: row.rowData,
-                newValue: Object.assign({}, row.rowData, { ProductName: newCellValue }), cancel: false
+                rowID: row.rowID,
+                oldValue: row.rowData,
+                newValue: Object.assign({}, row.rowData, { ProductName: newCellValue }),
+                cancel: false,
+                owner: grid
             };
             UIInteractions.triggerKeyDownEvtUponElem('enter', cellDom, true);
             flush();
@@ -1594,7 +1633,8 @@ describe('IgxGrid - Row Editing #grid', () => {
                 newValue: Object.assign({}, initialData, { ProductName: 'New Name' }),
                 oldValue: initialData,
                 rowID: 1,
-                cancel: false
+                cancel: false,
+                owner: grid
             });
         }));
 
@@ -1632,7 +1672,8 @@ describe('IgxGrid - Row Editing #grid', () => {
                 newValue: Object.assign({}, initialData, { ProductName: 'New Name' }),
                 oldValue: initialData,
                 rowID: 1,
-                cancel: true
+                cancel: true,
+                owner: grid
             });
 
             // Enter cell edit mode again
@@ -1653,7 +1694,8 @@ describe('IgxGrid - Row Editing #grid', () => {
                 newValue: Object.assign({}, initialData, { ProductName: 'New Name' }),
                 oldValue: initialData,
                 rowID: 1,
-                cancel: true
+                cancel: true,
+                owner: grid
             });
         }));
 
@@ -1683,7 +1725,8 @@ describe('IgxGrid - Row Editing #grid', () => {
                 newValue: null,
                 oldValue: initialData,
                 rowID: 1,
-                cancel: false
+                cancel: false,
+                owner: grid
             });
         }));
 
@@ -1721,7 +1764,8 @@ describe('IgxGrid - Row Editing #grid', () => {
                 newValue: null,
                 oldValue: initialData,
                 rowID: 1,
-                cancel: true
+                cancel: true,
+                owner: grid
             });
 
             // Enter cell edit mode again
@@ -1742,7 +1786,8 @@ describe('IgxGrid - Row Editing #grid', () => {
                 newValue: null,
                 oldValue: initialData,
                 rowID: 1,
-                cancel: true
+                cancel: true,
+                owner: grid
             });
         }));
 
@@ -1760,8 +1805,10 @@ describe('IgxGrid - Row Editing #grid', () => {
             expect(grid.onRowEditEnter.emit).toHaveBeenCalled();
             expect(grid.onRowEditEnter.emit).toHaveBeenCalledWith({
                 oldValue: initialData,
+                newValue: undefined,
                 rowID: 1,
-                cancel: false
+                cancel: false,
+                owner: grid
             });
         }));
 
@@ -1785,8 +1832,10 @@ describe('IgxGrid - Row Editing #grid', () => {
             expect(grid.onRowEditEnter.emit).toHaveBeenCalledTimes(1);
             expect(grid.onRowEditEnter.emit).toHaveBeenCalledWith({
                 oldValue: initialData,
+                newValue: undefined,
                 rowID: 1,
-                cancel: true
+                cancel: true,
+                owner: grid
             });
         }));
 
@@ -1816,7 +1865,8 @@ describe('IgxGrid - Row Editing #grid', () => {
                 newValue: Object.assign({}, initialData, { ProductName: 'New Name' }),
                 oldValue: initialData,
                 rowID: 1,
-                cancel: false
+                cancel: false,
+                owner: grid
             });
         }));
 
@@ -1846,16 +1896,22 @@ describe('IgxGrid - Row Editing #grid', () => {
                 newValue: null,
                 oldValue: initialData,
                 rowID: 1,
-                cancel: false
+                cancel: false,
+                owner: grid
             });
         }));
 
         it(`Should properly emit 'onCellEdit' event `, fakeAsync(() => {
             spyOn(grid.onCellEdit, 'emit').and.callThrough();
-            spyOn(grid.onRowEdit, 'emit').and.callThrough();
-
-            let cell = grid.getCellByColumn(0, 'ProductName');
-            const cellArgs = { cellID: cell.cellID, rowID: cell.row.rowID, oldValue: 'Chai', newValue: 'New Value', cancel: false };
+            const cellArgs = {
+                cellID: cell.cellID,
+                rowID: cell.row.rowID,
+                oldValue: 'Chai',
+                newValue: 'New Value',
+                cancel: false,
+                columnField: cell.column.field,
+                owner: grid
+            };
 
             cell.nativeElement.dispatchEvent(new MouseEvent('dblclick'));
             tick(16);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.crud.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.crud.spec.ts
@@ -156,7 +156,8 @@ describe('IgxGrid - CRUD operations #grid', () => {
             rowID: 1,
             oldValue: { index: 1, value: 1 },
             newValue: { index: 200, value: 200 },
-            cancel: false
+            cancel: false,
+            owner: grid
         };
 
         expect(grid.onRowEdit.emit).toHaveBeenCalledWith(args);
@@ -177,7 +178,9 @@ describe('IgxGrid - CRUD operations #grid', () => {
             cellID: cell.cellID,
             oldValue: 1,
             newValue: 200,
-            cancel: false
+            cancel: false,
+            columnField: cell.column.field,
+            owner: grid
         };
 
         expect(grid.rowList.first.cells.first.value).not.toEqual(-100);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.crud.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.crud.spec.ts
@@ -179,7 +179,7 @@ describe('IgxGrid - CRUD operations #grid', () => {
             oldValue: 1,
             newValue: 200,
             cancel: false,
-            columnField: cell.column.field,
+            column: cell.column,
             owner: grid
         };
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.crud.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.crud.spec.ts
@@ -177,7 +177,7 @@ describe('IgxGrid - CRUD operations #grid', () => {
             rowID: cell.cellID.rowID,
             cellID: cell.cellID,
             oldValue: 1,
-            newValue: 200,
+            newValue: 0,
             cancel: false,
             column: cell.column,
             owner: grid
@@ -187,12 +187,13 @@ describe('IgxGrid - CRUD operations #grid', () => {
         expect(grid.rowList.first.cells.first.nativeElement.textContent).not.toMatch('-100');
 
         // Update an existing cell
+        // updating numeric cell with string will end with cell value equals to 0
         grid.updateCell('change', 1, 'index');
         fix.detectChanges();
 
         expect(grid.onCellEdit.emit).toHaveBeenCalledWith(args);
-        expect(grid.rowList.first.cells.first.value).toEqual(200);
-        expect(grid.rowList.first.cells.first.nativeElement.textContent).toMatch('200');
+        expect(grid.rowList.first.cells.first.value).toEqual(0);
+        expect(grid.rowList.first.cells.first.nativeElement.textContent).toMatch('0');
     });
 
     it('should support updating a cell value through the cell object', () => {

--- a/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
@@ -87,7 +87,8 @@ export class IgxCell {
             cellID: this.id,
             oldValue: this.value,
             newValue: this.editValue,
-            cancel: false
+            cancel: false,
+            columnField: this.column.field
         };
     }
 }
@@ -133,11 +134,9 @@ export class IgxGridCRUDService {
             console.warn('The grid must have a `primaryKey` specified when using `rowEditable`!');
         }
         this.row = this.createRow(this.cell);
-        const args = {
-            rowID: this.row.id,
-            oldValue: this.row.data,
-            cancel: false
-        };
+        // TODO: should we emit newValue in onRowEditEnter?
+        const args = this.row.createEditEventArgs();
+        args.owner = this.grid;
         this.grid.onRowEditEnter.emit(args);
         if (args.cancel) {
             this.endRowEdit();
@@ -156,12 +155,9 @@ export class IgxGridCRUDService {
     begin(cell): void {
         const newCell = this.createCell(cell);
         newCell.primaryKey = this.primaryKey;
-        const args = {
-            cellID: newCell.id,
-            rowID: newCell.id.rowID,
-            oldValue: newCell.value,
-            cancel: false
-        };
+        // TODO: should we emit newValue in onCellEditEnter?
+        const args = newCell.createEditEventArgs();
+        args.owner = this.grid;
 
         this.grid.onCellEditEnter.emit(args);
 

--- a/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
@@ -88,7 +88,7 @@ export class IgxCell {
             oldValue: this.value,
             newValue: this.editValue,
             cancel: false,
-            columnField: this.column.field
+            column: this.column
         };
     }
 }

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-crud.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-crud.spec.ts
@@ -369,7 +369,8 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     rowID: 147,
                     oldValue: oldRow,
                     newValue: newRow,
-                    cancel: false
+                    cancel: false,
+                    owner: treeGrid
                 });
                 verifyCellValue(fix, 0, 'Name', 'New Name');
                 verifyRowsCount(fix, 3, 4);
@@ -397,7 +398,8 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     rowID: 299,
                     oldValue: oldRow,
                     newValue: newRow,
-                    cancel: false
+                    cancel: false,
+                    owner: treeGrid
                 });
                 verifyCellValue(fix, 6, 'Name', 'New Name');
                 verifyRowsCount(fix, 3, 10);
@@ -425,7 +427,8 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     rowID: 299,
                     oldValue: oldRow,
                     newValue: newRow,
-                    cancel: false
+                    cancel: false,
+                    owner: treeGrid
                 });
                 verifyCellValue(fix, 6, 'Name', 'New Name');
                 verifyRowsCount(fix, 3, 10);
@@ -455,7 +458,9 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     cellID: cellComponent.cellID,
                     oldValue: oldCellValue,
                     newValue: newCellValue,
-                    cancel: false
+                    cancel: false,
+                    columnField: cellComponent.column.field,
+                    owner: treeGrid
                 });
                 verifyCellValue(fix, 6, 'Age', '18');
                 verifyRowsCount(fix, 3, 10);
@@ -485,7 +490,9 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     cellID: cellComponent.cellID,
                     oldValue: oldCellValue,
                     newValue: newCellValue,
-                    cancel: false
+                    cancel: false,
+                    columnField: cellComponent.column.field,
+                    owner: treeGrid
                 });
                 verifyCellValue(fix, 6, 'Age', '18');
                 verifyRowsCount(fix, 3, 10);
@@ -525,7 +532,8 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     rowID: 1,
                     oldValue: oldRow,
                     newValue: newRow,
-                    cancel: false
+                    cancel: false,
+                    owner: treeGrid
                 });
                 verifyCellValue(fix, 0, 'Name', 'New Name');
                 verifyRowsCount(fix, 8, 8);
@@ -557,7 +565,8 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     rowID: 1,
                     oldValue: oldRow,
                     newValue: newRow,
-                    cancel: false
+                    cancel: false,
+                    owner: treeGrid
                 });
                 verifyCellValue(fix, 0, 'Name', 'New Name');
                 verifyRowsCount(fix, 8, 8);
@@ -588,7 +597,8 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     rowID: 7,
                     oldValue: oldRow,
                     newValue: newRow,
-                    cancel: false
+                    cancel: false,
+                    owner: treeGrid
                 });
                 verifyCellValue(fix, 3, 'Name', 'New Name');
                 verifyRowsCount(fix, 8, 8);
@@ -616,7 +626,8 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     rowID: 7,
                     oldValue: oldRow,
                     newValue: newRow,
-                    cancel: false
+                    cancel: false,
+                    owner: treeGrid
                 });
                 verifyCellValue(fix, 3, 'Name', 'New Name');
                 verifyRowsCount(fix, 8, 8);
@@ -647,7 +658,8 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     rowID: 7,
                     oldValue: oldRow,
                     newValue: newRow,
-                    cancel: false
+                    cancel: false,
+                    owner: treeGrid
                 });
                 verifyCellValue(fix, 3, 'Name', 'Jack Simon');
                 verifyCellValue(fix, 5, 'Name', 'New Name');
@@ -679,7 +691,9 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     cellID: cellComponent.cellID,
                     oldValue: oldCellValue,
                     newValue: newCellValue,
-                    cancel: false
+                    cancel: false,
+                    columnField: cellComponent.column.field,
+                    owner: treeGrid
                 });
                 verifyCellValue(fix, 3, 'Name', 'Michael Myers');
                 verifyRowsCount(fix, 8, 8);
@@ -710,7 +724,9 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     cellID: cellComponent.cellID,
                     oldValue: oldCellValue,
                     newValue: newCellValue,
-                    cancel: false
+                    cancel: false,
+                    columnField: cellComponent.column.field,
+                    owner: treeGrid
                 });
                 verifyCellValue(fix, 3, 'Name', 'Michael Myers');
                 verifyRowsCount(fix, 8, 8);

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-crud.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-crud.spec.ts
@@ -459,7 +459,7 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     oldValue: oldCellValue,
                     newValue: newCellValue,
                     cancel: false,
-                    columnField: cellComponent.column.field,
+                    column: cellComponent.column,
                     owner: treeGrid
                 });
                 verifyCellValue(fix, 6, 'Age', '18');
@@ -491,7 +491,7 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     oldValue: oldCellValue,
                     newValue: newCellValue,
                     cancel: false,
-                    columnField: cellComponent.column.field,
+                    column: cellComponent.column,
                     owner: treeGrid
                 });
                 verifyCellValue(fix, 6, 'Age', '18');
@@ -692,7 +692,7 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     oldValue: oldCellValue,
                     newValue: newCellValue,
                     cancel: false,
-                    columnField: cellComponent.column.field,
+                    column: cellComponent.column,
                     owner: treeGrid
                 });
                 verifyCellValue(fix, 3, 'Name', 'Michael Myers');
@@ -725,7 +725,7 @@ describe('IgxTreeGrid - CRUD #tGrid', () => {
                     oldValue: oldCellValue,
                     newValue: newCellValue,
                     cancel: false,
-                    columnField: cellComponent.column.field,
+                    column: cellComponent.column,
                     owner: treeGrid
                 });
                 verifyCellValue(fix, 3, 'Name', 'Michael Myers');


### PR DESCRIPTION
When emitted `IGridEditEventArgs` will commit `owner`, the grid where event was emitted, and `column` where is possible (e.g. will not pass `column` in `OnRowWhatever` events).

`onCellEdit` will now fire after the data in the cell is updated, as is `onRowEdit` now. Note, if one sets `cancel` to `true` in `On[Cell/Row]Edit` edit mode will not end, but the value will be submited.

Closes #7304 
Closes #4965 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 