### PR TITLE
fix(expansion-panel): handle null animation settings - 12.0.x

### DIFF
--- a/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel.spec.ts
+++ b/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel.spec.ts
@@ -191,6 +191,32 @@ describe('igxExpansionPanel', () => {
             expect(panel.onCollapsed.emit).toHaveBeenCalledTimes(1);
         }));
 
+        it('Should expand/collapse without animation when animationSettings === null', fakeAsync(() => {
+            const fixture = TestBed.createComponent(IgxExpansionPanelSampleComponent);
+            fixture.detectChanges();
+            const panel = fixture.componentInstance.panel;
+            panel.animationSettings = null;
+            expect(panel).toBeTruthy();
+
+            spyOn(panel.onCollapsed, 'emit');
+            spyOn(panel.onExpanded, 'emit');
+
+            panel.toggle();
+            tick();
+            fixture.detectChanges();
+            expect(panel.onCollapsed.emit).toHaveBeenCalledTimes(0); // Initially collapsed
+            expect(panel.onExpanded.emit).toHaveBeenCalledTimes(1);
+            expect(panel.collapsed).toBeFalsy();
+
+            panel.toggle();
+            tick();
+            fixture.detectChanges();
+            expect(panel.onCollapsed.emit).toHaveBeenCalledTimes(1);
+            expect(panel.onExpanded.emit).toHaveBeenCalledTimes(1);
+            expect(panel.collapsed).toBeTruthy();
+        }));
+
+
         it('Should NOT assign tabIndex to header when disabled', () => {
             const fixture = TestBed.createComponent(IgxExpansionPanelSampleComponent);
             fixture.detectChanges();

--- a/projects/igniteui-angular/src/lib/expansion-panel/toggle-animation-component.spec.ts
+++ b/projects/igniteui-angular/src/lib/expansion-panel/toggle-animation-component.spec.ts
@@ -2,6 +2,7 @@ import { AnimationBuilder } from '@angular/animations';
 import { TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { noop } from 'rxjs';
+import { growVerIn, growVerOut } from '../animations/main';
 import { configureTestSuite } from '../test-utils/configure-suite';
 import { ToggleAnimationPlayer ,ANIMATION_TYPE } from './toggle-animation-component';
 
@@ -39,6 +40,44 @@ describe('Toggle animation component', () => {
             expect(startPlayerSpy).toHaveBeenCalledWith(ANIMATION_TYPE.OPEN, null, mockCB);
             player.playCloseAnimation(null, mockCB);
             expect(startPlayerSpy).toHaveBeenCalledWith(ANIMATION_TYPE.CLOSE, null, mockCB);
+        });
+
+        it('Should allow overwriting animation setting with falsy value', () => {
+            const player = new MockTogglePlayer(mockBuilder);
+            expect(player.animationSettings).toEqual({
+                openAnimation: growVerIn,
+                closeAnimation: growVerOut
+            });
+            player.animationSettings = null;
+            expect(player.animationSettings).toEqual(null);
+        });
+
+        it('Should not throw if called with a falsy animationSettings value', () => {
+            const player = new MockTogglePlayer(mockBuilder);
+            player.animationSettings = null;
+            const mockCb = jasmine.createSpy('mockCb');
+            const mockElement = jasmine.createSpy('element');
+            spyOn(player.openAnimationStart, 'emit');
+            spyOn(player.openAnimationDone, 'emit');
+            spyOn(player.closeAnimationStart, 'emit');
+            spyOn(player.closeAnimationDone, 'emit');
+
+            player.playOpenAnimation({ nativeElement: mockElement }, mockCb);
+            expect(player.openAnimationStart.emit).toHaveBeenCalledTimes(1);
+            expect(player.openAnimationDone.emit).toHaveBeenCalledTimes(1);
+            expect(player.closeAnimationStart.emit).toHaveBeenCalledTimes(0);
+            expect(player.closeAnimationDone.emit).toHaveBeenCalledTimes(0);
+            expect(player.openAnimationStart.emit).toHaveBeenCalledBefore(player.openAnimationDone.emit);
+            expect(mockCb).toHaveBeenCalledTimes(1);
+
+            player.playCloseAnimation({ nativeElement: mockElement }, mockCb);
+            expect(player.openAnimationStart.emit).toHaveBeenCalledTimes(1);
+            expect(player.openAnimationDone.emit).toHaveBeenCalledTimes(1);
+            expect(player.closeAnimationStart.emit).toHaveBeenCalledTimes(1);
+            expect(player.closeAnimationDone.emit).toHaveBeenCalledTimes(1);
+            expect(player.closeAnimationStart.emit).toHaveBeenCalledBefore(player.closeAnimationDone.emit);
+
+            expect(mockCb).toHaveBeenCalledTimes(2);
         });
     });
 });


### PR DESCRIPTION
Closes #9783 

Setting `animationSettings = null` will be handled the same as `animationSettings = { openAnimation: null, closeAnimation: null }`.
Toggling the panel w/ `animationSettings === null` will expand / collapse it instantly, w/o animating.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 