### PR TITLE
DateTimeEditor sets placeholder properly

### DIFF
--- a/projects/igniteui-angular/src/lib/date-common/util/date-time.util.spec.ts
+++ b/projects/igniteui-angular/src/lib/date-common/util/date-time.util.spec.ts
@@ -36,12 +36,21 @@ describe(`DateTimeUtil Unit tests`, () => {
             expect(resDict[DatePart.Date]).toEqual(jasmine.objectContaining({ start: 3, end: 5 }));
             expect(resDict[DatePart.Year]).toEqual(jasmine.objectContaining({ start: 6, end: 10 }));
 
+            // M/d/yy should be 00/00/00
             result = DateTimeUtil.parseDateTimeFormat('M/d/yy');
             resDict = reduceToDictionary(result);
             expect(result.length).toEqual(5);
             expect(resDict[DatePart.Month]).toEqual(jasmine.objectContaining({ start: 0, end: 2 }));
             expect(resDict[DatePart.Date]).toEqual(jasmine.objectContaining({ start: 3, end: 5 }));
             expect(resDict[DatePart.Year]).toEqual(jasmine.objectContaining({ start: 6, end: 8 }));
+
+            // H:m:s should be 00:00:00
+            result = DateTimeUtil.parseDateTimeFormat('H:m:s');
+            resDict = reduceToDictionary(result);
+            expect(result.length).toEqual(5);
+            expect(resDict[DatePart.Hours]).toEqual(jasmine.objectContaining({start: 0, end: 2 }));
+            expect(resDict[DatePart.Minutes]).toEqual(jasmine.objectContaining({start: 3, end: 5 }));
+            expect(resDict[DatePart.Seconds]).toEqual(jasmine.objectContaining({start: 6, end: 8 }));
 
             result = DateTimeUtil.parseDateTimeFormat('dd.MM.yyyy г.');
             resDict = reduceToDictionary(result);

--- a/projects/igniteui-angular/src/lib/date-common/util/date-time.util.ts
+++ b/projects/igniteui-angular/src/lib/date-common/util/date-time.util.ts
@@ -2,7 +2,6 @@ import { DatePart, DatePartInfo } from '../../directives/date-time-editor/date-t
 import { formatDate, FormatWidth, getLocaleDateFormat } from '@angular/common';
 import { ValidationErrors } from '@angular/forms';
 import { isDate } from '../../core/utils';
-import { MaskParsingService } from '../../directives/mask/mask-parsing.service';
 
 /** @hidden */
 const enum FormatDesc {
@@ -89,10 +88,8 @@ export abstract class DateTimeUtil {
                     }
                 }
 
-                DateTimeUtil.ensureLeadingZero(currentPart);
-                currentPart.end = currentPart.start + currentPart.format.length;
+                DateTimeUtil.addCurrentPart(currentPart, dateTimeParts);
                 position = currentPart.end;
-                dateTimeParts.push(currentPart);
             }
 
             currentPart = {
@@ -101,6 +98,11 @@ export abstract class DateTimeUtil {
                 type,
                 format: formatArray[i]
             };
+        }
+
+        // make sure the last member of a format like H:m:s is not omitted
+        if (!dateTimeParts.filter(p => p.format.includes(currentPart.format)).length) {
+            DateTimeUtil.addCurrentPart(currentPart, dateTimeParts);
         }
 
         return dateTimeParts;
@@ -418,6 +420,12 @@ export abstract class DateTimeUtil {
         }
 
         return false;
+    }
+
+    private static addCurrentPart(currentPart: DatePartInfo, dateTimeParts: DatePartInfo[]): void {
+        DateTimeUtil.ensureLeadingZero(currentPart);
+        currentPart.end = currentPart.start + currentPart.format.length;
+        dateTimeParts.push(currentPart);
     }
 
     private static daysInMonth(fullYear: number, month: number): number {

--- a/projects/igniteui-angular/src/lib/directives/date-time-editor/date-time-editor.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/date-time-editor/date-time-editor.directive.spec.ts
@@ -37,10 +37,10 @@ describe('IgxDateTimeEditor', () => {
             dateTimeEditor.ngOnChanges(changes);
         };
         describe('Properties & Events', () => {
-           it('should emit valueChange event on clear()', () => {
+            it('should emit valueChange event on clear()', () => {
                 inputFormat = 'dd/M/yy';
                 inputDate = '6/6/2000';
-                elementRef = { nativeElement: { value: inputDate, setSelectionRange: () => {} } };
+                elementRef = { nativeElement: { value: inputDate, setSelectionRange: () => { } } };
                 initializeDateTimeEditor();
 
                 const date = new Date(2000, 5, 6);
@@ -61,13 +61,13 @@ describe('IgxDateTimeEditor', () => {
                 initializeDateTimeEditor();
 
                 dateTimeEditor.inputFormat = inputFormat;
-                expect(dateTimeEditor.mask).toEqual('0/0/00');
+                expect(dateTimeEditor.mask).toEqual('00/00/00');
 
                 dateTimeEditor.inputFormat = 'dd-MM-yyyy HH:mm:ss';
                 expect(dateTimeEditor.mask).toEqual('00-00-0000 00:00:00');
 
                 dateTimeEditor.inputFormat = 'H:m:s';
-                expect(dateTimeEditor.mask).toEqual('0:0:0');
+                expect(dateTimeEditor.mask).toEqual('00:00:00');
             });
         });
 
@@ -977,6 +977,30 @@ describe('IgxDateTimeEditor', () => {
                 fixture.detectChanges();
                 expect(dateTimeEditorDirective.value.getDate()).toEqual(today.getDate() - 1);
             }));
+
+            it('should properly set placeholder with inputFormat applied', () => {
+                fixture.componentInstance.placeholder = 'Date:';
+                fixture.detectChanges();
+                expect(dateTimeEditorDirective.nativeElement.placeholder).toEqual('Date:');
+            });
+
+            it('should be able to switch placeholders at runtime', () => {
+                let placeholder = 'Placeholder';
+                fixture.componentInstance.placeholder = placeholder;
+                fixture.detectChanges();
+                expect(dateTimeEditorDirective.nativeElement.placeholder).toEqual(placeholder);
+
+                placeholder = 'Placeholder1';
+                fixture.componentInstance.placeholder = placeholder;
+                fixture.detectChanges();
+                expect(dateTimeEditorDirective.nativeElement.placeholder).toEqual(placeholder);
+
+                // when an empty placeholder (incl. null, undefined) is provided, at run-time, we do not default to the inputFormat
+                placeholder = '';
+                fixture.componentInstance.placeholder = placeholder;
+                fixture.detectChanges();
+                expect(dateTimeEditorDirective.nativeElement.placeholder).toEqual(placeholder);
+            });
         });
 
         describe('Form control tests: ', () => {
@@ -1065,6 +1089,12 @@ describe('IgxDateTimeEditor', () => {
                 fixture.componentInstance.submit();
                 expect(result).toBe(inputDate);
             });
+
+            it('should default to inputFormat as placeholder if none is provided', () => {
+                fixture.componentInstance.dateTimeFormat = 'dd/MM/yyyy';
+                fixture.detectChanges();
+                expect(dateTimeEditorDirective.nativeElement.placeholder).toEqual('dd/MM/yyyy');
+            });
         });
     });
 });
