### PR TITLE
feat(combo): add selectionMode input, #9832

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ All notable changes for each version of this project will be documented in this 
 - `IgxDateTimeEditor`, `IgxMask`, `IgxDatePicker`, `IgxTimePicker`, `IgxDateRangePicker`
     - Added IME input support. When typing in an Asian language input, the control will display input method compositions and candidate lists directly in the control’s editing area, and immediately re-flow surrounding text as the composition ends.
 
+- `IgxCombo`
+    - Added `selectionMode` `@Input`. Allows to specify whether the selection mode should be 'multiple' (default, current behavior) or 'single' (allowing only one item to be selected).
+    ```html
+    <igx-combo #single [data]="myData" selectionMode="single">
+        ...
+    </igx-combo>
+    ``` 
+
 ### General
 - `IgxGridComponent`
     - The following properties are deprecated:

--- a/projects/igniteui-angular/src/lib/combo/README.md
+++ b/projects/igniteui-angular/src/lib/combo/README.md
@@ -301,6 +301,7 @@ Setting `[displayDensity]` affects the control's items' and inputs' css properti
 |  `id`                    | combo id                                          | string                      |
 |  `data`                  | combo data source                                 | any                         |
 |  `allowCustomValue`      | enables/disables combo custom value                | boolean                     |
+|  `selectionMode`         | specified whether the combo allows single or multiple selection | string ('multiple' | 'single' ) | 
 |  `filterable`            | enables/disables combo drop down filtering - enabled by default                  | boolean                     |
 |  `showSearchCaseIcon`          | defines whether the search case-sensitive icon should be displayed - disabled by default| boolean                     |
 |  `valueKey`              | combo value data source property                  | string                      |


### PR DESCRIPTION
Closes #9832 

Add an input to the combo that allows toggling between selection modes (single / multiple)

### Additional information (check all that apply):
 - [ ] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [x] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [x] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [x] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 