### PR TITLE
Correctly close all overlays on escape key

### DIFF
--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
@@ -356,7 +356,6 @@ export class IgxOverlayService implements OnDestroy {
         info.settings.scrollStrategy.detach();
         this.removeOutsideClickListener(info);
         this.removeResizeHandler();
-        this.removeCloseOnEscapeListener();
 
         const child: HTMLElement = info.elementRef.nativeElement;
         if (info.settings.modal) {
@@ -502,6 +501,7 @@ export class IgxOverlayService implements OnDestroy {
         if (this._overlayInfos.length === 0 && this._overlayElement && this._overlayElement.parentElement) {
             this._overlayElement.parentElement.removeChild(this._overlayElement);
             this._overlayElement = null;
+            this.removeCloseOnEscapeListener();
         }
     }
 
@@ -737,11 +737,7 @@ export class IgxOverlayService implements OnDestroy {
     }
 
     private removeCloseOnEscapeListener() {
-        const closingOverlaysCount =
-        this._overlayInfos
-            .filter(o => o.closeAnimationPlayer && o.closeAnimationPlayer.hasStarted())
-            .length;
-        if (this._overlayInfos.length - closingOverlaysCount === 1 && this._keyPressEventListener) {
+        if (this._keyPressEventListener) {
             this._keyPressEventListener.unsubscribe();
             this._keyPressEventListener = null;
         }


### PR DESCRIPTION
Remove `keydown` event listener only when all the overlays were closed.

Closes #7803  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 