### PR TITLE
fix(expansion-panel): disabled panel header is not focusable w/ click - 12.0.x

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/expansion-panel/_expansion-panel-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/expansion-panel/_expansion-panel-theme.scss
@@ -188,6 +188,8 @@
     }
 
     %igx-expansion-panel--disabled {
+        pointer-events: none;
+
         %igx-expansion-panel__header-title,
         %igx-expansion-panel__header-description {
             color: --var($theme, 'disabled-color')

--- a/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel-header.component.ts
+++ b/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel-header.component.ts
@@ -173,7 +173,8 @@ export class IgxExpansionPanelHeaderComponent {
     public set disabled(val: boolean) {
         this._disabled = val;
         if (val) {
-            this.tabIndex = null;
+            // V.S. June 11th, 2021: #9696 TabIndex should be removed when panel is disabled
+            delete this.tabIndex;
         } else {
             this.tabIndex = 0;
         }

--- a/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel-header.component.ts
+++ b/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel-header.component.ts
@@ -173,7 +173,7 @@ export class IgxExpansionPanelHeaderComponent {
     public set disabled(val: boolean) {
         this._disabled = val;
         if (val) {
-            this.tabIndex = -1;
+            this.tabIndex = null;
         } else {
             this.tabIndex = 0;
         }

--- a/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel.spec.ts
+++ b/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel.spec.ts
@@ -191,7 +191,7 @@ describe('igxExpansionPanel', () => {
             expect(panel.onCollapsed.emit).toHaveBeenCalledTimes(1);
         }));
 
-        it('Should set header tabIndex to -1 when header is disabled', () => {
+        it('Should NOT assign tabIndex to header when disabled', () => {
             const fixture = TestBed.createComponent(IgxExpansionPanelSampleComponent);
             fixture.detectChanges();
             const panelHeader = fixture.componentInstance.header;
@@ -204,7 +204,7 @@ describe('igxExpansionPanel', () => {
             fixture.detectChanges();
             innerElement = fixture.debugElement.queryAll(By.css('.igx-expansion-panel__header-inner'))[0];
             expect(innerElement).toBeDefined();
-            expect(innerElement.nativeElement.attributes['tabindex'].value).toBe('-1');
+            expect(innerElement.nativeElement.attributes['tabindex']).toBeUndefined();
             panelHeader.disabled = false;
             fixture.detectChanges();
             innerElement = fixture.debugElement.queryAll(By.css('.igx-expansion-panel__header-inner'))[0];


### PR DESCRIPTION
Closes #9696

header.disabled was incorrectly setting `tabIndex === -1`, which still allows elements to be focused via mouse click.
No tab index makes the element non-focusable and `pointer-events: none` style prevents flickering.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 