### PR TITLE
fix(grid): invalid checkbox state in edit mode

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/cell.component.html
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.html
@@ -90,8 +90,12 @@
         </igx-input-group>
     </ng-container>
     <ng-container *ngIf="column.dataType === 'boolean'">
+        <!-- The additional [checked] binding is needed as after the initial call of the checked getter
+        it is never called again as no change detection is triggered in the grid after that, resulting in wrong
+        rendered state of the checkbox. -->
         <igx-checkbox
             [(ngModel)]="editValue"
+            [checked]="editValue"
             [igxFocus]="true"
             [disableRipple]="true"
         ></igx-checkbox>

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-cell-editing.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-cell-editing.spec.ts
@@ -164,6 +164,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
             const editTemplate = cellDomBoolean.query(By.css('.igx-checkbox'));
             expect(editTemplate).toBeDefined();
             expect(cell.value).toBe(true);
+            expect(cell.nativeElement.querySelector('.igx-checkbox--checked')).toBeInstanceOf(HTMLElement);
 
             editTemplate.nativeElement.click();
             fixture.detectChanges();
@@ -173,6 +174,7 @@ describe('IgxGrid - Cell Editing #grid', () => {
 
             expect(cell.editMode).toBe(false);
             expect(cell.value).toBe(false);
+            expect(cell.nativeElement.querySelector('.igx-checkbox--checked')).toBeNull();
         }));
 
         it('edit template should be according column data type -- date', () => {


### PR DESCRIPTION
After the initial change detection when 'swapping' the
current cell template, change detection is skipped which
results in the `checked` getter never being called again
after binding from the `ngModel`.

Additional binding to the `checked` property properly
triggers the getter and applying the style class.

Closes #9223


### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 