### PR TITLE
Allow to show/hide summary row when the group/parent row is collapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes for each version of this project will be documented in this 
 - `IgxNavbar`:
     - **Breaking Changes** - The `igx-action-icon` has been renamed to `igx-navbar-action`. It should get renamed in your components via `ng update`;
 ### New Features
+- `IgxGrid`, `IgxTreeGrid`, `IgxHierarchicalGrid`
+    - Introduced `showSummaryOnCollapse` grid property which allows you to control whether the summary row stays visible when the groupBy / parent row is collapsed.
 - `IgxGridState` directive
     - Added support for expansion states, column selection and row pinning.
     - Added support for `IgxTreeGrid` and `IgxHierarchicalGrid` (including child grids)

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -1014,6 +1014,15 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
         }
     }
 
+    /**
+     * Controls whether the summary row is visible when groupBy / parent row is collapsed.
+     * @example
+     * ```html
+     * <igx-grid #grid [data]="localData" [showSummaryOnCollapse]="true" [autoGenerate]="true"></igx-grid>
+     * ```
+     * @remarks
+     * By default showSummaryOnCollapse is set to false  which means that summary row is not visible when groupBy / parent row is collapsed.
+     */
     @Input()
     get showSummaryOnCollapse() {
         return this._showSummaryOnCollapse;

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -1014,6 +1014,16 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
         }
     }
 
