### PR TITLE
Mvenkov/end editing on data source change 10.2

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid/grid-cell-editing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-cell-editing.spec.ts
@@ -1149,6 +1149,25 @@ describe('IgxGrid - Cell Editing #grid', () => {
             expect(grid.crudService.cell).toBeNull();
         });
 
+        it('should exit edit mode on data change', () => {
+            const cell = grid.getCellByColumn(0, 'fullName');
+            const cellDom = fixture.debugElement.queryAll(By.css(CELL_CSS_CLASS))[0];
+
+            UIInteractions.simulateDoubleClickAndSelectEvent(cell);
+            fixture.detectChanges();
+
+            const editTemplate = cellDom.query(By.css('input'));
+            expect(cell.editMode).toBe(true);
+            UIInteractions.clickAndSendInputElementValue(editTemplate, 'Rick Gilmore');
+            fixture.detectChanges();
+
+            const data = [...grid.data];
+            grid.data = data;
+            fixture.detectChanges();
+
+            expect(grid.crudService.cell).toBeNull();
+        });
+
         it('should update correct cell when sorting is applied', () => {
             grid.sort({ fieldName: 'age', dir: SortingDirection.Desc, ignoreCase: false });
             fixture.detectChanges();

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-row-editing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-row-editing.spec.ts
@@ -1124,6 +1124,20 @@ describe('IgxGrid - Row Editing #grid', () => {
             expect(grid.endEdit).toHaveBeenCalledTimes(1);
             expect(grid.endEdit).toHaveBeenCalledWith(true);
         });
+
+        it(`Should exit row editing AND DISCARD on DATA CHANGE`, () => {
+            const row = grid.getRowByIndex(0);
+            cell.setEditMode(true);
+            fix.detectChanges();
+            expect(grid.rowEditingOverlay.collapsed).toBeFalsy();
+            expect(grid.crudService.rowInEditMode).toBeTruthy();
+
+            grid.data = [...grid.data];
+            fix.detectChanges();
+
+            expect(grid.rowEditingOverlay.collapsed).toBeTruthy();
+            expect(grid.crudService.rowInEditMode).toBeFalsy();
+        });
     });
 
     describe('Integration', () => {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
@@ -143,6 +143,7 @@ export class IgxGridComponent extends IgxGridBaseDirective implements GridType, 
     }
 
     public set data(value: any[]) {
+        this.crudService.endEditMode();
         this._data = value || [];
         this.summaryService.clearSummaryCache();
         if (this.shouldGenerate) {

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
@@ -89,6 +89,7 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
      */
     @Input()
     public set data(value: any[]) {
+        this.crudService.endEditMode();
         this._data = value || [];
         this.summaryService.clearSummaryCache();
         if (this.shouldGenerate) {

--- a/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
@@ -357,7 +357,7 @@ export class IgxGridCRUDService {
     /** Clears cell and row editing state and closes row editing template if it is open */
     public endEditMode() {
         this.endCellEdit();
-        if (this.grid.rowEditable) {
+        if (this.grid?.rowEditable) {
             this.endRowEdit();
             this.grid.closeRowEditingOverlay();
         }

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
@@ -107,6 +107,7 @@ export class IgxTreeGridComponent extends IgxGridBaseDirective implements GridTy
     }
 
     public set data(value: any[]) {
+        this.crudService.endEditMode();
         this._data = value || [];
         this.summaryService.clearSummaryCache();
         if (this.shouldGenerate) {


### PR DESCRIPTION
Grids should exit cell/row editing without committing changes when data of the grid was changed.

Closes #8711   

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 