@@ -1074,9 +1104,11 @@ describe('IgxDateTimeEditor', () => {
     template: `
 <igx-input-group #igxInputGroup>
         <input type="text" igxInput [disabled]="disabled" [readonly]="readonly"
-            [igxDateTimeEditor]="dateTimeFormat" [displayFormat]="displayFormat"
+            [igxDateTimeEditor]="dateTimeFormat" [displayFormat]="displayFormat" [placeholder]="placeholder"
             [(ngModel)]="date" [minValue]="minDate" [maxValue]="maxDate" [promptChar]="promptChar"/>
     </igx-input-group>
+
+    <input [(ngModel)]="placeholder" />
 `
 })
 export class IgxDateTimeEditorSampleComponent {
@@ -1089,11 +1121,12 @@ export class IgxDateTimeEditorSampleComponent {
     public promptChar = '_';
     public disabled = false;
     public readonly = false;
+    public placeholder = null;
 }
 
 @Component({
     template: `
-    <form (ngSubmit)="submit()" [formGroup]="reactiveForm">
+<form (ngSubmit)="submit()" [formGroup]="reactiveForm">
     <igx-input-group>
         <input formControlName="dateEditor" type="text"
         igxInput [igxDateTimeEditor]="dateTimeFormat" [minValue]="minDate" [maxValue]="maxDate"/>

--- a/projects/igniteui-angular/src/lib/directives/date-time-editor/date-time-editor.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/date-time-editor/date-time-editor.directive.ts
@@ -2,7 +2,7 @@
 import {
   Directive, Input, ElementRef,
   Renderer2, NgModule, Output, EventEmitter, Inject,
-  LOCALE_ID, OnChanges, SimpleChanges, DoCheck, HostListener
+  LOCALE_ID, OnChanges, SimpleChanges, HostListener, OnInit
 } from '@angular/core';
 import {
   ControlValueAccessor,
@@ -53,7 +53,7 @@ import { DateTimeUtil } from '../../date-common/util/date-time.util';
     { provide: NG_VALIDATORS, useExisting: IgxDateTimeEditorDirective, multi: true }
   ]
 })
-export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnChanges, DoCheck, Validator, ControlValueAccessor {
+export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnChanges, OnInit, Validator, ControlValueAccessor {
   /**
    * Locale settings used for value formatting.
    *
@@ -147,15 +147,13 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
   @Input(`igxDateTimeEditor`)
   public set inputFormat(value: string) {
     if (value) {
-      this._format = value;
+      this.setMask(value);
+      this._inputFormat = value;
     }
-    const mask = (this.inputFormat || DateTimeUtil.DEFAULT_INPUT_FORMAT)
-      .replace(new RegExp(/(?=[^t])[\w]/, 'g'), '0');
-    this.mask = mask.indexOf('tt') !== -1 ? mask.replace(new RegExp('tt', 'g'), 'LL') : mask;
   }
 
   public get inputFormat(): string {
-    return this._format || this._inputFormat;
+    return this._inputFormat || this._defaultInputFormat;
   }
 
   /**
@@ -212,13 +210,13 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
   @Output()
   public validationFailed = new EventEmitter<IgxDateTimeEditorEventArgs>();
 
-  private _format: string;
+  private _inputFormat: string;
   private _oldValue: Date;
   private _dateValue: Date;
   private _onClear: boolean;
   private document: Document;
   private _isFocused: boolean;
-  private _inputFormat: string;
+  private _defaultInputFormat: string;
   private _value: Date | string;
   private _minValue: Date | string;
   private _maxValue: Date | string;
@@ -300,22 +298,20 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
     }
   }
 
-  /** @hidden @internal */
-  public ngOnChanges(changes: SimpleChanges) {
-    if (changes['locale'] && !this._format) {
-      this._inputFormat = DateTimeUtil.getDefaultInputFormat(this.locale);
-    }
-    if (changes['inputFormat']) {
-      this.updateInputFormat();
-    }
+  public ngOnInit(): void {
+    this.updateDefaultFormat();
   }
 
   /** @hidden @internal */
-  public ngDoCheck(): void {
-    if (this._inputFormat !== this.inputFormat) {
-      this.updateInputFormat();
+  public ngOnChanges(changes: SimpleChanges) {
+    if (changes['locale'] && !changes['locale'].firstChange) {
+      this.updateDefaultFormat();
+    }
+    if (changes['inputFormat'] && !changes['inputFormat'].firstChange) {
+      this.updateMask();
     }
   }
+
 
   /** Clear the input element value. */
   public clear(): void {
@@ -473,8 +469,15 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
     super.onBlur(value);
   }
 
-  /** @hidden @internal */
-  public updateMask(): void {
+  private updateDefaultFormat(): void {
+    this._defaultInputFormat = DateTimeUtil.getDefaultInputFormat(this.locale);
+    if (!this._inputFormat) {
+      this.setMask(this.inputFormat);
+      this.updateMask();
+    }
+  }
+
+  private updateMask(): void {
     if (!this.dateValue || !DateTimeUtil.isValidDate(this.dateValue)) {
       if (!this._isFocused) {
         this.inputValue = '';
@@ -506,6 +509,20 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
     }
   }
 
+  private setMask(inputFormat: string) {
+    const oldFormat = this._inputDateParts?.map(p => p.format).join('');
+    this._inputDateParts = DateTimeUtil.parseDateTimeFormat(inputFormat);
+    inputFormat = this._inputDateParts.map(p => p.format).join('');
+    const mask = (inputFormat || DateTimeUtil.DEFAULT_INPUT_FORMAT)
+      .replace(new RegExp(/(?=[^t])[\w]/, 'g'), '0');
+    this.mask = mask.indexOf('tt') !== -1 ? mask.replace(new RegExp('tt', 'g'), 'LL') : mask;
+
+    const placeholder = this.nativeElement.placeholder;
+    if (!placeholder || oldFormat === placeholder) {
+      this.renderer.setAttribute(this.nativeElement, 'placeholder', inputFormat);
+    }
+  }
+
   private parseDate(val: string): Date | null {
     if (!val) {
       return null;
@@ -532,17 +549,6 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
     return mask;
   }
 
-  private updateInputFormat(): void {
-    const defPlaceholder = this.inputFormat || DateTimeUtil.getDefaultInputFormat(this.locale);
-    this._inputDateParts = DateTimeUtil.parseDateTimeFormat(this.inputFormat);
-    this.inputFormat = this._inputDateParts.map(p => p.format).join('');
-    if (!this.nativeElement.placeholder || this._inputFormat !== this.inputFormat) {
-      this.renderer.setAttribute(this.nativeElement, 'placeholder', defPlaceholder);
-    }
-    // TODO: fill in partial dates?
-    this.updateMask();
-    this._inputFormat = this.inputFormat;
-  }
 
   private valueInRange(value: Date): boolean {
     if (!value) {


### PR DESCRIPTION
The problem was with the `IgxDateTimeEditorDirective` which did not update its placeholder when an `inputFormat` was provided. So the issue was reproducible in all components that used the directive.

Closes #9409

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 