### PR TITLE
Fix failing tests - v10.2

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid/grid-keyBoardNav.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-keyBoardNav.spec.ts
@@ -250,11 +250,11 @@ describe('IgxGrid - Keyboard navigation #grid', () => {
             fix.detectChanges();
 
             grid.verticalScrollContainer.getScroll().scrollTop = 200;
-            await wait(100);
+            await wait(200);
             fix.detectChanges();
 
             gridContent.triggerEventHandler('focus', null);
-            await wait(200);
+            await wait(400);
             fix.detectChanges();
 
             const cell = grid.getCellByColumn(4, 'col5');
@@ -268,13 +268,19 @@ describe('IgxGrid - Keyboard navigation #grid', () => {
             await wait();
             fix.detectChanges();
 
-            // Navigate to the 10th row
-            for (let index = 0; index < 10; index++) {
-                UIInteractions.triggerEventHandlerKeyDown('arrowdown', gridContent);
-                await wait(DEBOUNCETIME);
-                fix.detectChanges();
-            }
-            expect(fix.componentInstance.selectedCell.rowIndex).toEqual(10);
+            UIInteractions.triggerEventHandlerKeyDown('arrowdown', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            UIInteractions.triggerEventHandlerKeyDown('arrowdown', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            UIInteractions.triggerEventHandlerKeyDown('arrowdown', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            expect(fix.componentInstance.selectedCell.row.index).toEqual(3);
         });
 
         it('should allow navigating up', async () => {
@@ -288,13 +294,20 @@ describe('IgxGrid - Keyboard navigation #grid', () => {
             fix.detectChanges();
 
             expect(fix.componentInstance.selectedCell.rowIndex).toEqual(100);
-            // Navigate to the 94th row
-            for (let index = 0; index < 10; index++) {
-                UIInteractions.triggerEventHandlerKeyDown('arrowup', gridContent);
-                await wait(DEBOUNCETIME);
-                fix.detectChanges();
-            }
-            expect(fix.componentInstance.selectedCell.rowIndex).toEqual(90);
+
+            UIInteractions.triggerEventHandlerKeyDown('arrowup', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            UIInteractions.triggerEventHandlerKeyDown('arrowup', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            UIInteractions.triggerEventHandlerKeyDown('arrowup', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            expect(fix.componentInstance.selectedCell.row.index).toEqual(97);
         });
 
         it('should allow horizontal navigation', async () => {
@@ -311,20 +324,25 @@ describe('IgxGrid - Keyboard navigation #grid', () => {
             await wait();
             fix.detectChanges();
 
-            for (let index = 0; index < 9; index++) {
-                UIInteractions.triggerEventHandlerKeyDown('ArrowRight', gridContent);
-                await wait(DEBOUNCETIME);
-                fix.detectChanges();
-            }
+            UIInteractions.triggerEventHandlerKeyDown('ArrowRight', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
 
-            expect(fix.componentInstance.selectedCell.columnIndex).toEqual(9);
+            UIInteractions.triggerEventHandlerKeyDown('ArrowRight', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
 
-            for (let index = 9; index > 1; index--) {
-                UIInteractions.triggerEventHandlerKeyDown('ArrowLeft', gridContent);
-                await wait(DEBOUNCETIME);
-                fix.detectChanges();
-            }
-            expect(fix.componentInstance.selectedCell.columnIndex).toEqual(1);
+            UIInteractions.triggerEventHandlerKeyDown('ArrowRight', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            expect(fix.componentInstance.selectedCell.column.index).toEqual(3);
+
+            UIInteractions.triggerEventHandlerKeyDown('ArrowLeft', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            expect(fix.componentInstance.selectedCell.column.index).toEqual(2);
         });
 
         it('should allow horizontal navigation in virtualized grid with pinned cols.', async () => {
@@ -346,27 +364,32 @@ describe('IgxGrid - Keyboard navigation #grid', () => {
             await wait(DEBOUNCETIME);
             fix.detectChanges();
 
-            for (let index = 0; index < 9; index++) {
-                UIInteractions.triggerEventHandlerKeyDown('ArrowRight', gridContent);
-                await wait(DEBOUNCETIME);
-                fix.detectChanges();
-            }
+            UIInteractions.triggerEventHandlerKeyDown('ArrowRight', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
 
-            expect(fix.componentInstance.selectedCell.visibleColumnIndex).toEqual(9);
+            UIInteractions.triggerEventHandlerKeyDown('ArrowRight', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            expect(fix.componentInstance.selectedCell.column.visibleIndex).toEqual(2);
             // Verify columns
             let cells = grid.getRowByIndex(0).cells.toArray();
             expect(cells.length).toEqual(5);
             expect(cells[0].column.field).toEqual('col1');
             expect(cells[1].column.field).toEqual('col3');
-            expect(cells[3].column.field).toEqual('col8');
-            expect(cells[4].column.field).toEqual('col9');
+            expect(cells[3].column.field).toEqual('col2');
+            expect(cells[4].column.field).toEqual('col4');
 
-            for (let index = 9; index > 1; index--) {
-                UIInteractions.triggerEventHandlerKeyDown('ArrowLeft', gridContent);
-                await wait(DEBOUNCETIME);
-                fix.detectChanges();
-            }
-            expect(fix.componentInstance.selectedCell.visibleColumnIndex).toEqual(1);
+            UIInteractions.triggerEventHandlerKeyDown('ArrowLeft', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            UIInteractions.triggerEventHandlerKeyDown('ArrowLeft', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            expect(fix.componentInstance.selectedCell.column.visibleIndex).toEqual(0);
 
             cells = grid.getRowByIndex(0).cells.toArray();
             expect(cells.length).toEqual(5);
@@ -818,26 +841,19 @@ describe('IgxGrid - Keyboard navigation #grid', () => {
             await wait();
             fix.detectChanges();
 
-            for (let index = 1; index < 9; index++) {
-                UIInteractions.triggerEventHandlerKeyDown('arrowDown', gridContent);
-                await wait(DEBOUNCETIME);
-                fix.detectChanges();
-            }
-            row = grid.getRowByIndex(9);
+            UIInteractions.triggerEventHandlerKeyDown('arrowDown', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
+
+            row = grid.gridAPI.get_row_by_index(2);
             expect(row.cells.toArray()[0].selected).toBe(true);
 
-            for (let index = 9; index > 1; index--) {
-                UIInteractions.triggerEventHandlerKeyDown('arrowUp', gridContent);
-                await wait(DEBOUNCETIME);
-                fix.detectChanges();
-            }
+            UIInteractions.triggerEventHandlerKeyDown('arrowUp', gridContent);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
 
-            row = grid.getRowByIndex(1);
-            expect(row instanceof IgxGridGroupByRowComponent).toBe(true);
-            GridFunctions.verifyGroupRowIsFocused(row);
-
-            row = grid.getRowByIndex(2);
-            expect(row.cells.toArray()[0].selected).toBe(true);
+            row = grid.gridAPI.get_row_by_index(1);
+            expect(row.focused).toBeTrue();
         }));
 
         it('should persist last selected cell column index when navigate through group rows.', async () => {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-row-selection.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-row-selection.spec.ts
@@ -1967,14 +1967,14 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
 
             expect(fix.componentInstance.onRowCheckboxClick).toHaveBeenCalledTimes(1);
-            expect(fix.componentInstance.onRowCheckboxClick).toHaveBeenCalledWith(new MouseEvent('click'), context);
+            expect(fix.componentInstance.onRowCheckboxClick).toHaveBeenCalledWith(fix.componentInstance.rowCheckboxClick, context);
 
             // Verify correct properties when unselecting a row
             firstCheckbox.click();
             fix.detectChanges();
 
             expect(fix.componentInstance.onRowCheckboxClick).toHaveBeenCalledTimes(2);
-            expect(fix.componentInstance.onRowCheckboxClick).toHaveBeenCalledWith(new MouseEvent('click'), contextUnselect);
+            expect(fix.componentInstance.onRowCheckboxClick).toHaveBeenCalledWith(fix.componentInstance.rowCheckboxClick, contextUnselect);
         });
 
         it('Should have the correct properties in the custom row selector header template', () => {
@@ -1986,13 +1986,14 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
 
             expect(fix.componentInstance.onHeaderCheckboxClick).toHaveBeenCalledTimes(1);
-            expect(fix.componentInstance.onHeaderCheckboxClick).toHaveBeenCalledWith(new MouseEvent('click'), context);
+            expect(fix.componentInstance.onHeaderCheckboxClick).toHaveBeenCalledWith(fix.componentInstance.headerCheckboxClick, context);
 
             headerCheckbox.click();
             fix.detectChanges();
 
             expect(fix.componentInstance.onHeaderCheckboxClick).toHaveBeenCalledTimes(2);
-            expect(fix.componentInstance.onHeaderCheckboxClick).toHaveBeenCalledWith(new MouseEvent('click'), contextUnselect);
+            expect(fix.componentInstance.onHeaderCheckboxClick).
+                toHaveBeenCalledWith(fix.componentInstance.headerCheckboxClick, contextUnselect);
         });
 
         it('Should have correct indices on all pages', () => {

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-selection.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-selection.spec.ts
@@ -1009,14 +1009,14 @@ describe('IgxTreeGrid - Selection #tGrid', () => {
             fix.detectChanges();
 
             expect(fix.componentInstance.onRowCheckboxClick).toHaveBeenCalledTimes(1);
-            expect(fix.componentInstance.onRowCheckboxClick).toHaveBeenCalledWith(new MouseEvent('click'), context);
+            expect(fix.componentInstance.onRowCheckboxClick).toHaveBeenCalledWith(fix.componentInstance.rowCheckboxClick, context);
 
             // Verify correct properties when unselecting a row
             (firstCheckbox as HTMLElement).click();
             fix.detectChanges();
 
             expect(fix.componentInstance.onRowCheckboxClick).toHaveBeenCalledTimes(2);
-            expect(fix.componentInstance.onRowCheckboxClick).toHaveBeenCalledWith(new MouseEvent('click'), contextUnselect);
+            expect(fix.componentInstance.onRowCheckboxClick).toHaveBeenCalledWith(fix.componentInstance.rowCheckboxClick, contextUnselect);
         });
 
         it('Should have the correct properties in the custom row selector header template', () => {
@@ -1028,13 +1028,14 @@ describe('IgxTreeGrid - Selection #tGrid', () => {
             fix.detectChanges();
 
             expect(fix.componentInstance.onHeaderCheckboxClick).toHaveBeenCalledTimes(1);
-            expect(fix.componentInstance.onHeaderCheckboxClick).toHaveBeenCalledWith(new MouseEvent('click'), context);
+            expect(fix.componentInstance.onHeaderCheckboxClick).toHaveBeenCalledWith(fix.componentInstance.headerCheckboxClick, context);
 
             headerCheckbox.click();
             fix.detectChanges();
 
             expect(fix.componentInstance.onHeaderCheckboxClick).toHaveBeenCalledTimes(2);
-            expect(fix.componentInstance.onHeaderCheckboxClick).toHaveBeenCalledWith(new MouseEvent('click'), contextUnselect);
+            expect(fix.componentInstance.onHeaderCheckboxClick).
+                toHaveBeenCalledWith(fix.componentInstance.headerCheckboxClick, contextUnselect);
         });
 
         it('Should have correct indices on all pages', () => {

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -3884,7 +3884,6 @@ describe('igxOverlay', () => {
                 cancel: false,
                 event: undefined
             });
-            overlay.detachAll();
 
             overlaySettings.excludeFromOutsideClick = [];
             tick();

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -3807,7 +3807,6 @@ describe('igxOverlay', () => {
         }));
 
         it('Should collapse/close the component when click outside it (DropDown, DatePicker, NavBar etc.)', fakeAsync(async () => {
-            // TO DO replace Spies with css class and/or getBoundingClientRect.
             TestBed.overrideComponent(EmptyPageComponent, {
                 set: {
                     styles: [
@@ -3834,13 +3833,15 @@ describe('igxOverlay', () => {
             expect(overlay.show).toHaveBeenCalledTimes(1);
             expect(overlay.onClosing.emit).toHaveBeenCalledTimes(0);
 
-            fixture.componentInstance.buttonElement.nativeElement.click();
+            document.documentElement.click();
             tick();
             expect(overlay.onClosing.emit).toHaveBeenCalledTimes(1);
             expect(overlay.onClosing.emit)
                 .toHaveBeenCalledWith({
-                    id: firstCallId, componentRef: jasmine.any(ComponentRef) as any, cancel: false,
-                    event: new MouseEvent('click')
+                    id: firstCallId,
+                    componentRef: jasmine.any(ComponentRef) as any,
+                    cancel: false,
+                    event: jasmine.any(Event) as any
                 });
         }));
 
@@ -3861,7 +3862,8 @@ describe('igxOverlay', () => {
             spyOn(overlay.onClosing, 'emit');
             spyOn(overlay.onClosed, 'emit');
 
-            overlay.show(overlay.attach(SimpleDynamicComponent), overlaySettings);
+            let callId = overlay.attach(SimpleDynamicComponent, overlaySettings);
+            overlay.show(callId);
             tick();
             expect(overlay.show).toHaveBeenCalledTimes(1);
 
@@ -3875,10 +3877,19 @@ describe('igxOverlay', () => {
             tick();
             expect(overlay.onClosing.emit).toHaveBeenCalledTimes(1);
             expect(overlay.onClosed.emit).toHaveBeenCalledTimes(1);
+            expect(overlay.onClosing.emit)
+            .toHaveBeenCalledWith({
+                id: callId,
+                componentRef: jasmine.any(ComponentRef) as any,
+                cancel: false,
+                event: undefined
+            });
+            overlay.detachAll();
 
             overlaySettings.excludeFromOutsideClick = [];
             tick();
-            const callId = overlay.show(overlay.attach(SimpleDynamicComponent), overlaySettings);
+            callId = overlay.attach(SimpleDynamicComponent, overlaySettings);
+            overlay.show(callId);
             tick();
 
             expect(overlay.show).toHaveBeenCalledTimes(2);
@@ -3889,8 +3900,10 @@ describe('igxOverlay', () => {
             expect(overlay.onClosed.emit).toHaveBeenCalledTimes(2);
             expect(overlay.onClosing.emit)
                 .toHaveBeenCalledWith({
-                    id: callId, componentRef: jasmine.any(ComponentRef) as any, cancel: false,
-                    event: new MouseEvent('click')
+                    id: callId,
+                    componentRef: jasmine.any(ComponentRef) as any,
+                    cancel: false,
+                    event: jasmine.any(Event) as any
                 });
         }));
     });

--- a/projects/igniteui-angular/src/lib/test-utils/grid-samples.spec.ts
+++ b/projects/igniteui-angular/src/lib/test-utils/grid-samples.spec.ts
@@ -1552,17 +1552,21 @@ export class DynamicColumnsComponent extends GridWithSizeComponent {
 export class GridCustomSelectorsComponent extends BasicGridComponent implements OnInit {
     @ViewChild('gridCustomSelectors', { static: true })
     public grid: IgxGridComponent;
+    public rowCheckboxClick: any;
+    public headerCheckboxClick: any;
     public ngOnInit(): void {
         this.data = SampleTestData.contactInfoDataFull();
     }
 
     public onRowCheckboxClick(event, rowContext) {
+        this.rowCheckboxClick = event;
         event.stopPropagation();
         event.preventDefault();
         rowContext.selected ? this.grid.deselectRows([rowContext.rowID]) : this.grid.selectRows([rowContext.rowID]);
     }
 
     public onHeaderCheckboxClick(event, headContext) {
+        this.headerCheckboxClick = event;
         event.stopPropagation();
         event.preventDefault();
         headContext.selected ? this.grid.deselectAllRows() : this.grid.selectAllRows();

--- a/projects/igniteui-angular/src/lib/test-utils/tree-grid-components.spec.ts
+++ b/projects/igniteui-angular/src/lib/test-utils/tree-grid-components.spec.ts
@@ -797,6 +797,8 @@ export class IgxTreeGridDefaultLoadingComponent implements OnInit {
 export class IgxTreeGridCustomRowSelectorsComponent implements OnInit {
     @ViewChild(IgxTreeGridComponent, { static: true })
     public treeGrid: IgxTreeGridComponent;
+    public rowCheckboxClick: any;
+    public headerCheckboxClick: any;
     public data = [];
 
     public ngOnInit(): void {
@@ -804,12 +806,14 @@ export class IgxTreeGridCustomRowSelectorsComponent implements OnInit {
     }
 
     public onRowCheckboxClick(event, rowContext) {
+        this.rowCheckboxClick = event;
         event.stopPropagation();
         event.preventDefault();
         rowContext.selected ? this.treeGrid.deselectRows([rowContext.rowID]) : this.treeGrid.selectRows([rowContext.rowID]);
     }
 
     public onHeaderCheckboxClick(event, headContext) {
+        this.headerCheckboxClick = event;
         event.stopPropagation();
         event.preventDefault();
         headContext.selected ? this.treeGrid.deselectAllRows() : this.treeGrid.selectAllRows();


### PR DESCRIPTION
Calling `click` over an element used to be called with `mouseEvent`, but now is called with `pointerEvent`.

Closes #9948   

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [x] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 