### PR TITLE
Fix failing tests

### DIFF
--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -3976,15 +3976,13 @@ describe('igxOverlay', () => {
             expect(overlay.show).toHaveBeenCalledTimes(1);
             expect(overlay.closing.emit).toHaveBeenCalledTimes(0);
 
-            fixture.componentInstance.buttonElement.nativeElement.click();
+            document.documentElement.click();
             tick();
-            // TODO
-            // expect(overlay.closing.emit).toHaveBeenCalledTimes(1);
-            //     .toHaveBeenCalledWith(
-            //     {
-            //         id: firstCallId, componentRef: jasmine.any(ComponentRef) as any, cancel: false,
-            //         event: new MouseEvent('click')
-            //     }
+            expect(overlay.closing.emit).toHaveBeenCalledTimes(1);
+            expect(overlay.closing.emit).toHaveBeenCalledWith({
+                id: firstCallId, componentRef: jasmine.any(ComponentRef) as any, cancel: false,
+                event: new PointerEvent('click')
+            });
         }));
 
         it('Should remain opened when click is on an element contained in the excludeFromOutsideClick collection', fakeAsync(async () => {
@@ -4004,7 +4002,8 @@ describe('igxOverlay', () => {
             spyOn(overlay.closing, 'emit');
             spyOn(overlay.closed, 'emit');
 
-            overlay.show(overlay.attach(SimpleDynamicComponent), overlaySettings);
+            let callId = overlay.attach(SimpleDynamicComponent, overlaySettings);
+            overlay.show(callId);
             tick();
             expect(overlay.show).toHaveBeenCalledTimes(1);
 
@@ -4018,10 +4017,16 @@ describe('igxOverlay', () => {
             tick();
             expect(overlay.closing.emit).toHaveBeenCalledTimes(1);
             expect(overlay.closed.emit).toHaveBeenCalledTimes(1);
+            expect(overlay.closing.emit)
+            .toHaveBeenCalledWith({
+                id: callId, componentRef: jasmine.any(ComponentRef) as any, cancel: false,
+                event: undefined
+            });
+            overlay.detachAll();
 
             overlaySettings.excludeFromOutsideClick = [];
             tick();
-            const callId = overlay.attach(SimpleDynamicComponent, overlaySettings);
+            callId = overlay.attach(SimpleDynamicComponent, overlaySettings);
             overlay.show(callId);
             tick();
 
@@ -4031,11 +4036,11 @@ describe('igxOverlay', () => {
 
             expect(overlay.closing.emit).toHaveBeenCalledTimes(2);
             expect(overlay.closed.emit).toHaveBeenCalledTimes(2);
-            // expect(overlay.closing.emit)
-            //     .toHaveBeenCalledWith({
-            //         id: callId, componentRef: jasmine.any(ComponentRef) as any, cancel: false,
-            //         event: new MouseEvent('click')
-            //     });
+            expect(overlay.closing.emit)
+            .toHaveBeenCalledWith({
+                id: callId, componentRef: jasmine.any(ComponentRef) as any, cancel: false,
+                event: new PointerEvent('click')
+            });
         }));
     });
 

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -3948,7 +3948,6 @@ describe('igxOverlay', () => {
         }));
 
         it('Should collapse/close the component when click outside it (DropDown, DatePicker, NavBar etc.)', fakeAsync(async () => {
-            // TO DO replace Spies with css class and/or getBoundingClientRect.
             TestBed.overrideComponent(EmptyPageComponent, {
                 set: {
                     styles: [
@@ -3980,8 +3979,10 @@ describe('igxOverlay', () => {
             tick();
             expect(overlay.closing.emit).toHaveBeenCalledTimes(1);
             expect(overlay.closing.emit).toHaveBeenCalledWith({
-                id: firstCallId, componentRef: jasmine.any(ComponentRef) as any, cancel: false,
-                event: new PointerEvent('click')
+                id: firstCallId,
+                componentRef: jasmine.any(ComponentRef) as any,
+                cancel: false,
+                event: jasmine.any(Event) as any
             });
         }));
 
@@ -4019,7 +4020,9 @@ describe('igxOverlay', () => {
             expect(overlay.closed.emit).toHaveBeenCalledTimes(1);
             expect(overlay.closing.emit)
             .toHaveBeenCalledWith({
-                id: callId, componentRef: jasmine.any(ComponentRef) as any, cancel: false,
+                id: callId,
+                componentRef: jasmine.any(ComponentRef) as any,
+                cancel: false,
                 event: undefined
             });
             overlay.detachAll();
@@ -4038,8 +4041,10 @@ describe('igxOverlay', () => {
             expect(overlay.closed.emit).toHaveBeenCalledTimes(2);
             expect(overlay.closing.emit)
             .toHaveBeenCalledWith({
-                id: callId, componentRef: jasmine.any(ComponentRef) as any, cancel: false,
-                event: new PointerEvent('click')
+                id: callId,
+                componentRef: jasmine.any(ComponentRef) as any,
+                cancel: false,
+                event: jasmine.any(Event) as any
             });
         }));
     });


### PR DESCRIPTION
Calling `click` over an element used to be called with `mouseEvent`, but now is called with `pointerEvent`.

Closes #9948   

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [x] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 