### PR TITLE
fix(migrations): migrate GridPagingMode via members.json

### DIFF
--- a/projects/igniteui-angular/migrations/common/UpdateChanges.ts
+++ b/projects/igniteui-angular/migrations/common/UpdateChanges.ts
@@ -196,7 +196,8 @@ export class UpdateChanges {
         this.valueTransforms.set(functionName, callback);
     }
 
-    public getDefaultLanguageService(entryPath: string): tss.LanguageService | undefined {
+    /** Path must be absolute. If calling externally, use this.getAbsolutePath */
+    protected getDefaultLanguageService(entryPath: string): tss.LanguageService | undefined {
         const project = this.getDefaultProjectForFile(entryPath);
         return project.getLanguageService();
     }

--- a/projects/igniteui-angular/migrations/common/tsUtils.ts
+++ b/projects/igniteui-angular/migrations/common/tsUtils.ts
@@ -247,7 +247,7 @@ const getTypeDefinitions = (langServ: tss.LanguageService, entryPath: string, po
  * Get type information about a TypeScript identifier
  *
  * @param langServ TypeScript/Angular LanguageService
- * @param entryPath path to file
+ * @param entryPath path to file (absolute)
  * @param position Index of identifier
  */
 export const getTypeDefinitionAtPosition =

--- a/projects/igniteui-angular/migrations/update-11_1_0/changes/members.json
+++ b/projects/igniteui-angular/migrations/update-11_1_0/changes/members.json
@@ -363,6 +363,20 @@
             "definedIn": [
                 "IgxTooltipTargetDirective"
             ]
+        },
+        {
+            "member": "remote",
+            "replaceWith": "Remote",
+            "definedIn": [
+                "GridPagingMode"
+            ]
+        },
+        {
+            "member": "local",
+            "replaceWith": "Local",
+            "definedIn": [
+                "GridPagingMode"
+            ]
         }
     ]
 }

--- a/projects/igniteui-angular/migrations/update-11_1_0/index.spec.ts
+++ b/projects/igniteui-angular/migrations/update-11_1_0/index.spec.ts
@@ -762,9 +762,9 @@ import { GridPagingMode } from "igniteui-angular";
     styleUrls: ["./paging-test.component.scss"],
     templateUrl: "./paging-test.component.html"
 })
-export class CsvExportComponent {
-    public pagingLocal: GridPagingMode = GridPagingMode.local;
-    public pagingRemote: GridPagingMode = GridPagingMode.remote;
+export class PagingComponent {
+    public pagingLocal: GridPagingMode = GridPagingMode.Local;
+    public pagingRemote: GridPagingMode = GridPagingMode.Remote;
     constructor(){}
 }
 `);
@@ -782,7 +782,7 @@ import { GridPagingMode } from "igniteui-angular";
     styleUrls: ["./paging-test.component.scss"],
     templateUrl: "./paging-test.component.html"
 })
-export class CsvExportComponent {
+export class PagingComponent {
     public pagingLocal: GridPagingMode = GridPagingMode.local;
     public pagingRemote: GridPagingMode = GridPagingMode.remote;
     constructor(){}
@@ -790,7 +790,7 @@ export class CsvExportComponent {
 `;
         expect(
             tree.readContent(
-                '/testSrc/appPrefix/component/csv-export.component.ts'
+                '/testSrc/appPrefix/component/paging-test.component.ts'
             )
         ).toEqual(expectedContent);
     });

--- a/projects/igniteui-angular/migrations/update-11_1_0/index.spec.ts
+++ b/projects/igniteui-angular/migrations/update-11_1_0/index.spec.ts
@@ -749,4 +749,49 @@ export class CsvExportComponent {
             )
         ).toEqual(expectedContent);
     });
+
+    it('should update GridPagingMode enum from lowerCase to TitleCase', async () => {
+        pending('set up tests for migrations through lang service');
+        appTree.create(
+            '/testSrc/appPrefix/component/paging-test.component.ts',
+`import { Component } from '@angular/core';
+import { GridPagingMode } from "igniteui-angular";
+
+@Component({
+    selector: "app-paging-test",
+    styleUrls: ["./paging-test.component.scss"],
+    templateUrl: "./paging-test.component.html"
+})
+export class CsvExportComponent {
+    public pagingLocal: GridPagingMode = GridPagingMode.local;
+    public pagingRemote: GridPagingMode = GridPagingMode.remote;
+    constructor(){}
+}
+`);
+
+        const tree = await runner
+            .runSchematicAsync('migration-19', {}, appTree)
+            .toPromise();
+
+        const expectedContent =
+`import { Component } from '@angular/core';
+import { GridPagingMode } from "igniteui-angular";
+
+@Component({
+    selector: "app-paging-test",
+    styleUrls: ["./paging-test.component.scss"],
+    templateUrl: "./paging-test.component.html"
+})
+export class CsvExportComponent {
+    public pagingLocal: GridPagingMode = GridPagingMode.local;
+    public pagingRemote: GridPagingMode = GridPagingMode.remote;
+    constructor(){}
+}
+`;
+        expect(
+            tree.readContent(
+                '/testSrc/appPrefix/component/csv-export.component.ts'
+            )
+        ).toEqual(expectedContent);
+    });
 });

--- a/projects/igniteui-angular/migrations/update-11_1_0/index.ts
+++ b/projects/igniteui-angular/migrations/update-11_1_0/index.ts
@@ -1,5 +1,4 @@
 import { Rule, SchematicContext, Tree } from '@angular-devkit/schematics';
-import { findMatches, replaceMatch } from '../common/tsUtils';
 import { UpdateChanges } from '../common/UpdateChanges';
 
 const version = '11.1.0';
@@ -8,28 +7,5 @@ export default (): Rule => (host: Tree, context: SchematicContext) => {
     context.logger.info(`Applying migration for Ignite UI for Angular to version ${version}`);
 
     const update = new UpdateChanges(__dirname, host, context);
-    const tsFiles = update.tsFiles;
-    const targetEnum = 'GridPagingMode';
-    const changes = [
-        { member: 'remote', replaceWith: 'Remote', definedIn: [targetEnum] },
-        { member: 'local', replaceWith: 'Local', definedIn: [targetEnum] }
-    ];
     update.applyChanges();
-    for (const entryPath of tsFiles) {
-        const ls = update.getDefaultLanguageService(entryPath);
-        let content = host.read(entryPath).toString();
-        for (const change of changes) {
-            const matches = findMatches(content, change.member);
-            for (const position of matches) {
-                const definition = ls.getDefinitionAndBoundSpan(entryPath, position - 1)?.definitions[0];
-                if (definition
-                    && definition.kind === 'enum'
-                    && definition.name === targetEnum
-                    && definition.fileName.includes('igniteui-angular')) {
-                    content = replaceMatch(content, change.member, change.replaceWith, position);
-                    host.overwrite(entryPath, content);
-                }
-            }
-        }
-    }
 };


### PR DESCRIPTION
Related #9927 

Changes to TsServerHost and handling of ngLS introduced in [this PR](https://github.com/IgniteUI/igniteui-angular/pull/9610) force `UpdateChange.getLanguageServiceForFile()` to work only with absolute paths. This breaks the migration for `GridPagingMode` in `11.1.x` (which uses relative paths).

That migration is now moved to the `members.json` (as IvyLS enables it to work).

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 