### PR TITLE
fix(grid): keep input focus on canceled edit w/ enter #4135

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
@@ -210,12 +210,12 @@ export class IgxGridCRUDService {
         }
 
         if (this.cellInEditMode) {
+            // TODO: case solely for f2/enter nav that uses enterEditMode as toggle. Refactor.
             const canceled = this.grid.endEdit(true);
-            if (this.grid.rowEditable && canceled) {
-                this._rowEditingBlocked = canceled;
-            }
 
-            this.grid.tbody.nativeElement.focus();
+            if (!canceled || !this.cell) {
+                this.grid.tbody.nativeElement.focus();
+            }
         } else {
 
             if (cell?.row.addRow) {
@@ -355,7 +355,7 @@ export class IgxGridCRUDService {
     }
 
 
-    /** Cleares cell and row editing state and closes row editing template if it is open */
+    /** Clears cell and row editing state and closes row editing template if it is open */
     public endEditMode() {
         this.endCellEdit();
         if (this.grid.rowEditable) {


### PR DESCRIPTION
Related #4135

From [this reply](https://github.com/IgniteUI/igniteui-angular/issues/4135#issuecomment-704717291) when preventing `cellEdit` on enter/f2 the cell looses focus (transferred to the grid body) and you have to click again, which is not ideal for KB scenarios. Works works well for outside clicks and tabs after events refactor for #7931, so this brings all in line.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 