### PR TITLE
fix(expansion-panel): add migration for deprecated `panel` property in IExpansionPanelEventArgs

### DIFF
--- a/projects/igniteui-angular/migrations/common/tsUtils.ts
+++ b/projects/igniteui-angular/migrations/common/tsUtils.ts
@@ -236,7 +236,7 @@ export function getTypeDefinitionAtPosition(langServ: tss.LanguageService, entry
             .filter(<(a: ts.Statement) => a is ts.ClassDeclaration>(m => m.kind === ts.SyntaxKind.ClassDeclaration))
             .find(m => m.name.getText() === definition.containerName);
         const member: ts.ClassElement = classDeclaration
-            .members
+            ?.members
             .find(m => m.name.getText() === definition.name);
         if (!member || !member.name) { return null; }
         typeDefs = langServ.getTypeDefinitionAtPosition(definition.fileName, member.name.getStart() + 1);

--- a/projects/igniteui-angular/migrations/update-10_2_0/changes/members.json
+++ b/projects/igniteui-angular/migrations/update-10_2_0/changes/members.json
@@ -9,6 +9,13 @@
                 "IgxTreeGridComponent",
                 "IgxHierarchicalGridComponent"
             ]
+        },
+        {
+            "member": "panel",
+            "replaceWith": "owner",
+            "definedIn": [
+                "IExpansionPanelEventArgs"
+            ]
         }
     ]
 }

--- a/projects/igniteui-angular/migrations/update-10_2_0/index.spec.ts
+++ b/projects/igniteui-angular/migrations/update-10_2_0/index.spec.ts
@@ -50,4 +50,51 @@ describe('Update 10.2.0', () => {
     it('should replace selectedRows() with selectedRows in ts files', async () => {
         pending('set up tests for migrations through lang service');
     });
+
+    it('Should remove references to deprecated `pane` property of `IExpansionPanelEventArgs`', async () => {
+        pending('set up tests for migrations through lang service');
+        appTree.create(
+            '/testSrc/appPrefix/component/expansion-test.component.ts',
+            `import { Component, ViewChild } from '@angular/core';
+import { IExpansionPanelEventArgs, IgxExpansionPanelComponent } from 'igniteui-angular';
+
+@Component({
+    selector: 'app-expansion-test',
+    templateUrl: './expansion-test.component.html',
+    styleUrls: ['./expansion-test.component.scss']
+})
+export class ExpansionTestComponent {
+
+    @ViewChild(IgxExpansionPanelComponent, { static: true })
+    public panel: IgxExpansionPanelComponent;
+
+    public onPanelOpened(event: IExpansionPanelEventArgs) {
+        console.log(event.panel);
+    }
+}`
+        );
+        const tree = await schematicRunner
+            .runSchematicAsync('migration-17', {}, appTree)
+            .toPromise();
+        const expectedContent =  `import { Component, ViewChild } from '@angular/core';
+import { IExpansionPanelEventArgs, IgxExpansionPanelComponent } from 'igniteui-angular';
+
+@Component({
+    selector: 'app-expansion-test',
+    templateUrl: './expansion-test.component.html',
+    styleUrls: ['./expansion-test.component.scss']
+})
+export class ExpansionTestComponent {
+
+    @ViewChild(IgxExpansionPanelComponent, { static: true })
+    public panel: IgxExpansionPanelComponent;
+
+    public onPanelOpened(event: IExpansionPanelEventArgs) {
+        console.log(event.owner);
+    }
+}`;
+        expect(
+                tree.readContent('/testSrc/appPrefix/component/expansion-test.component.ts')
+            ).toEqual(expectedContent);
+    });
 });


### PR DESCRIPTION
Migration for fix in #8190 

### Additional information (check all that apply):
 - [ ] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [x] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 