### PR TITLE
fix(igxGrid): Inject unique instances of the scroll sync service for … 

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.spec.ts
@@ -1142,6 +1142,47 @@ describe('IgxForOf directive -', () => {
             expect(firstInnerDisplayContainer.children[0].textContent).toBe('0');
         });
     });
+
+    describe('on create new instance', () => {
+        let fix: ComponentFixture<VerticalVirtualCreateComponent>;
+
+        configureTestSuite();
+        beforeAll(async(() => {
+            TestBed.configureTestingModule({
+                declarations: [
+                    VerticalVirtualCreateComponent
+                ],
+                imports: [IgxForOfModule],
+                providers: [{ provide: NgZone, useFactory: () => zone = new TestNgZone() }]
+            }).compileComponents();
+        }));
+
+        beforeEach(() => {
+            fix = TestBed.createComponent(VerticalVirtualCreateComponent);
+            fix.componentInstance.data = dg.generateVerticalData(fix.componentInstance.cols);
+            fix.componentRef.hostView.detectChanges();
+            fix.detectChanges();
+
+        });
+
+        it('should reset scroll position if new component is created.', async () => {
+            const scrollComponent = fix.debugElement.query(By.css(VERTICAL_SCROLLER)).componentInstance;
+            expect(scrollComponent.scrollAmount).toBe(0);
+            expect(scrollComponent.destroyed).toBeFalsy();
+
+            scrollComponent.nativeElement.scrollTop = 500;
+            fix.detectChanges();
+            await wait(100);
+            fix.detectChanges();
+            expect(scrollComponent.scrollAmount).toBe(500);
+
+            fix.componentInstance.exists = true;
+            fix.detectChanges();
+            await wait();
+            const secondForOf = fix.componentInstance.secondForOfDir;
+            expect(secondForOf.state.startIndex).toBe(0);
+        });
+});
 });
 
 class DataGenerator {
@@ -1403,6 +1444,45 @@ export class VerticalVirtualComponent extends VirtualComponent {
 })
 export class VerticalVirtualDestroyComponent extends VerticalVirtualComponent {
     public exists = true;
+}
+
+@Component({
+    template: `
+    <div #container [style.width]='width' [style.height]='height'>
+        <ng-template #scrollContainer igxFor let-rowData [igxForOf]="data"
+            [igxForScrollOrientation]="'vertical'"
+            [igxForContainerSize]='height'
+            [igxForItemSize]='itemSize'>
+            <div [style.display]="'flex'" [style.height]="rowData.height || itemSize || '50px'">
+                <div [style.min-width]=cols[0].width>{{rowData['1']}}</div>
+                <div [style.min-width]=cols[1].width>{{rowData['2']}}</div>
+                <div [style.min-width]=cols[2].width>{{rowData['3']}}</div>
+                <div [style.min-width]=cols[3].width>{{rowData['4']}}</div>
+                <div [style.min-width]=cols[4].width>{{rowData['5']}}</div>
+            </div>
+        </ng-template>
+    </div>
+        <div *ngIf='exists' #container [style.width]='width' [style.height]='height'>
+            <ng-template #scrollContainer2 igxFor let-rowData [igxForOf]="data"
+                [igxForScrollOrientation]="'vertical'"
+                [igxForContainerSize]='height'
+                [igxForItemSize]='itemSize'>
+                <div [style.display]="'flex'" [style.height]="rowData.height || itemSize || '50px'">
+                    <div [style.min-width]=cols[0].width>{{rowData['1']}}</div>
+                    <div [style.min-width]=cols[1].width>{{rowData['2']}}</div>
+                    <div [style.min-width]=cols[2].width>{{rowData['3']}}</div>
+                    <div [style.min-width]=cols[3].width>{{rowData['4']}}</div>
+                    <div [style.min-width]=cols[4].width>{{rowData['5']}}</div>
+                </div>
+            </ng-template>
+        </div>
+    `
+})
+export class VerticalVirtualCreateComponent extends VerticalVirtualComponent {
+    public exists = false;
+
+    @ViewChild('scrollContainer2', { read: IgxForOfDirective, static: false })
+    public secondForOfDir: IgxForOfDirective<any>;
 }
 
 /** Only horizontally virtualized component */

--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
@@ -68,7 +68,8 @@ export class IgxForOfContext<T> {
 
 }
 
-@Directive({ selector: '[igxFor][igxForOf]' })
+@Directive({ selector: '[igxFor][igxForOf]',
+providers: [ IgxForOfScrollSyncService ] })
 export class IgxForOfDirective<T> implements OnInit, OnChanges, DoCheck, OnDestroy, AfterViewInit {
 
     /**

--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.sync.service.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.sync.service.ts
@@ -48,7 +48,9 @@ export class IgxForOfSyncService {
     }
 }
 
-@Injectable()
+@Injectable({
+    providedIn: 'root',
+})
 export class IgxForOfScrollSyncService {
     private _masterScroll: Map<string, VirtualHelperBaseDirective> = new Map<string, any>();
     public setScrollMaster(dir: string, scroll: VirtualHelperBaseDirective) {

--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.sync.service.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.sync.service.ts
@@ -48,9 +48,7 @@ export class IgxForOfSyncService {
     }
 }
 
-@Injectable({
-    providedIn: 'root',
-})
+@Injectable()
 export class IgxForOfScrollSyncService {
     private _masterScroll: Map<string, VirtualHelperBaseDirective> = new Map<string, any>();
     public setScrollMaster(dir: string, scroll: VirtualHelperBaseDirective) {


### PR DESCRIPTION
 …IgxForOfDirective. Re-use same instances only when used in a Grid, where a common instance is injected in the Grid itself.
Closes #7698   

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 