### PR TITLE
fix(date-picker, time-picker): export input group module

### DIFF
--- a/projects/igniteui-angular/src/lib/combo/combo.component.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.ts
@@ -1625,7 +1625,8 @@ export class IgxComboComponent extends DisplayDensityBase implements IgxComboBas
         IgxComboFooterDirective,
         IgxComboAddItemDirective,
         IgxComboToggleIconDirective,
-        IgxComboClearIconDirective],
+        IgxComboClearIconDirective,
+        IgxInputGroupModule],
     imports: [IgxRippleModule, CommonModule, IgxInputGroupModule, FormsModule, ReactiveFormsModule,
         IgxForOfModule, IgxToggleModule, IgxCheckboxModule, IgxDropDownModule, IgxButtonModule, IgxIconModule]
 })

--- a/projects/igniteui-angular/src/lib/date-picker/date-picker.component.ts
+++ b/projects/igniteui-angular/src/lib/date-picker/date-picker.component.ts
@@ -1423,7 +1423,8 @@ export class IgxDatePickerComponent implements IDatePicker, ControlValueAccessor
         IgxDatePickerTemplateDirective,
         IgxDatePickerActionsDirective,
         DatePickerDisplayValuePipe,
-        DatePickerInputValuePipe
+        DatePickerInputValuePipe,
+        IgxInputGroupModule
     ],
     imports: [
         CommonModule,

--- a/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.module.ts
+++ b/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.module.ts
@@ -43,7 +43,8 @@ import { IgxDateTimeEditorModule } from '../directives/date-time-editor/public_a
         IgxDateRangeEndComponent,
         IgxDateRangeSeparatorDirective,
         IgxDateTimeEditorModule,
-        IgxPickerToggleComponent
+        IgxPickerToggleComponent,
+        IgxInputGroupModule
     ]
 })
 export class IgxDateRangePickerModule { }

--- a/projects/igniteui-angular/src/lib/select/select.module.ts
+++ b/projects/igniteui-angular/src/lib/select/select.module.ts
@@ -31,7 +31,8 @@ import { IgxSelectGroupComponent } from './select-group.component';
         IgxSelectHeaderDirective,
         IgxSelectItemComponent,
         IgxSelectItemNavigationDirective,
-        IgxSelectToggleIconDirective
+        IgxSelectToggleIconDirective,
+        IgxInputGroupModule
     ],
     imports: [
         CommonModule,

--- a/projects/igniteui-angular/src/lib/time-picker/time-picker.component.ts
+++ b/projects/igniteui-angular/src/lib/time-picker/time-picker.component.ts
@@ -2185,7 +2185,8 @@ export class IgxTimePickerComponent implements
         IgxTimePickerTemplateDirective,
         IgxTimePickerActionsDirective,
         TimeDisplayFormatPipe,
-        TimeInputFormatPipe
+        TimeInputFormatPipe,
+        IgxInputGroupModule
     ],
     imports: [
         CommonModule,


### PR DESCRIPTION
Closes #8586   

Export igxInputGroupModule for igxDatePicker, igxTimePicker, igxDateRangePicker, igxSelect & igxCombo. This will remove the need to import igxInputGroupModule in an application with one of the components above and will allow to project label and other components and will allow templating.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 