### PR TITLE
Fix: When summary position is top Ctrl+Home or Ctrl+Arrow up selects the summary cell --9.1.

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-navigation.service.ts
@@ -364,7 +364,7 @@ export class IgxGridNavigationService {
     }
 
     protected findFirstDataRowIndex(): number {
-        return this.grid.dataView.findIndex(rec => !this.grid.isGroupByRecord(rec) && !this.grid.isDetailRecord(rec));
+        return this.grid.dataView.findIndex(rec => !this.grid.isGroupByRecord(rec) && !this.grid.isDetailRecord(rec) && !rec.summaries);
     }
 
     protected findLastDataRowIndex(): number {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
@@ -1759,6 +1759,38 @@ describe('IgxGrid - Summaries #grid', () => {
             expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(5);
         });
 
+        it('should navigate correctly with Ctrl + ArrowUp/Home when summary position is top', () => {
+            grid.showSummaryOnCollapse = true;
+            fix.detectChanges();
+
+            grid.summaryPosition = 'top';
+            fix.detectChanges();
+
+            fix.detectChanges();
+            let cell = grid.getCellByColumn(6, 'Age');
+            UIInteractions.simulateClickAndSelectEvent(cell);
+            fix.detectChanges();
+
+            expect(cell.selected).toBe(true);
+            UIInteractions.triggerKeyDownEvtUponElem('Home', cell.nativeElement, true, false, false, true);
+            fix.detectChanges();
+
+            cell = grid.getCellByColumn(2, 'ID');
+            expect(cell.selected).toBe(true);
+            expect(cell.active).toBe(true);
+
+            cell = grid.getCellByColumn(6, 'Name');
+            UIInteractions.simulateClickAndSelectEvent(cell);
+            fix.detectChanges();
+
+            UIInteractions.triggerKeyDownEvtUponElem('ArrowUp', cell.nativeElement, true, false, false, true);
+            fix.detectChanges();
+
+            cell = grid.getCellByColumn(2, 'Name');
+            expect(cell.selected).toBe(true);
+            expect(cell.active).toBe(true);
+        });
+
         it('should be able to enable/disable summaries at runtime', () => {
             grid.getColumnByName('Age').hasSummary = false;
             grid.getColumnByName('ParentID').hasSummary = false;


### PR DESCRIPTION
Closes #7330   

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 