### PR TITLE
fix(expansion-panel): handle null animation settings - 11.1.x

### DIFF
--- a/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel.component.ts
+++ b/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel.component.ts
@@ -253,7 +253,13 @@ export class IgxExpansionPanelComponent implements IgxExpansionPanelBase, AfterC
         if (!this.body) { // if not body element is passed, there is nothing to animate
             return;
         }
-        const animation = useAnimation(this.animationSettings.openAnimation);
+
+        const targetAnimationSettings = this.animationSettings || { openAnimation: null, closeAnimation: null };
+        if (!targetAnimationSettings.openAnimation) {
+            cb();
+            return;
+        }
+        const animation = useAnimation(targetAnimationSettings.openAnimation);
         const animationBuilder = this.builder.build(animation);
         const openAnimationPlayer = animationBuilder.create(this.body.element.nativeElement);
 
@@ -269,7 +275,12 @@ export class IgxExpansionPanelComponent implements IgxExpansionPanelBase, AfterC
         if (!this.body) { // if not body element is passed, there is nothing to animate
             return;
         }
-        const animation = useAnimation(this.animationSettings.closeAnimation);
+        const targetAnimationSettings = this.animationSettings || { openAnimation: null, closeAnimation: null };
+        if (!targetAnimationSettings.closeAnimation) {
+            cb();
+            return;
+        }
+        const animation = useAnimation(targetAnimationSettings.closeAnimation);
         const animationBuilder = this.builder.build(animation);
         const closeAnimationPlayer = animationBuilder.create(this.body.element.nativeElement);
         closeAnimationPlayer.onDone(() => {

--- a/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel.spec.ts
+++ b/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel.spec.ts
@@ -211,6 +211,31 @@ describe('igxExpansionPanel', () => {
             expect(innerElement).toBeDefined();
             expect(innerElement.nativeElement.attributes['tabindex'].value).toBe('0');
         });
+
+        it('Should expand/collapse without animation when animationSettings === null', fakeAsync(() => {
+            const fixture = TestBed.createComponent(IgxExpansionPanelSampleComponent);
+            fixture.detectChanges();
+            const panel = fixture.componentInstance.panel;
+            panel.animationSettings = null;
+            expect(panel).toBeTruthy();
+
+            spyOn(panel.onCollapsed, 'emit');
+            spyOn(panel.onExpanded, 'emit');
+
+            panel.toggle();
+            tick();
+            fixture.detectChanges();
+            expect(panel.onCollapsed.emit).toHaveBeenCalledTimes(0); // Initially collapsed
+            expect(panel.onExpanded.emit).toHaveBeenCalledTimes(1);
+            expect(panel.collapsed).toBeFalsy();
+
+            panel.toggle();
+            tick();
+            fixture.detectChanges();
+            expect(panel.onCollapsed.emit).toHaveBeenCalledTimes(1);
+            expect(panel.onExpanded.emit).toHaveBeenCalledTimes(1);
+            expect(panel.collapsed).toBeTruthy();
+        }));
     });
 
     describe('Expansion tests: ', () => {


### PR DESCRIPTION
Closes #9783

Setting `animationSettings = null` will be handled the same as `animationSettings = { openAnimation: null, closeAnimation: null }`.
Toggling the panel w/ `animationSettings === null` will expand / collapse it instantly, w/o animating. 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 