### PR TITLE
fix(migrations): resolve package for checks in seperate process #8254

### DIFF
--- a/projects/igniteui-angular/migrations/common/ServerHost.ts
+++ b/projects/igniteui-angular/migrations/common/ServerHost.ts
@@ -1,6 +1,6 @@
 import { Tree } from '@angular-devkit/schematics';
 import * as ts from 'typescript/lib/tsserverlibrary';
-import { CUSTOM_TS_PLUGIN_NAME } from './tsUtils';
+import { CUSTOM_TS_PLUGIN_NAME, CUSTOM_TS_PLUGIN_PATH } from './tsUtils';
 
 export class ServerHost implements ts.server.ServerHost {
     readonly args: string[];
@@ -75,6 +75,7 @@ export class ServerHost implements ts.server.ServerHost {
         try {
             const paths = [initialPath];
             if (moduleName === CUSTOM_TS_PLUGIN_NAME) {
+                moduleName = CUSTOM_TS_PLUGIN_PATH;
                 paths.push(__dirname);
             }
             const modulePath = require.resolve(moduleName, { paths });

--- a/projects/igniteui-angular/migrations/common/UpdateChanges.ts
+++ b/projects/igniteui-angular/migrations/common/UpdateChanges.ts
@@ -9,12 +9,12 @@ import {
     SelectorChanges, ThemePropertyChanges, ImportsChanges, MemberChanges
 } from './schema';
 import {
-    getLanguageService, getRenamePositions, findMatches,
-    replaceMatch, createProjectService, isMemberIgniteUI, NG_LANG_SERVICE_PACKAGE_NAME
+    getLanguageService, getRenamePositions, findMatches, replaceMatch,
+    createProjectService, isMemberIgniteUI, NG_LANG_SERVICE_PACKAGE_NAME, NG_CORE_PACKAGE_NAME
 } from './tsUtils';
 import {
     getProjectPaths, getWorkspace, getProjects, escapeRegExp,
-    getPackageManager, canResolvePackage, tryInstallPackage, tryUninstallPackage
+    getPackageManager, canResolvePackage, tryInstallPackage, tryUninstallPackage, getPackageVersion
 } from './util';
 import { ServerHost } from './ServerHost';
 
@@ -30,7 +30,14 @@ export interface BoundPropertyObject {
 
 /* eslint-disable arrow-parens */
 export class UpdateChanges {
-    protected projectService: tss.server.ProjectService;
+    protected _projectService: tss.server.ProjectService;
+    public get projectService(): tss.server.ProjectService {
+        if (!this._projectService) {
+            this._projectService = createProjectService(this.serverHost);
+        }
+        return this._projectService;
+    }
+
     protected serverHost: ServerHost;
     protected workspace: WorkspaceSchema;
     protected sourcePaths: string[];
@@ -119,7 +126,6 @@ export class UpdateChanges {
         this.importsChanges = this.loadConfig('imports.json');
         this.membersChanges = this.loadConfig('members.json');
         this.serverHost = new ServerHost(this.host);
-        this.projectService = createProjectService(this.serverHost);
     }
 
     /** Apply configured changes to the Host Tree */
@@ -128,7 +134,13 @@ export class UpdateChanges {
             && !canResolvePackage(NG_LANG_SERVICE_PACKAGE_NAME);
         if (shouldInstallPkg) {
             this.context.logger.info(`Installing temporary migration dependencies via ${this.packageManager}.`);
-            tryInstallPackage(this.context, this.packageManager, NG_LANG_SERVICE_PACKAGE_NAME);
+            // try and get an appropriate version of the package to install
+            let targetVersion = getPackageVersion(NG_CORE_PACKAGE_NAME) || 'latest';
+            if (targetVersion.startsWith('11')) {
+                // TODO: Temporary restrict 11 LS version, till update for new module loading
+                targetVersion = '11.0.0';
+            }
+            tryInstallPackage(this.context, this.packageManager, `${NG_LANG_SERVICE_PACKAGE_NAME}@${targetVersion}`);
         }
 
         this.updateTemplateFiles();

--- a/projects/igniteui-angular/migrations/common/tsUtils.ts
+++ b/projects/igniteui-angular/migrations/common/tsUtils.ts
@@ -225,14 +225,14 @@ export const createProjectService = (serverHost: tss.server.ServerHost): tss.ser
  * Attempts to get type definitions using the TypeScript Language Service.
  * Can fall back to a cached version of the TSLS.
  */
-const getTypeDefinitions = (langServ: tss.LanguageService, entryPath: string, definition: tss.DefinitionInfo): any =>
+const getTypeDefinitions = (langServ: tss.LanguageService, entryPath: string, position: number): any =>
     /*
         getTypeScriptLanguageService is attached by us to the Typescript Language Service
         via a custom made plugin, it's sole purpose is to cache the language service and return it
         before any other plugins modify it
     */
-    langServ.getTypeDefinitionAtPosition(entryPath, definition.textSpan.start)
-    || (langServ as TSLanguageService).getTypeScriptLanguageService().getTypeDefinitionAtPosition(entryPath, definition.textSpan.start);
+    langServ.getTypeDefinitionAtPosition(entryPath, position)
+    || (langServ as TSLanguageService).getTypeScriptLanguageService().getTypeDefinitionAtPosition(entryPath, position);
 
 /**
  * Get type information about a TypeScript identifier
@@ -252,7 +252,7 @@ export const getTypeDefinitionAtPosition =
         if (definition.kind.toString() === 'reference') {
             return langServ.getDefinitionAndBoundSpan(entryPath, definition.textSpan.start).definitions[0];
         }
-        let typeDefs = getTypeDefinitions(langServ, entryPath, definition);
+        let typeDefs = getTypeDefinitions(langServ, entryPath, definition.textSpan.start);
         // if there are no type definitions found, the identifier is a ts property, referred in an internal/external template
         // or is a reference in a decorator
         if (!typeDefs) {
@@ -289,7 +289,7 @@ export const getTypeDefinitionAtPosition =
                 return null;
             }
 
-            typeDefs = langServ.getTypeDefinitionAtPosition(definition.fileName, member.name.getStart() + 1);
+            typeDefs = getTypeDefinitions(langServ, definition.fileName, member.name.getStart() + 1);
         }
         if (typeDefs?.length) {
             return typeDefs[0];

--- a/projects/igniteui-angular/migrations/common/tsUtils.ts
+++ b/projects/igniteui-angular/migrations/common/tsUtils.ts
@@ -9,6 +9,7 @@ import { TSLanguageService } from './tsPlugin/TSLanguageService';
 
 export const IG_PACKAGE_NAME = 'igniteui-angular';
 export const NG_LANG_SERVICE_PACKAGE_NAME = '@angular/language-service';
+export const NG_CORE_PACKAGE_NAME = '@angular/core';
 export const CUSTOM_TS_PLUGIN_NAME = './tsPlugin';
 
 /** Returns a source file */

--- a/projects/igniteui-angular/migrations/common/tsUtils.ts
+++ b/projects/igniteui-angular/migrations/common/tsUtils.ts
@@ -10,7 +10,8 @@ import { TSLanguageService } from './tsPlugin/TSLanguageService';
 export const IG_PACKAGE_NAME = 'igniteui-angular';
 export const NG_LANG_SERVICE_PACKAGE_NAME = '@angular/language-service';
 export const NG_CORE_PACKAGE_NAME = '@angular/core';
-export const CUSTOM_TS_PLUGIN_NAME = './tsPlugin';
+export const CUSTOM_TS_PLUGIN_PATH = './tsPlugin';
+export const CUSTOM_TS_PLUGIN_NAME = 'igx-ts-plugin';
 
 /** Returns a source file */
 // export function getFileSource(sourceText: string): ts.SourceFile {


### PR DESCRIPTION
This prevents our check from caching the package json result
which will prevent the package from loading correctly after install

Closes #8254  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 