+    @Input()
+    get showSummaryOnCollapse() {
+        return this._showSummaryOnCollapse;
+    }
+
+    set showSummaryOnCollapse(value: boolean) {
+        this._showSummaryOnCollapse = value;
+        this.notifyChanges();
+    }
+
     /**
      * Gets/Sets the filtering strategy of the grid.
      * @example
@@ -2623,6 +2633,7 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
 
     private _summaryPosition = GridSummaryPosition.bottom;
     private _summaryCalculationMode = GridSummaryCalculationMode.rootAndChildLevels;
+    private _showSummaryOnCollapse = false;
     private _cellSelectionMode = GridSelectionMode.multiple;
     private _rowSelectionMode = GridSelectionMode.none;
     private _columnSelectionMode = GridSelectionMode.none;

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -1027,13 +1027,14 @@ export class IgxGridBaseDirective extends DisplayDensityBase implements
     }
 
     /**
-     * Controls whether the summary row is visible when groupBy / parent row is collapsed.
+     * Controls whether the summary row is visible when groupBy/parent row is collapsed.
      * @example
      * ```html
      * <igx-grid #grid [data]="localData" [showSummaryOnCollapse]="true" [autoGenerate]="true"></igx-grid>
      * ```
      * @remarks
-     * By default showSummaryOnCollapse is set to false  which means that summary row is not visible when groupBy / parent row is collapsed.
+     * By default showSummaryOnCollapse is set to 'false' which means that the summary row is not visible
+     * when the groupBy/parent row is collapsed.
      */
     @Input()
     get showSummaryOnCollapse() {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
@@ -1759,6 +1759,112 @@ describe('IgxGrid - Summaries #grid', () => {
             expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(5);
         });
 
+        it('should show summaries when group row is collapsed', () => {
+            expect(grid.showSummaryOnCollapse).toBe(false);
+            expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(3);
+            const groupRows = grid.groupsRowList.toArray();
+            grid.showSummaryOnCollapse = true;
+            fix.detectChanges();
+
+            groupRows[0].toggle();
+            fix.detectChanges();
+
+            expect(groupRows[0].expanded).toBe(false);
+            expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(4);
+            let summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 1);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 1, ['Count', 'Min', 'Max', 'Sum', 'Avg'], ['2', '17', '17', '34', '17']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2, ['Count'], ['2']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3,
+                ['Count', 'Earliest', 'Latest'], ['2', 'Dec 18, 2007', 'Mar 19, 2016']);
+
+            groupRows[0].toggle();
+            fix.detectChanges();
+
+            expect(groupRows[0].expanded).toBe(true);
+            expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(3);
+            summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 3);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 1, ['Count', 'Min', 'Max', 'Sum', 'Avg'], ['2', '17', '17', '34', '17']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2, ['Count'], ['2']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3,
+                ['Count', 'Earliest', 'Latest'], ['2', 'Dec 18, 2007', 'Mar 19, 2016']);
+        });
+
+        it('should be able to change showSummaryOnCollapse run time', () => {
+            expect(grid.showSummaryOnCollapse).toBe(false);
+            expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(3);
+            const groupRows = grid.groupsRowList.toArray();
+            fix.detectChanges();
+
+            groupRows[0].toggle();
+            fix.detectChanges();
+
+            expect(groupRows[0].expanded).toBe(false);
+            expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(3);
+
+            grid.showSummaryOnCollapse = true;
+            fix.detectChanges();
+
+            expect(grid.showSummaryOnCollapse).toBe(true);
+            expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(4);
+            const summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 1);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 1, ['Count', 'Min', 'Max', 'Sum', 'Avg'], ['2', '17', '17', '34', '17']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2, ['Count'], ['2']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3,
+                ['Count', 'Earliest', 'Latest'], ['2', 'Dec 18, 2007', 'Mar 19, 2016']);
+        });
+
+
+        it('should correctly position summary row when group row is collapsed', () => {
+            grid.showSummaryOnCollapse = true;
+            fix.detectChanges();
+            grid.groupBy({ fieldName: 'OnPTO', dir: SortingDirection.Asc, ignoreCase: false });
+            fix.detectChanges();
+
+            let summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 4);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 1, ['Count', 'Min', 'Max', 'Sum', 'Avg'], ['2', '17', '17', '34', '17']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2, ['Count'], ['2']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3,
+                ['Count', 'Earliest', 'Latest'], ['2', 'Dec 18, 2007', 'Mar 19, 2016']);
+
+            summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 5);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 1, ['Count', 'Min', 'Max', 'Sum', 'Avg'], ['2', '17', '17', '34', '17']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2, ['Count'], ['2']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3,
+                ['Count', 'Earliest', 'Latest'], ['2', 'Dec 18, 2007', 'Mar 19, 2016']);
+
+            const groupRows = grid.groupsRowList.toArray();
+            groupRows[1].toggle();
+            fix.detectChanges();
+
+            summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 2);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 1, ['Count', 'Min', 'Max', 'Sum', 'Avg'], ['2', '17', '17', '34', '17']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2, ['Count'], ['2']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3,
+                ['Count', 'Earliest', 'Latest'], ['2', 'Dec 18, 2007', 'Mar 19, 2016']);
+
+            summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 3);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 1, ['Count', 'Min', 'Max', 'Sum', 'Avg'], ['2', '17', '17', '34', '17']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2, ['Count'], ['2']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3,
+                ['Count', 'Earliest', 'Latest'], ['2', 'Dec 18, 2007', 'Mar 19, 2016']);
+
+            grid.summaryPosition = 'top';
+            fix.detectChanges();
+
+            summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 1);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 1, ['Count', 'Min', 'Max', 'Sum', 'Avg'], ['2', '17', '17', '34', '17']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2, ['Count'], ['2']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3,
+                ['Count', 'Earliest', 'Latest'], ['2', 'Dec 18, 2007', 'Mar 19, 2016']);
+
+            summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 3);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 1, ['Count', 'Min', 'Max', 'Sum', 'Avg'], ['2', '17', '17', '34', '17']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2, ['Count'], ['2']);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3,
+                ['Count', 'Earliest', 'Latest'], ['2', 'Dec 18, 2007', 'Mar 19, 2016']);
+
+        });
+
         it('should be able to enable/disable summaries at runtime', () => {
             grid.getColumnByName('Age').hasSummary = false;
             grid.getColumnByName('ParentID').hasSummary = false;

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.html
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.html
@@ -138,7 +138,7 @@
         | gridSort:sortingExpressions:sortStrategy:id:pipeTrigger
         | gridGroupBy:groupingExpressions:groupingExpansionState:groupsExpanded:id:groupsRecords:pipeTrigger
         | gridPaging:page:perPage:id:pipeTrigger
-        | gridSummary:hasSummarizedColumns:summaryCalculationMode:summaryPosition:id:pipeTrigger:summaryPipeTrigger
+        | gridSummary:hasSummarizedColumns:summaryCalculationMode:summaryPosition:id:showSummaryOnCollapse:pipeTrigger:summaryPipeTrigger
         | gridDetails:hasDetails:expansionStates:pipeTrigger
         | gridRowPinning:id:false:pipeTrigger"
             let-rowIndex="index" [igxForScrollOrientation]="'vertical'" [igxForScrollContainer]='verticalScroll'

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.summary.pipe.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.summary.pipe.ts
@@ -73,6 +73,15 @@ export class IgxGridSummaryPipe implements PipeTransform {
                 recordsWithSummary.push(record);
             }
 
+            if (summaryPosition === GridSummaryPosition.bottom && showSummary && (groupByRecord && !grid.isExpandedGroup(groupByRecord))) {
+                const records = this.removeDeletedRecord(grid, groupByRecord.records.slice());
+                const summaries = grid.summaryService.calculateSummaries(recordId, records);
+                const summaryRecord: ISummaryRecord = {
+                    summaries: summaries,
+                    max: maxSummaryHeight
+                };
+                recordsWithSummary.push(summaryRecord);
+            }
             if (summaryPosition === GridSummaryPosition.bottom && lastChildMap.has(recordId)) {
                 const groupRecords = lastChildMap.get(recordId);
 
@@ -90,7 +99,6 @@ export class IgxGridSummaryPipe implements PipeTransform {
             }
 
             const showSummaries = showSummary ? false : (groupByRecord && !grid.isExpandedGroup(groupByRecord));
-
             if (groupByRecord === null || showSummaries) {
                 continue;
             }
@@ -105,7 +113,6 @@ export class IgxGridSummaryPipe implements PipeTransform {
                 recordsWithSummary.push(summaryRecord);
             } else if (summaryPosition === GridSummaryPosition.bottom) {
                 let lastChild = groupByRecord;
-                debugger;
 
                 while (lastChild.groups && lastChild.groups.length > 0 && grid.isExpandedGroup(lastChild)) {
                     lastChild = lastChild.groups[lastChild.groups.length - 1];

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.summary.pipe.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.summary.pipe.ts
@@ -30,16 +30,16 @@ export class IgxGridSummaryPipe implements PipeTransform {
         hasSummary: boolean,
         summaryCalculationMode: GridSummaryCalculationMode,
         summaryPosition: GridSummaryPosition,
-        id: string, pipeTrigger: number, summaryPipeTrigger: number): any[] {
+        id: string, showSummary, pipeTrigger: number, summaryPipeTrigger: number): any[] {
 
         if (!collection.data || !hasSummary || summaryCalculationMode === GridSummaryCalculationMode.rootLevelOnly) {
             return collection.data;
         }
 
-        return this.addSummaryRows(id, collection, summaryPosition);
+        return this.addSummaryRows(id, collection, summaryPosition, showSummary);
     }
 
-    private addSummaryRows(gridId: string, collection: IGroupByResult, summaryPosition: GridSummaryPosition): any[] {
+    private addSummaryRows(gridId: string, collection: IGroupByResult, summaryPosition: GridSummaryPosition, showSummary): any[] {
         const recordsWithSummary = [];
         const lastChildMap = new Map<any, IGroupByRecord[]>();
         const grid: IgxGridComponent = this.gridAPI.grid;
@@ -89,7 +89,9 @@ export class IgxGridSummaryPipe implements PipeTransform {
                 }
             }
 
-            if (groupByRecord === null || !grid.isExpandedGroup(groupByRecord)) {
+            const showSummaries = showSummary ? false : (groupByRecord && !grid.isExpandedGroup(groupByRecord));
+
+            if (groupByRecord === null || showSummaries) {
                 continue;
             }
 
@@ -103,6 +105,7 @@ export class IgxGridSummaryPipe implements PipeTransform {
                 recordsWithSummary.push(summaryRecord);
             } else if (summaryPosition === GridSummaryPosition.bottom) {
                 let lastChild = groupByRecord;
+                debugger;
 
                 while (lastChild.groups && lastChild.groups.length > 0 && grid.isExpandedGroup(lastChild)) {
                     lastChild = lastChild.groups[lastChild.groups.length - 1];
@@ -123,7 +126,6 @@ export class IgxGridSummaryPipe implements PipeTransform {
                 groupRecords.unshift(groupByRecord);
             }
         }
-
         return recordsWithSummary;
     }
 

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-summaries.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-summaries.spec.ts
@@ -163,6 +163,99 @@ describe('IgxTreeGrid - Summaries #tGrid', () => {
             expect(GridSummaryFunctions.getAllVisibleSummariesRowIndexes(fix)).toEqual([6, 7, rootSummaryIndex]);
         });
 
+        it('should be able to show/hide summaries for collapsed parent rows runtime', () => {
+            treeGrid.summaryCalculationMode = 'childLevelsOnly';
+            fix.detectChanges();
+
+            let summaries = GridSummaryFunctions.getAllVisibleSummaries(fix);
+            expect(summaries.length).toBe(0);
+
+            treeGrid.showSummaryOnCollapse = true;
+            fix.detectChanges();
+
+            summaries = GridSummaryFunctions.getAllVisibleSummaries(fix);
+            expect(summaries.length).toBe(4);
+
+            treeGrid.showSummaryOnCollapse = false;
+            fix.detectChanges();
+
+            summaries = GridSummaryFunctions.getAllVisibleSummaries(fix);
+            expect(summaries.length).toBe(0);
+        });
+
+        it('should position correctly summary row for collapsed rows -- bottom position', () => {
+            treeGrid.expandAll();
+            fix.detectChanges();
+
+            treeGrid.summaryCalculationMode = 'childLevelsOnly';
+            fix.detectChanges();
+
+            let summaries = GridSummaryFunctions.getAllVisibleSummaries(fix);
+            expect(summaries.length).toBe(4);
+
+            treeGrid.showSummaryOnCollapse = true;
+            fix.detectChanges();
+
+            treeGrid.toggleRow(treeGrid.getRowByIndex(3).rowID);
+            fix.detectChanges();
+
+            summaries = GridSummaryFunctions.getAllVisibleSummaries(fix);
+            expect(summaries.length).toBe(4);
+
+            let summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 4);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2,
+                ['Count', 'Earliest', 'Latest'], ['2', 'Nov 11, 2009', 'Oct 17, 2015']);
+
+            summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 5);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2,
+                ['Count', 'Earliest', 'Latest'], ['3', 'Jul 19, 2009', 'Sep 18, 2014']);
+
+            treeGrid.summaryPosition = 'top';
+            fix.detectChanges();
+
+            summaries = GridSummaryFunctions.getAllVisibleSummaries(fix);
+            expect(summaries.length).toBe(4);
+
+            summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 1);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2,
+                ['Count', 'Earliest', 'Latest'], ['3', 'Jul 19, 2009', 'Sep 18, 2014']);
+
+            summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 5);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2,
+                ['Count', 'Earliest', 'Latest'], ['2', 'Nov 11, 2009', 'Oct 17, 2015']);
+        });
+
+        it('should position correctly summary row for collapsed rows -- top position', () => {
+            treeGrid.expandAll();
+            fix.detectChanges();
+
+            treeGrid.summaryCalculationMode = 'childLevelsOnly';
+            fix.detectChanges();
+
+            treeGrid.showSummaryOnCollapse = true;
+            fix.detectChanges();
+
+            let summaries = GridSummaryFunctions.getAllVisibleSummaries(fix);
+            expect(summaries.length).toBe(4);
+
+            treeGrid.toggleRow(treeGrid.getRowByIndex(3).rowID);
+            fix.detectChanges();
+
+            treeGrid.summaryPosition = 'top';
+            fix.detectChanges();
+
+            summaries = GridSummaryFunctions.getAllVisibleSummaries(fix);
+            expect(summaries.length).toBe(4);
+
+            let summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 1);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2,
+                ['Count', 'Earliest', 'Latest'], ['3', 'Jul 19, 2009', 'Sep 18, 2014']);
+
+            summaryRow = GridSummaryFunctions.getSummaryRowByDataRowIndex(fix, 5);
+            GridSummaryFunctions.verifyColumnSummaries(summaryRow, 2,
+                ['Count', 'Earliest', 'Latest'], ['2', 'Nov 11, 2009', 'Oct 17, 2015']);
+        });
+
         it('should be able to enable/disable summaries at runtime', () => {
             treeGrid.expandAll();
             fix.detectChanges();

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.html
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.html
@@ -104,7 +104,7 @@
         | treeGridSorting:sortingExpressions:sortStrategy:id:pipeTrigger
         | treeGridFlattening:id:expansionDepth:expansionStates:pipeTrigger
         | treeGridPaging:page:perPage:id:pipeTrigger
-        | treeGridSummary:hasSummarizedColumns:summaryCalculationMode:summaryPosition:id:pipeTrigger:summaryPipeTrigger
+        | treeGridSummary:hasSummarizedColumns:summaryCalculationMode:summaryPosition:showSummaryOnCollapse:id:pipeTrigger:summaryPipeTrigger
         | gridRowPinning:id:false:pipeTrigger"
             let-rowIndex="index" [igxForScrollOrientation]="'vertical'" [igxForScrollContainer]='verticalScroll'
             [igxForContainerSize]='calcHeight' [igxForItemSize]="renderedRowHeight" #verticalScrollContainer

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.summary.pipe.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.summary.pipe.ts
@@ -55,7 +55,6 @@ export class IgxTreeGridSummaryPipe implements PipeTransform {
                     cellIndentation: record.level + 1
                 };
                 recordsWithSummary.push(summaryRecord);
-                continue;
             }
             const isExpanded = record.children && record.children.length > 0 && record.expanded;
             if (summaryPosition === GridSummaryPosition.bottom && !isExpanded) {

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.summary.pipe.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.summary.pipe.ts
@@ -45,7 +45,6 @@ export class IgxTreeGridSummaryPipe implements PipeTransform {
 
             const isCollapsed = !record.expanded && record.children && record.children.length > 0 && showSummaryOnCollapse;
             if (isCollapsed) {
-                console.log(record.rowID, record.expanded);
                 let childData = record.children.filter(r => !r.isFilteredOutParent).map(r => r.data);
                 childData = this.removeDeletedRecord(grid, record.rowID, childData);
                 const summaries = grid.summaryService.calculateSummaries(record.rowID, childData);

--- a/src/app/grid-groupby/grid-groupby.sample.html
+++ b/src/app/grid-groupby/grid-groupby.sample.html
@@ -1,7 +1,9 @@
 <div class="wrapper">
     <igx-switch [(ngModel)]="hideGroupedColumns" (change)="toggleGroupedVisibility($event)">Toggle Hiding Of Grouped Columns</igx-switch>
+    <br />
     <igx-switch (change)="toggleSummaryPosition($event)">Toggle Summary Position</igx-switch>
-    <button (click)="grid1.showSummaryOnCollapse = !grid1.showSummaryOnCollapse"> {{ grid1.showSummaryOnCollapse }}</button>
+    <br />
+    <button igxButton="raised" (click)="grid1.showSummaryOnCollapse = !grid1.showSummaryOnCollapse"> {{ grid1.showSummaryOnCollapse }}</button> - Show summary on collapse
     <div class="separator"></div>
     <div class="density-chooser" style="margin-bottom: 16px">
             <igx-buttongroup [values]="summaryModes" (onSelect)="selectSummaryMode($event)" style="display: block; width: 500px"></igx-buttongroup>

--- a/src/app/grid-groupby/grid-groupby.sample.html
+++ b/src/app/grid-groupby/grid-groupby.sample.html
@@ -1,11 +1,13 @@
 <div class="wrapper">
     <igx-switch [(ngModel)]="hideGroupedColumns" (change)="toggleGroupedVisibility($event)">Toggle Hiding Of Grouped Columns</igx-switch>
+    <igx-switch (change)="toggleSummaryPosition($event)">Toggle Summary Position</igx-switch>
+    <button (click)="grid1.showSummaryOnCollapse = !grid1.showSummaryOnCollapse"> {{ grid1.showSummaryOnCollapse }}</button>
     <div class="separator"></div>
     <div class="density-chooser" style="margin-bottom: 16px">
             <igx-buttongroup [values]="summaryModes" (onSelect)="selectSummaryMode($event)" style="display: block; width: 500px"></igx-buttongroup>
         </div>
     <igx-grid #grid1 [data]="data" [allowFiltering]="true" [cellSelection]="'single'" [width]="'1200px'" [hideGroupedColumns]="hideGroupedColumns"
-    [height]="'700px'" [(groupingExpansionState)]='expState' [rowSelection]='selectionMode'  [summaryCalculationMode]="summaryMode">
+    [height]="'700px'" [(groupingExpansionState)]='expState' [rowSelection]='selectionMode'  [summaryCalculationMode]="summaryMode" [summaryPosition]='position'>
         <igx-column *ngFor="let c of columns" [sortable]="true" [field]="c.field" [header]="c.field" [width]="c.width"
             [hidden]='c.hidden' [sortable]='true' [groupable]='c.groupable' [movable]='true' [pinned]='!!c.pinned' [editable]="true" [hasSummary]="true" [dataType]='c.dataType'>
         </igx-column>

--- a/src/app/grid-groupby/grid-groupby.sample.ts
+++ b/src/app/grid-groupby/grid-groupby.sample.ts
@@ -2,7 +2,7 @@ import { Component, ViewChild, OnInit, Inject } from '@angular/core';
 
 import {
     IgxGridComponent, SortingDirection, ISortingExpression,
-    DefaultSortingStrategy, DisplayDensity, IDisplayDensityOptions, DisplayDensityToken, GridSelectionMode
+    DefaultSortingStrategy, DisplayDensity, IDisplayDensityOptions, DisplayDensityToken, GridSelectionMode, GridSummaryPosition
 } from 'igniteui-angular';
 
 @Component({
@@ -21,6 +21,7 @@ export class GridGroupBySampleComponent implements OnInit {
     public summaryMode = 'rootLevelOnly';
     public summaryModes = [];
     public selectionMode;
+    public position = GridSummaryPosition.top;
     constructor(@Inject(DisplayDensityToken) public displayDensityOptions: IDisplayDensityOptions) {}
     public ngOnInit(): void {
         this.columns = [
@@ -96,6 +97,10 @@ export class GridGroupBySampleComponent implements OnInit {
     }
     toggleGroupedVisibility(event){
         this.grid1.hideGroupedColumns = !event.checked;
+    }
+
+    toggleSummaryPosition($event) {
+        this.position = this.position === GridSummaryPosition.top ? GridSummaryPosition.bottom : GridSummaryPosition.top;
     }
     toggleDensity() {
         switch (this.displayDensityOptions.displayDensity ) {

--- a/src/app/tree-grid-flat-data/tree-grid-flat-data.sample.html
+++ b/src/app/tree-grid-flat-data/tree-grid-flat-data.sample.html
@@ -11,6 +11,7 @@
             <div class="density-chooser" style="margin-bottom: 16px">
                 <igx-buttongroup [values]="displayDensities" (onSelect)="selectDensity($event)" style="display: block; width: 500px"></igx-buttongroup>
             </div>
+            <button (click)="grid1.showSummaryOnCollapse = !grid1.showSummaryOnCollapse"> {{ grid1.showSummaryOnCollapse }}</button>
 
             <igx-tree-grid #grid1 [allowFiltering]='true' [data]="data" primaryKey="employeeID" foreignKey="PID" [rowSelection]="selectionMode"
                 [paging]="false" [displayDensity]="density" [width]="'900px'" [height]="'800px'" [showToolbar]="true"


### PR DESCRIPTION
Closes #7334

### Additional information (check all that apply):
 - [ ] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [x] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 