### PR TITLE
fix(list): reset pan state and list item position on pancancel event - 12.0.x

### DIFF
--- a/projects/igniteui-angular/src/lib/list/list-item.component.ts
+++ b/projects/igniteui-angular/src/lib/list/list-item.component.ts
@@ -324,6 +324,16 @@ export class IgxListItemComponent implements IListChild {
     /**
      * @hidden
      */
+    @HostListener('pancancel')
+    public pancancel() {
+        this.setContentElementLeft(0);
+        this._panState = IgxListPanState.NONE;
+        this.hideLeftAndRightPanTemplates();
+    }
+
+    /**
+     * @hidden
+     */
     @HostListener('panmove', ['$event'])
     public panMove(ev) {
         if (this.isTrue(this.isHeader)) {

--- a/projects/igniteui-angular/src/lib/list/list.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/list/list.component.spec.ts
@@ -594,6 +594,44 @@ describe('List', () => {
         expect(rightPanTmpl.nativeElement.style.visibility).toBe('hidden');
     }));
 
+    it('cancel left panning', fakeAsync(() => {
+        const fixture = TestBed.createComponent(ListWithPanningTemplatesComponent);
+        const list = fixture.componentInstance.list;
+        fixture.detectChanges();
+
+        const firstItem = list.items[0] as IgxListItemComponent;
+        const leftPanTmpl = firstItem.leftPanningTemplateElement;
+        const rightPanTmpl = firstItem.rightPanningTemplateElement;
+        const itemNativeElements = fixture.debugElement.queryAll(By.css('igx-list-item'));
+
+        /* Pan item left */
+        cancelItemPanning(itemNativeElements[1], -2, -8);
+        tick(600);
+
+        expect(firstItem.panState).toBe(IgxListPanState.NONE);
+        expect(leftPanTmpl.nativeElement.style.visibility).toBe('hidden');
+        expect(rightPanTmpl.nativeElement.style.visibility).toBe('hidden');
+    }));
+
+    it('cancel right panning', fakeAsync(() => {
+        const fixture = TestBed.createComponent(ListWithPanningTemplatesComponent);
+        const list = fixture.componentInstance.list;
+        fixture.detectChanges();
+
+        const firstItem = list.items[0] as IgxListItemComponent;
+        const leftPanTmpl = firstItem.leftPanningTemplateElement;
+        const rightPanTmpl = firstItem.rightPanningTemplateElement;
+        const itemNativeElements = fixture.debugElement.queryAll(By.css('igx-list-item'));
+
+        /* Pan item right */
+        cancelItemPanning(itemNativeElements[1], 2, 8);
+        tick(600);
+
+        expect(firstItem.panState).toBe(IgxListPanState.NONE);
+        expect(leftPanTmpl.nativeElement.style.visibility).toBe('hidden');
+        expect(rightPanTmpl.nativeElement.style.visibility).toBe('hidden');
+    }));
+
     it('checking the header list item does not have panning and content containers.', () => {
         const fixture = TestBed.createComponent(ListWithPanningTemplatesComponent);
         const list = fixture.componentInstance.list;
@@ -816,6 +854,19 @@ describe('List', () => {
         itemNativeElement.triggerEventHandler('panmove', {
             deltaX: factorX * itemWidth, duration: 200
         });
+    };
+
+    const cancelItemPanning = (itemNativeElement, factorX, factorY) => {
+        itemNativeElement.triggerEventHandler('panstart', {
+            deltaX: factorX
+        });
+        itemNativeElement.triggerEventHandler('panmove', {
+            deltaX: factorX,
+            deltaY: factorY,
+            additionalEvent: 'panup'
+        });
+
+        itemNativeElement.triggerEventHandler('pancancel', null);
     };
 
     const clickItem = (currentItem: IgxListItemComponent) => Promise.resolve(currentItem.element.click());


### PR DESCRIPTION
Closes #9105 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 