### PR TITLE
Close on outside click when in shadow DOM - 9.1

### DIFF
--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -1009,10 +1009,10 @@ describe('igxOverlay', () => {
                 modal: false,
                 closeOnOutsideClick: true,
                 positionStrategy: new ConnectedPositioningStrategy(),
-                target: button.nativeElement,
                 outlet: outlet
             };
 
+            overlaySettings.positionStrategy.settings.target = button.nativeElement;
             overlay.show(overlay.attach(SimpleDynamicComponent), overlaySettings);
             tick();
             fix.detectChanges();

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
@@ -658,7 +658,7 @@ export class IgxOverlayService implements OnDestroy {
                 return;
             }
             if (info.settings.closeOnOutsideClick) {
-                const target = ev.composedPath()[0] || ev.target;
+                const target = ev.composed ? ev.composedPath()[0] : ev.target;
                 //  if the click is on the element do not close this overlay
                 if (!info.elementRef.nativeElement.contains(target)) {
                     // if we should exclude position target check if the click is over it. If so do not close overlay

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
@@ -447,7 +447,7 @@ export class IgxOverlayService implements OnDestroy {
 
     private getOverlayElement(info: OverlayInfo): HTMLElement {
         if (info.settings.outlet) {
-            return info.settings.outlet.nativeElement;
+            return info.settings.outlet.nativeElement || info.settings.outlet;
         }
         if (!this._overlayElement) {
             this._overlayElement = this._document.createElement('div');

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
@@ -269,7 +269,7 @@ export class IgxOverlayService implements OnDestroy {
         const info: OverlayInfo = this.getOverlayById(id);
 
         if (!info) {
-           return;
+            return;
         }
 
         info.transformX += deltaX;
@@ -658,14 +658,14 @@ export class IgxOverlayService implements OnDestroy {
                 return;
             }
             if (info.settings.closeOnOutsideClick) {
-                const target = ev.target as any;
+                const target = ev.composedPath()[0] || ev.target;
                 //  if the click is on the element do not close this overlay
                 if (!info.elementRef.nativeElement.contains(target)) {
                     // if we should exclude position target check if the click is over it. If so do not close overlay
                     const positionTarget = info.settings.positionStrategy.settings.target as HTMLElement;
                     let clickOnPositionTarget = false;
                     if (positionTarget && positionTarget.contains) {
-                        clickOnPositionTarget = positionTarget.contains(target);
+                        clickOnPositionTarget = positionTarget.contains(target as any);
                     }
 
                     if (!(info.settings.excludePositionTarget && clickOnPositionTarget)) {


### PR DESCRIPTION
When component with encapsulation set to ShadowDom tried to show overlay in an outlet, clicking on 
When clicking on overlay content in overlay with `closeOnOutsideClick` set to true overlay should not close. However, when content is shown in outlet in component with ShadowDom encapsulation the target of click event comes as the component. To fix this and get the actual target we are now getting `composedPath` and its first child.

Closes #8626 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 