### PR TITLE
Handle keydown and iterate items by first character, if no item matched typed input - master

### DIFF
--- a/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
+++ b/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
@@ -62,13 +62,14 @@ export class IgxSelectItemNavigationDirective extends IgxDropDownItemNavigationD
         }
 
         super.handleKeyDown(event);
+        this.captureKey(event);
     }
 
     // tslint:disable:member-ordering
     private inputStream = '';
     private clearStream$ = Subscription.EMPTY;
 
-    @HostListener('keydown', ['$event'])
+    // @HostListener('keydown', ['$event'])
     public captureKey(event: KeyboardEvent) {
         // relying only on key, available on all major browsers:
         // https://caniuse.com/#feat=keyboardevent-key (IE/Edge quirk doesn't affect letter typing)

--- a/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
+++ b/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
@@ -72,8 +72,8 @@ export class IgxSelectItemNavigationDirective extends IgxDropDownItemNavigationD
     public captureKey(event: KeyboardEvent) {
         // relying only on key, available on all major browsers:
         // https://caniuse.com/#feat=keyboardevent-key (IE/Edge quirk doesn't affect letter typing)
-        if (!event || !event.key || event.key.length > 1 || ' ') {
-            // ignore longer keys ('Alt', 'ArrowDown', etc) AND space (used of open/close)
+        if (!event || !event.key || event.key.length > 1 || event.key === ' ' || event.key === 'spacebar') {
+            // ignore longer keys ('Alt', 'ArrowDown', etc) AND spacebar (used of open/close)
             return;
         }
 

--- a/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
+++ b/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
@@ -72,8 +72,8 @@ export class IgxSelectItemNavigationDirective extends IgxDropDownItemNavigationD
     public captureKey(event: KeyboardEvent) {
         // relying only on key, available on all major browsers:
         // https://caniuse.com/#feat=keyboardevent-key (IE/Edge quirk doesn't affect letter typing)
-        if (!event || !event.key || event.key.length > 1) {
-            // ignore longer keys ('Alt', 'ArrowDown', etc)
+        if (!event || !event.key || event.key.length > 1 || " ") {
+            // ignore longer keys ('Alt', 'ArrowDown', etc) AND space (used of open/close)
             return;
         }
 

--- a/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
+++ b/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
@@ -122,9 +122,8 @@ export class IgxSelectItemNavigationDirective extends IgxDropDownItemNavigationD
         const activeItemIndex = items.indexOf(this.target.focusedItem as IgxSelectItemComponent) || 0;
 
         // Match next item in ddl items and wrap around if needed
-        const item = items.slice(activeItemIndex + 1).find(x => !x.disabled && (x.itemText.toLowerCase().startsWith(text.toLowerCase()))) ||
+        return items.slice(activeItemIndex + 1).find(x => !x.disabled && (x.itemText.toLowerCase().startsWith(text.toLowerCase()))) ||
             items.slice(0, activeItemIndex).find(x => !x.disabled && (x.itemText.toLowerCase().startsWith(text.toLowerCase())));
-        return item;
     }
 
     ngOnDestroy(): void {

--- a/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
+++ b/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
@@ -72,7 +72,7 @@ export class IgxSelectItemNavigationDirective extends IgxDropDownItemNavigationD
     public captureKey(event: KeyboardEvent) {
         // relying only on key, available on all major browsers:
         // https://caniuse.com/#feat=keyboardevent-key (IE/Edge quirk doesn't affect letter typing)
-        if (!event || !event.key || event.key.length > 1 || " ") {
+        if (!event || !event.key || event.key.length > 1 || ' ') {
             // ignore longer keys ('Alt', 'ArrowDown', etc) AND space (used of open/close)
             return;
         }

--- a/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
+++ b/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
@@ -99,8 +99,8 @@ export class IgxSelectItemNavigationDirective extends IgxDropDownItemNavigationD
 
         let nextItem = this.findNextItem(items, text);
 
-        // If there is no such an item starting with the current text input stream AND the last Char in the input stream is the same as the first one,
-        // find next item starting with the same first Char.
+        // If there is no such an item starting with the current text input stream AND the last Char in the input stream
+        // is the same as the first one, find next item starting with the same first Char.
         // Covers cases of holding down the same key Ex: "pppppp" that iterates trough list items starting with "p".
         if (!nextItem && text.charAt(0) === text.charAt(text.length - 1)) {
             text = text.slice(0, 1);

--- a/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
+++ b/projects/igniteui-angular/src/lib/select/select-navigation.directive.ts
@@ -69,7 +69,6 @@ export class IgxSelectItemNavigationDirective extends IgxDropDownItemNavigationD
     private inputStream = '';
     private clearStream$ = Subscription.EMPTY;
 
-    // @HostListener('keydown', ['$event'])
     public captureKey(event: KeyboardEvent) {
         // relying only on key, available on all major browsers:
         // https://caniuse.com/#feat=keyboardevent-key (IE/Edge quirk doesn't affect letter typing)

--- a/projects/igniteui-angular/src/lib/select/select.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/select/select.component.spec.ts
@@ -47,7 +47,7 @@ const homeKeyEvent = new KeyboardEvent('keydown', { key: 'Home' });
 const tabKeyEvent = new KeyboardEvent('keydown', { key: 'Tab' });
 const shiftTabKeysEvent = new KeyboardEvent('keydown', { 'key': 'Tab', shiftKey: true });
 
-fdescribe('igxSelect', () => {
+describe('igxSelect', () => {
     let fixture;
     let select: IgxSelectComponent;
     let inputElement: DebugElement;
@@ -849,7 +849,7 @@ fdescribe('igxSelect', () => {
                 fixture.detectChanges();
                 verifySelectedItem(selectedItemIndex);
             });
-            fit('should select item with ENTER/SPACE keys', fakeAsync(() => {
+            it('should select item with ENTER/SPACE keys', fakeAsync(() => {
                 let selectedItemIndex = 2;
                 select.toggle();
                 tick();
@@ -1050,7 +1050,7 @@ fdescribe('igxSelect', () => {
                     const selectedItems = fixture.debugElement.nativeElement.querySelectorAll('.' + CSS_CLASS_SELECTED_ITEM);
                     expect(selectedItems.length).toEqual(0);
                 }));
-            fit('should not append any text to the input box when an item is focused but not selected',
+            it('should not append any text to the input box when an item is focused but not selected',
                 fakeAsync(() => {
                     let focusedItem = select.items[2];
                     const navigationStep = focusedItem.index;
@@ -1509,7 +1509,7 @@ fdescribe('igxSelect', () => {
             inputElement = fixture.debugElement.query(By.css('.' + CSS_CLASS_INPUT));
             selectList = fixture.debugElement.query(By.css('.' + CSS_CLASS_DROPDOWN_LIST_SCROLL));
         }));
-        fit('should toggle dropdown on ALT+ArrowUp/Down keys interaction', fakeAsync(() => {
+        it('should toggle dropdown on ALT+ArrowUp/Down keys interaction', fakeAsync(() => {
             expect(select.collapsed).toBeTruthy();
 
             inputElement.triggerEventHandler('keydown', altArrowDownKeyEvent);
@@ -1581,7 +1581,7 @@ fdescribe('igxSelect', () => {
             fixture.detectChanges();
             expect(select.collapsed).toBeTruthy();
         }));
-        fit('should properly emit opening/closing events on ALT+ArrowUp/Down keys interaction', fakeAsync(() => {
+        it('should properly emit opening/closing events on ALT+ArrowUp/Down keys interaction', fakeAsync(() => {
             spyOn(select.onOpening, 'emit');
             spyOn(select.onOpened, 'emit');
             spyOn(select.onClosing, 'emit');

--- a/projects/igniteui-angular/src/lib/select/select.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/select/select.component.spec.ts
@@ -783,7 +783,7 @@ fdescribe('igxSelect', () => {
             expect(selectComp.collapsed).toBeTruthy();
         }));
     });
-    fdescribe('Selection tests: ', () => {
+    describe('Selection tests: ', () => {
         describe('Using simple select component', () => {
             beforeEach(waitForAsync(() => {
                 fixture = TestBed.createComponent(IgxSelectSimpleComponent);
@@ -849,7 +849,7 @@ fdescribe('igxSelect', () => {
                 fixture.detectChanges();
                 verifySelectedItem(selectedItemIndex);
             });
-            it('should select item with ENTER/SPACE keys', fakeAsync(() => {
+            fit('should select item with ENTER/SPACE keys', fakeAsync(() => {
                 let selectedItemIndex = 2;
                 select.toggle();
                 tick();
@@ -1050,7 +1050,7 @@ fdescribe('igxSelect', () => {
                     const selectedItems = fixture.debugElement.nativeElement.querySelectorAll('.' + CSS_CLASS_SELECTED_ITEM);
                     expect(selectedItems.length).toEqual(0);
                 }));
-            it('should not append any text to the input box when an item is focused but not selected',
+            fit('should not append any text to the input box when an item is focused but not selected',
                 fakeAsync(() => {
                     let focusedItem = select.items[2];
                     const navigationStep = focusedItem.index;
@@ -1501,7 +1501,7 @@ fdescribe('igxSelect', () => {
             expect(groupElement.nativeElement.classList.contains(CSS_CLASS_FOCUSED_ITEM)).toBeFalsy();
         }));
     });
-    fdescribe('Key navigation tests: ', () => {
+    describe('Key navigation tests: ', () => {
         beforeEach(waitForAsync(() => {
             fixture = TestBed.createComponent(IgxSelectSimpleComponent);
             select = fixture.componentInstance.select;
@@ -1509,7 +1509,7 @@ fdescribe('igxSelect', () => {
             inputElement = fixture.debugElement.query(By.css('.' + CSS_CLASS_INPUT));
             selectList = fixture.debugElement.query(By.css('.' + CSS_CLASS_DROPDOWN_LIST_SCROLL));
         }));
-        it('should toggle dropdown on ALT+ArrowUp/Down keys interaction', fakeAsync(() => {
+        fit('should toggle dropdown on ALT+ArrowUp/Down keys interaction', fakeAsync(() => {
             expect(select.collapsed).toBeTruthy();
 
             inputElement.triggerEventHandler('keydown', altArrowDownKeyEvent);
@@ -1581,7 +1581,7 @@ fdescribe('igxSelect', () => {
             fixture.detectChanges();
             expect(select.collapsed).toBeTruthy();
         }));
-        it('should properly emit opening/closing events on ALT+ArrowUp/Down keys interaction', fakeAsync(() => {
+        fit('should properly emit opening/closing events on ALT+ArrowUp/Down keys interaction', fakeAsync(() => {
             spyOn(select.onOpening, 'emit');
             spyOn(select.onOpened, 'emit');
             spyOn(select.onClosing, 'emit');

--- a/projects/igniteui-angular/src/lib/select/select.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/select/select.component.spec.ts
@@ -1903,10 +1903,10 @@ describe('igxSelect', () => {
 
                 const filteredItemsInxs = fixture.componentInstance.filterCities('pa');
                 for (let index = 0; index < filteredItemsInxs.length; index++) {
-                    inputElement.triggerEventHandler('keyup', { key: 'p' });
+                    inputElement.triggerEventHandler('keydown', { key: 'p' });
                     tick();
                     fixture.detectChanges();
-                    inputElement.triggerEventHandler('keyup', { key: 'a' });
+                    inputElement.triggerEventHandler('keydown', { key: 'a' });
                     tick();
                     fixture.detectChanges();
                     verifyFocusedItem(filteredItemsInxs[index]);
@@ -1920,14 +1920,14 @@ describe('igxSelect', () => {
             fixture.detectChanges();
 
             const filteredItemsInxs = fixture.componentInstance.filterCities('l');
-            inputElement.triggerEventHandler('keyup', { key: 'l' });
+            inputElement.triggerEventHandler('keydown', { key: 'l' });
             tick();
             fixture.detectChanges();
             verifyFocusedItem(filteredItemsInxs[0]);
             tick(500);
             fixture.detectChanges();
 
-            inputElement.triggerEventHandler('keyup', { key: 'L' });
+            inputElement.triggerEventHandler('keydown', { key: 'L' });
             tick();
             fixture.detectChanges();
             verifyFocusedItem(filteredItemsInxs[1]);
@@ -1942,7 +1942,7 @@ describe('igxSelect', () => {
 
                 const filteredItemsInxs = fixture.componentInstance.filterCities('l');
                 for (let index = 0; index < filteredItemsInxs.length; index++) {
-                    inputElement.triggerEventHandler('keyup', { key: 'l' });
+                    inputElement.triggerEventHandler('keydown', { key: 'l' });
                     tick();
                     fixture.detectChanges();
                     verifyFocusedItem(filteredItemsInxs[index]);
@@ -1950,7 +1950,7 @@ describe('igxSelect', () => {
                     fixture.detectChanges();
                 }
                 // Navigate back to the first filtered item to verify that selection is wrapped
-                inputElement.triggerEventHandler('keyup', { key: 'l' });
+                inputElement.triggerEventHandler('keydown', { key: 'l' });
                 tick();
                 fixture.detectChanges();
                 verifyFocusedItem(filteredItemsInxs[0]);
@@ -1978,7 +1978,7 @@ describe('igxSelect', () => {
             // German characters
             let filteredItemsInxs = fixture.componentInstance.filterCities('ü');
             for (let index = 0; index < filteredItemsInxs.length; index++) {
-                inputElement.triggerEventHandler('keyup', { key: 'ü' });
+                inputElement.triggerEventHandler('keydown', { key: 'ü' });
                 tick();
                 fixture.detectChanges();
                 verifyFocusedItem(filteredItemsInxs[index]);
@@ -1989,7 +1989,7 @@ describe('igxSelect', () => {
             // Ciryllic characters
             filteredItemsInxs = fixture.componentInstance.filterCities('с');
             for (let index = 0; index < filteredItemsInxs.length; index++) {
-                inputElement.triggerEventHandler('keyup', { key: 'с' });
+                inputElement.triggerEventHandler('keydown', { key: 'с' });
                 tick();
                 fixture.detectChanges();
                 verifyFocusedItem(filteredItemsInxs[index]);
@@ -2003,7 +2003,7 @@ describe('igxSelect', () => {
             fixture.detectChanges();
 
             const filteredItemsInxs = fixture.componentInstance.filterCities('l');
-            inputElement.triggerEventHandler('keyup', { key: 'l' });
+            inputElement.triggerEventHandler('keydown', { key: 'l' });
             tick();
             fixture.detectChanges();
             verifyFocusedItem(filteredItemsInxs[0]);
@@ -2011,7 +2011,7 @@ describe('igxSelect', () => {
             fixture.detectChanges();
 
             // Verify that focus is unchanged
-            inputElement.triggerEventHandler('keyup', { key: 'w' });
+            inputElement.triggerEventHandler('keydown', { key: 'w' });
             tick();
             fixture.detectChanges();
             verifyFocusedItem(filteredItemsInxs[0]);
@@ -2022,10 +2022,10 @@ describe('igxSelect', () => {
             fakeAsync(() => {
                 const filteredItemsInxs = fixture.componentInstance.filterCities('pa');
                 for (let index = 0; index < filteredItemsInxs.length; index++) {
-                    inputElement.triggerEventHandler('keyup', { key: 'p' });
+                    inputElement.triggerEventHandler('keydown', { key: 'p' });
                     tick();
                     fixture.detectChanges();
-                    inputElement.triggerEventHandler('keyup', { key: 'a' });
+                    inputElement.triggerEventHandler('keydown', { key: 'a' });
                     tick();
                     fixture.detectChanges();
                     verifySelectedItem(filteredItemsInxs[index]);
@@ -2035,14 +2035,14 @@ describe('igxSelect', () => {
             }));
         it('character key navigation when dropdown is closed should be case insensitive', fakeAsync(() => {
             const filteredItemsInxs = fixture.componentInstance.filterCities('l');
-            inputElement.triggerEventHandler('keyup', { key: 'l' });
+            inputElement.triggerEventHandler('keydown', { key: 'l' });
             tick();
             fixture.detectChanges();
             verifySelectedItem(filteredItemsInxs[0]);
             tick(500);
             fixture.detectChanges();
 
-            inputElement.triggerEventHandler('keyup', { key: 'L' });
+            inputElement.triggerEventHandler('keydown', { key: 'L' });
             tick();
             fixture.detectChanges();
             verifySelectedItem(filteredItemsInxs[1]);
@@ -2053,7 +2053,7 @@ describe('igxSelect', () => {
             fakeAsync(() => {
                 const filteredItemsInxs = fixture.componentInstance.filterCities('l');
                 for (let index = 0; index < filteredItemsInxs.length; index++) {
-                    inputElement.triggerEventHandler('keyup', { key: 'l' });
+                    inputElement.triggerEventHandler('keydown', { key: 'l' });
                     tick();
                     fixture.detectChanges();
                     verifySelectedItem(filteredItemsInxs[index]);
@@ -2061,7 +2061,7 @@ describe('igxSelect', () => {
                     fixture.detectChanges();
                 }
                 // Navigate back to the first filtered item to verify that selection is wrapped
-                inputElement.triggerEventHandler('keyup', { key: 'l' });
+                inputElement.triggerEventHandler('keydown', { key: 'l' });
                 tick();
                 fixture.detectChanges();
                 verifySelectedItem(filteredItemsInxs[0]);
@@ -2086,7 +2086,7 @@ describe('igxSelect', () => {
             // German characters
             let filteredItemsInxs = fixture.componentInstance.filterCities('ü');
             for (let index = 0; index < filteredItemsInxs.length; index++) {
-                inputElement.triggerEventHandler('keyup', { key: 'ü' });
+                inputElement.triggerEventHandler('keydown', { key: 'ü' });
                 tick();
                 fixture.detectChanges();
                 verifySelectedItem(filteredItemsInxs[index]);
@@ -2097,7 +2097,7 @@ describe('igxSelect', () => {
             // Ciryllic characters
             filteredItemsInxs = fixture.componentInstance.filterCities('с');
             for (let index = 0; index < filteredItemsInxs.length; index++) {
-                inputElement.triggerEventHandler('keyup', { key: 'с' });
+                inputElement.triggerEventHandler('keydown', { key: 'с' });
                 tick();
                 fixture.detectChanges();
                 verifySelectedItem(filteredItemsInxs[index]);
@@ -2107,7 +2107,7 @@ describe('igxSelect', () => {
         }));
         it('should not change selection when pressing non-matching character and dropdown is closed', fakeAsync(() => {
             const filteredItemsInxs = fixture.componentInstance.filterCities('l');
-            inputElement.triggerEventHandler('keyup', { key: 'l' });
+            inputElement.triggerEventHandler('keydown', { key: 'l' });
             tick();
             fixture.detectChanges();
             verifyFocusedItem(filteredItemsInxs[0]);
@@ -2115,14 +2115,14 @@ describe('igxSelect', () => {
             fixture.detectChanges();
 
             // Verify that selection is unchanged
-            inputElement.triggerEventHandler('keyup', { key: 'q' });
+            inputElement.triggerEventHandler('keydown', { key: 'q' });
             tick();
             fixture.detectChanges();
             verifyFocusedItem(filteredItemsInxs[0]);
             tick(500);
             fixture.detectChanges();
 
-            inputElement.triggerEventHandler('keyup', { key: 'l' });
+            inputElement.triggerEventHandler('keydown', { key: 'l' });
             tick();
             fixture.detectChanges();
             verifyFocusedItem(filteredItemsInxs[1]);

--- a/projects/igniteui-angular/src/lib/select/select.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/select/select.component.spec.ts
@@ -47,7 +47,7 @@ const homeKeyEvent = new KeyboardEvent('keydown', { key: 'Home' });
 const tabKeyEvent = new KeyboardEvent('keydown', { key: 'Tab' });
 const shiftTabKeysEvent = new KeyboardEvent('keydown', { 'key': 'Tab', shiftKey: true });
 
-describe('igxSelect', () => {
+fdescribe('igxSelect', () => {
     let fixture;
     let select: IgxSelectComponent;
     let inputElement: DebugElement;
@@ -783,7 +783,7 @@ describe('igxSelect', () => {
             expect(selectComp.collapsed).toBeTruthy();
         }));
     });
-    describe('Selection tests: ', () => {
+    fdescribe('Selection tests: ', () => {
         describe('Using simple select component', () => {
             beforeEach(waitForAsync(() => {
                 fixture = TestBed.createComponent(IgxSelectSimpleComponent);
@@ -1501,7 +1501,7 @@ describe('igxSelect', () => {
             expect(groupElement.nativeElement.classList.contains(CSS_CLASS_FOCUSED_ITEM)).toBeFalsy();
         }));
     });
-    describe('Key navigation tests: ', () => {
+    fdescribe('Key navigation tests: ', () => {
         beforeEach(waitForAsync(() => {
             fixture = TestBed.createComponent(IgxSelectSimpleComponent);
             select = fixture.componentInstance.select;


### PR DESCRIPTION
Closes #8436   

- Make the component feel more responsive now as if no exact match is found for the current input stream, a next item with the same start letter will be selected (if such an item).
- Behave more like a native HTML select in terms of fast searching through items by 1st character, and yet do not suffer from the negative downside of not matching same second character if holding down or typing fast same char. Native select basically ignores selecting items via the current input stream while the same char is continuously typed as it seems to prioritize fast items iteration by first char instead.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 