### PR TITLE
fix(migrations): move disabled property to textarea, #9339

### DIFF
--- a/projects/igniteui-angular/migrations/update-12_0_0/index.spec.ts
+++ b/projects/igniteui-angular/migrations/update-12_0_0/index.spec.ts
@@ -1852,4 +1852,30 @@ export class SimpleComponent {
     `
         );
     });
+
+    it('Should move disabled input group to textarea w/ igxInput', async () => {
+        appTree.create(
+            `/testSrc/appPrefix/component/test.component.html`,
+            `
+    <igx-input-group [disabled]="true">
+        <textarea igxInput [(ngModel)]="name">Some Text</textarea>
+    </igx-input-group>
+    `
+        );
+
+        const tree = await schematicRunner
+            .runSchematicAsync(migrationName, {}, appTree)
+            .toPromise();
+// this is the expected output
+// putting just the disabled attribute on an igx-input-group is an invalid scenario
+        expect(
+            tree.readContent('/testSrc/appPrefix/component/test.component.html')
+        ).toEqual(
+            `
+    <igx-input-group>
+        <textarea igxInput [(ngModel)]="name" [disabled]="true">Some Text</textarea>
+    </igx-input-group>
+    `
+        );
+    });
 });

--- a/projects/igniteui-angular/migrations/update-12_0_0/index.ts
+++ b/projects/igniteui-angular/migrations/update-12_0_0/index.ts
@@ -472,7 +472,7 @@ See https://www.infragistics.com/products/ignite-ui-angular/angular/components/t
     const INPUT_GROUP_CHANGES = {
         GROUP_TAG: 'igx-input-group',
         ATTRIBUTES: ['[disabled]', 'disabled'],
-        INPUT_TAG: 'input',
+        INPUT_TAG: ['input', 'textarea'],
         DIRECTIVE: 'igxInput'
     };
 


### PR DESCRIPTION
Migration for `igx-input-group` `disabled` property was only moving the property to `input` children. it now moves it to `textarea` as well.
 
### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [x] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 