### PR TITLE
Fix scrollbar jump in FireFox when grid needs to autosize (100% height of container that has no size).

### DIFF
--- a/projects/igniteui-angular/src/lib/core/utils.ts
+++ b/projects/igniteui-angular/src/lib/core/utils.ts
@@ -297,7 +297,8 @@ export class PlatformUtil {
     public isFirefox = this.isBrowser && /Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent);
     public isEdge = this.isBrowser && /Edge[\/\s](\d+\.\d+)/.test(navigator.userAgent);
     public isIE = this.isBrowser && navigator.appVersion.indexOf('Trident/') > 0;
-
+    public isChromium = this.isBrowser && (/Chrom|e?ium/g.test(navigator.userAgent) ||
+    /Google Inc/g.test(navigator.vendor)) && !/Edge/g.test(navigator.userAgent);
     constructor(@Inject(PLATFORM_ID) private platformId: any) { }
 }
 

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -33,7 +33,7 @@ import ResizeObserver from 'resize-observer-polyfill';
 import 'igniteui-trial-watermark';
 import { Subject, pipe, fromEvent, noop } from 'rxjs';
 import { takeUntil, first, filter, throttleTime, map, shareReplay } from 'rxjs/operators';
-import { cloneArray, flatten, mergeObjects, isIE, compareMaps, resolveNestedPath, isObject } from '../core/utils';
+import { cloneArray, flatten, mergeObjects, isIE, compareMaps, resolveNestedPath, isObject, PlatformUtil } from '../core/utils';
 import { DataType } from '../data-operations/data-util';
 import { FilteringLogic, IFilteringExpression } from '../data-operations/filtering-expression.interface';
 import { IGroupByRecord } from '../data-operations/groupby-record.interface';
@@ -87,9 +87,7 @@ import {
     GridSelectionRange,
     IgxGridCRUDService,
     IgxRow,
-    IgxCell,
-    isChromium,
-    isFireFox
+    IgxCell
 } from './selection/selection.service';
 import { DragScrollDirection } from './selection/drag-select.directive';
 import { ICachedViewLoadedEventArgs, IgxTemplateOutletDirective } from '../directives/template-outlet/template_outlet.directive';
@@ -157,7 +155,6 @@ import { IgxSnackbarComponent } from '../snackbar/snackbar.component';
 import { v4 as uuidv4 } from 'uuid';
 import { IgxActionStripComponent } from '../action-strip/action-strip.component';
 import { DeprecateProperty } from '../core/deprecateDecorators';
-
 let FAKE_ROW_ID = -1;
 
 const MINIMUM_COLUMN_WIDTH = 136;
@@ -3094,7 +3091,8 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
         @Inject(IgxOverlayService) protected overlayService: IgxOverlayService,
         public summaryService: IgxGridSummaryService,
         @Optional() @Inject(DisplayDensityToken) protected _displayDensityOptions: IDisplayDensityOptions,
