### PR TITLE
fix(drop-down): revert fix for bottom shadow #7821 #3977

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-component.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-component.scss
@@ -17,11 +17,6 @@
         @extend %igx-drop-down__list !optional;
     }
 
-    @include e(list, $m: empty) {
-        @extend %igx-drop-down__list !optional;
-        @extend %igx-drop-down__list--empty !optional;
-    }
-
     @include e(list-scroll) {
         @extend %igx-drop-down__list-scroll !optional;
     }

--- a/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-theme.scss
@@ -236,10 +236,6 @@
         border: --var($theme, 'border-width') solid --var($theme, 'border-color');
     }
 
-    %igx-drop-down__list--empty {
-        box-shadow: none;
-    }
-
     %igx-drop-down__list-scroll {
         overflow-y: auto;
         overflow-x: hidden;

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down.component.html
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down.component.html
@@ -1,7 +1,4 @@
-<div [ngClass]="{
-    'igx-drop-down__list': items.length > 0,
-    'igx-drop-down__list--empty': items.length === 0 }"
-[style.width]="width"
+<div class="igx-drop-down__list" [style.width]="width"
 igxToggle
 (onAppended)="onToggleContentAppended()"
 (onOpening)="onToggleOpening($event)" (onOpened)="onToggleOpened()"


### PR DESCRIPTION
Closes #7821
Reopens #3977 because there is no way to check content in the dropdown parent container. Autocomplete will handle the problem instead of doing it in the dropdown.

The reverted PR is #7626 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 