### PR TITLE
fix(migrations): resolve package for checks in seperate process #8254

### DIFF
--- a/projects/igniteui-angular/migrations/common/tsUtils.ts
+++ b/projects/igniteui-angular/migrations/common/tsUtils.ts
@@ -8,6 +8,7 @@ import { Logger } from './tsLogger';
 
 export const IG_PACKAGE_NAME = 'igniteui-angular';
 export const NG_LANG_SERVICE_PACKAGE_NAME = '@angular/language-service';
+export const NG_CORE_PACKAGE_NAME = '@angular/core';
 
 /** Returns an source file */
 // export function getFileSource(sourceText: string): ts.SourceFile {


### PR DESCRIPTION
This prevents our check from caching the package json result
which will prevent the package from loading correctly after install

Closes #8254

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 