-        @Inject(LOCALE_ID) private localeId: string) {
+        @Inject(LOCALE_ID) private localeId: string,
+        public platformUtil: PlatformUtil) {
         super(_displayDensityOptions);
         this.locale = this.locale || this.localeId;
         this.datePipe = new DatePipe(this.locale);
@@ -6687,7 +6685,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
         let res = !this.nativeElement.parentElement ||
             this.nativeElement.parentElement.clientHeight === 0 ||
             this.nativeElement.parentElement.clientHeight === renderedHeight;
-        if (!isChromium() && !isFireFox()) {
+        if (!this.platformUtil.isChromium && !this.platformUtil.isFirefox) {
             // If grid causes the parent container to extend (for example when container is flex)
             // we should always auto-size since the actual size of the container will continuously change as the grid renders elements.
             res = this.checkContainerSizeChange();

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -88,7 +88,8 @@ import {
     IgxGridCRUDService,
     IgxRow,
     IgxCell,
-    isChromium
+    isChromium,
+    isFireFox
 } from './selection/selection.service';
 import { DragScrollDirection } from './selection/drag-select.directive';
 import { ICachedViewLoadedEventArgs, IgxTemplateOutletDirective } from '../directives/template-outlet/template_outlet.directive';
@@ -6686,7 +6687,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
         let res = !this.nativeElement.parentElement ||
             this.nativeElement.parentElement.clientHeight === 0 ||
             this.nativeElement.parentElement.clientHeight === renderedHeight;
-        if (!isChromium()) {
+        if (!isChromium() && !isFireFox()) {
             // If grid causes the parent container to extend (for example when container is flex)
             // we should always auto-size since the actual size of the container will continuously change as the grid renders elements.
             res = this.checkContainerSizeChange();

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid-base.directive.ts
@@ -34,6 +34,7 @@ import { IgxColumnGroupComponent } from '../columns/column-group.component';
 import { IgxColumnComponent } from '../columns/column.component';
 import { IForOfState } from '../../directives/for-of/for_of.directive';
 import { takeUntil } from 'rxjs/operators';
+import { PlatformUtil } from '../../core/utils';
 
 export const hierarchicalTransactionServiceFactory = () => new IgxTransactionService();
 
@@ -158,7 +159,9 @@ export abstract class IgxHierarchicalGridBaseDirective extends IgxGridBaseDirect
         @Inject(IgxOverlayService) protected overlayService: IgxOverlayService,
         public summaryService: IgxGridSummaryService,
         @Optional() @Inject(DisplayDensityToken) protected _displayDensityOptions: IDisplayDensityOptions,
-        @Inject(LOCALE_ID) localeId: string) {
+        @Inject(LOCALE_ID) localeId: string,
+        public platformUtil: PlatformUtil
+        ) {
         super(
             selectionService,
             crudService,
@@ -177,7 +180,8 @@ export abstract class IgxHierarchicalGridBaseDirective extends IgxGridBaseDirect
             overlayService,
             summaryService,
             _displayDensityOptions,
-            localeId);
+            localeId,
+            platformUtil);
         this.hgridAPI = gridAPI as IgxHierarchicalGridAPIService;
     }
 

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/row-island.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/row-island.component.ts
@@ -41,7 +41,7 @@ import { IgxOverlayService } from '../../services/public_api';
 import { first, filter, takeUntil, pluck } from 'rxjs/operators';
 import { IgxColumnComponent } from '../columns/column.component';
 import { IgxRowIslandAPIService } from './row-island-api.service';
-import { IBaseEventArgs } from '../../core/utils';
+import { IBaseEventArgs, PlatformUtil } from '../../core/utils';
 import { IgxColumnResizingService } from '../resizing/resizing.service';
 import { GridType } from '../common/grid.interface';
 import { IgxGridToolbarDirective, IgxGridToolbarTemplateContext } from '../toolbar/common';
@@ -235,7 +235,9 @@ export class IgxRowIslandComponent extends IgxHierarchicalGridBaseDirective
         public summaryService: IgxGridSummaryService,
         @Optional() @Inject(DisplayDensityToken) protected _displayDensityOptions: IDisplayDensityOptions,
         public rowIslandAPI: IgxRowIslandAPIService,
-        @Inject(LOCALE_ID) localeId: string) {
+        @Inject(LOCALE_ID) localeId: string,
+        public platformUtil: PlatformUtil
+        ) {
         super(
             selectionService,
             crudService,
@@ -254,7 +256,8 @@ export class IgxRowIslandComponent extends IgxHierarchicalGridBaseDirective
             overlayService,
             summaryService,
             _displayDensityOptions,
-            localeId
+            localeId,
+            platformUtil
         );
         this.hgridAPI = gridAPI as IgxHierarchicalGridAPIService;
     }

--- a/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
@@ -1084,3 +1084,4 @@ export class IgxGridSelectionService {
 
 export const isChromium = (): boolean => (/Chrom|e?ium/g.test(navigator.userAgent) ||
     /Google Inc/g.test(navigator.vendor)) && !/Edge/g.test(navigator.userAgent);
+export const isFireFox = (): boolean => (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent));

--- a/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
@@ -1,5 +1,6 @@
 import { EventEmitter, Injectable, NgZone } from '@angular/core';
 import { Subject } from 'rxjs';
+import { PlatformUtil } from '../../core/utils';
 import { FilteringExpressionsTree } from '../../data-operations/filtering-expressions-tree';
 import { IGridEditEventArgs, IGridEditDoneEventArgs } from '../common/events';
 import { GridType } from '../common/grid.interface';
@@ -437,7 +438,7 @@ export class IgxGridSelectionService {
         this.pointerState.primaryButton = value;
     }
 
-    constructor(private zone: NgZone) {
+    constructor(private zone: NgZone, protected platform: PlatformUtil) {
         this.initPointerState();
         this.initKeyboardState();
         this.initColumnsState();
@@ -587,7 +588,7 @@ export class IgxGridSelectionService {
 
         // Focus triggered by keyboard navigation
         if (kbState.active) {
-            if (isChromium()) {
+            if (this.platform.isChromium) {
                 this._moveSelectionChrome(dom);
             }
             // Start generating a range if shift is hold
@@ -1081,6 +1082,3 @@ export class IgxGridSelectionService {
         document.body.removeEventListener('pointerup', this.pointerOriginHandler);
     };
 }
-
-export const isChromium = (): boolean => (/Chrom|e?ium/g.test(navigator.userAgent) ||
-    /Google Inc/g.test(navigator.vendor)) && !/Edge/g.test(navigator.userAgent);

--- a/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
@@ -1084,4 +1084,3 @@ export class IgxGridSelectionService {
 
 export const isChromium = (): boolean => (/Chrom|e?ium/g.test(navigator.userAgent) ||
     /Google Inc/g.test(navigator.vendor)) && !/Edge/g.test(navigator.userAgent);
-export const isFireFox = (): boolean => (/Firefox[\/\s](\d+\.\d+)/.test(navigator.userAgent));


### PR DESCRIPTION
…hole grid container in FF causes scrollbar to jump.

Closes #9705   

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 