### PR TITLE
GroupBy row select emit event once, perf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ All notable changes for each version of this project will be documented in this 
         - Inputs  `showToolbar`, `toolbarTitle`, `columnHiding`, `columnHidingTitle`, `hiddenColumnsText`,
         `columnPinning`, `columnPinningTitle`, `pinnedColumnsText`.
         Use `IgxGridToolbarComponent`, `IgxGridToolbarHidingComponent`, `IgxGridToolbarPinningComponent` instead.
+    - **Breaking Change** - The `rowSelected` event is renamed to `rowSelectionChanging` to better reflect its function
 - `igxGrid`
     - Exposed a `groupStrategy` input that functions similarly to `sortStrategy`, allowing customization of the grouping behavior of the grid. Please, refer to the [Group By ](https://www.infragistics.com/products/ignite-ui-angular/angular/components/grid/groupby) topic for more information.
 - `IgxColumnActionsComponent`

--- a/projects/igniteui-angular/migrations/update-13_0_0/changes/members.json
+++ b/projects/igniteui-angular/migrations/update-13_0_0/changes/members.json
@@ -21,6 +21,16 @@
             "definedIn": [
                 "IgxComboBaseDirective"
             ]
+        },
+        {
+            "member": "rowSelected",
+            "replaceWith": "rowSelectionChanging",
+            "definedIn": [
+                "IgxGridComponent",
+                "IgxTreeGridComponent",
+                "IgxHierarchicalGridComponent",
+                "IgxRowIslandComponent"
+            ]
         }
     ]
 }

--- a/projects/igniteui-angular/migrations/update-13_0_0/changes/outputs.json
+++ b/projects/igniteui-angular/migrations/update-13_0_0/changes/outputs.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "../../common/schema/binding.schema.json",
+    "changes": [
+        {
+            "name": "rowSelected",
+            "replaceWith": "rowSelectionChanging",
+            "owner": {
+                "selector": "igx-grid",
+                "type": "component"
+            }
+        },
+        {
+            "name": "rowSelected",
+            "replaceWith": "rowSelectionChanging",
+            "owner": {
+                "selector": "igx-tree-grid",
+                "type": "component"
+            }
+        },
+        {
+            "name": "rowSelected",
+            "replaceWith": "rowSelectionChanging",
+            "owner": {
+                "selector": "igx-hierarchical-grid",
+                "type": "component"
+            }
+        },
+        {
+            "name": "rowSelected",
+            "replaceWith": "rowSelectionChanging",
+            "owner": {
+                "selector": "igx-row-island",
+                "type": "component"
+            }
+        }
+    ]
+}

--- a/projects/igniteui-angular/src/lib/grids/README.md
+++ b/projects/igniteui-angular/src/lib/grids/README.md
@@ -228,7 +228,7 @@ A list of the events emitted by the **igx-grid**:
 |`columnMovingEnd`|Emitted when a column moving ends. Returns the source and target columns objects. This event is cancelable.|
 |`columnMovingStart`|Emitted when a column moving starts. Returns the moved column object.|
 |`selected`|Emitted when a cell is selected. Returns the cell object.|
-|`rowSelected`|Emitted when a row selection has changed. Returns array with old and new selected rows' IDs and the target row, if available.|
+|`rowSelectionChanging`|Emitted when row selection is changing. Returns array with old and new selected rows' IDs and the target row, if available.|
 |`columnSelected`|Emitted when a column selection has changed. Returns array with old and new selected column' fields|
 |`columnInit`|Emitted when the grid columns are initialized. Returns the column object.|
 |`sortingDone`|Emitted when sorting is performed through the UI. Returns the sorting expression.|

--- a/projects/igniteui-angular/src/lib/grids/common/events.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/events.ts
@@ -83,11 +83,11 @@ export interface IColumnResizingEventArgs extends IColumnResizeEventArgs, Cancel
 }
 
 export interface IRowSelectionEventArgs extends CancelableEventArgs, IBaseEventArgs {
-    oldSelection: any[];
+    readonly oldSelection: any[];
     newSelection: any[];
-    added: any[];
-    removed: any[];
-    event?: Event;
+    readonly added: any[];
+    readonly removed: any[];
+    readonly event?: Event;
 }
 
 export interface IColumnSelectionEventArgs extends CancelableEventArgs, IBaseEventArgs {

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -465,11 +465,11 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
      *
      * @example
      * ```html
-     * <igx-grid #grid (rowSelected)="onCellClickChange($event)" [data]="localData" [autoGenerate]="true"></igx-grid>
+     * <igx-grid #grid (rowSelectionChanging)="rowSelectionChanging($event)" [data]="localData" [autoGenerate]="true"></igx-grid>
      * ```
      */
     @Output()
-    public rowSelected = new EventEmitter<IRowSelectionEventArgs>();
+    public rowSelectionChanging = new EventEmitter<IRowSelectionEventArgs>();
 
     /**
      *  Emitted when `IgxColumnComponent` is selected.

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-row-selection.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-row-selection.spec.ts
@@ -124,14 +124,14 @@ describe('IgxGrid - Row Selection #grid', () => {
 
         it('Header checkbox should select/deselect all rows', () => {
             const allRowsArray = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19];
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             GridSelectionFunctions.clickHeaderRowCheckbox(fix);
             fix.detectChanges();
 
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, true);
             GridSelectionFunctions.verifyRowsArraySelected(grid.rowList.toArray());
             expect(grid.selectedRows).toEqual(allRowsArray);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
             let args: IRowSelectionEventArgs = {
                 added: allRowsArray,
                 cancel: false,
@@ -140,7 +140,7 @@ describe('IgxGrid - Row Selection #grid', () => {
                 oldSelection: [],
                 removed: []
             };
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith(args);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith(args);
 
             GridSelectionFunctions.clickHeaderRowCheckbox(fix);
             fix.detectChanges();
@@ -148,7 +148,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             expect(grid.selectedRows).toEqual([]);
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, false, false);
             GridSelectionFunctions.verifyRowsArraySelected(grid.rowList.toArray(), false);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
             args = {
                 oldSelection: allRowsArray,
                 newSelection: [],
@@ -157,12 +157,12 @@ describe('IgxGrid - Row Selection #grid', () => {
                 event: jasmine.anything() as any,
                 cancel: false
             };
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith(args);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith(args);
         });
 
         it('Header checkbox should deselect all rows - scenario when clicking first row, while header checkbox is clicked', () => {
             const firstRow = grid.gridAPI.get_row_by_index(0);
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
 
             GridSelectionFunctions.clickHeaderRowCheckbox(fix);
             fix.detectChanges();
@@ -187,18 +187,18 @@ describe('IgxGrid - Row Selection #grid', () => {
 
             GridSelectionFunctions.verifyRowSelected(firstRow, false);
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(4);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(4);
         });
 
         it('Checkbox should select/deselect row', () => {
             const firstRow = grid.gridAPI.get_row_by_index(0);
             const secondRow = grid.gridAPI.get_row_by_index(1);
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
 
             GridSelectionFunctions.clickRowCheckbox(firstRow);
             fix.detectChanges();
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
             let args: IRowSelectionEventArgs = {
                 added: [1],
                 cancel: false,
@@ -207,7 +207,7 @@ describe('IgxGrid - Row Selection #grid', () => {
                 oldSelection: [],
                 removed: []
             };
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith(args);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith(args);
 
             expect(grid.selectedRows).toEqual([1]);
             GridSelectionFunctions.verifyRowSelected(firstRow);
@@ -221,7 +221,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowSelected(secondRow);
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, false, true);
             expect(grid.selectedRows).toEqual([1, 2]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
             args = {
                 added: [2],
                 cancel: false,
@@ -230,7 +230,7 @@ describe('IgxGrid - Row Selection #grid', () => {
                 oldSelection: [1],
                 removed: []
             };
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith(args);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith(args);
 
             GridSelectionFunctions.clickRowCheckbox(firstRow);
             fix.detectChanges();
@@ -239,7 +239,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowSelected(secondRow);
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, false, true);
             expect(grid.selectedRows).toEqual([2]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(3);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(3);
             args = {
                 added: [],
                 cancel: false,
@@ -248,7 +248,7 @@ describe('IgxGrid - Row Selection #grid', () => {
                 oldSelection: [1, 2],
                 removed: [1]
             };
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith(args);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith(args);
 
             GridSelectionFunctions.clickRowCheckbox(secondRow);
             fix.detectChanges();
@@ -256,7 +256,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowSelected(secondRow, false);
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix);
             expect(grid.selectedRows).toEqual([]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(4);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(4);
             args = {
                 added: [],
                 cancel: false,
@@ -265,12 +265,12 @@ describe('IgxGrid - Row Selection #grid', () => {
                 oldSelection: [2],
                 removed: [2]
             };
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith(args);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith(args);
         });
 
         it('Should select the row with mouse click ', () => {
             expect(grid.selectRowOnClick).toBe(true);
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(1);
             const secondRow = grid.gridAPI.get_row_by_index(2);
             const mockEvent = new MouseEvent('click');
@@ -280,8 +280,8 @@ describe('IgxGrid - Row Selection #grid', () => {
 
             GridSelectionFunctions.verifyRowSelected(firstRow);
             expect(grid.selectedRows).toEqual([2]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith({
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith({
                 added: [2],
                 cancel: false,
                 event: mockEvent,
@@ -295,7 +295,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
 
             GridSelectionFunctions.verifyRowSelected(firstRow);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
 
             // Click on a different row
             secondRow.nativeElement.dispatchEvent(mockEvent);
@@ -305,8 +305,8 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowSelected(secondRow);
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, false, true);
             expect(grid.selectedRows).toEqual([3]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith({
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith({
                 added: [3],
                 cancel: false,
                 event: mockEvent,
@@ -323,7 +323,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             expect(grid.selectRowOnClick).toBe(false);
             grid.hideRowSelectors = false;
 
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(1);
             const secondRow = grid.gridAPI.get_row_by_index(2);
 
@@ -332,7 +332,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
             GridSelectionFunctions.verifyRowSelected(firstRow);
             expect(grid.selectedRows).toEqual([2]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
 
             // Click on the second row
             UIInteractions.simulateClickEvent(secondRow.nativeElement);
@@ -342,18 +342,18 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowSelected(secondRow, false);
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, false, true);
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
         });
         it('Should select multiple rows with clicking and holding Ctrl', () => {
             expect(grid.selectRowOnClick).toBe(true);
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(2);
             const secondRow = grid.gridAPI.get_row_by_index(0);
 
             UIInteractions.simulateClickEvent(firstRow.nativeElement);
             fix.detectChanges();
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
             GridSelectionFunctions.verifyRowSelected(firstRow);
 
             // Click again on this row holding Ctrl
@@ -361,7 +361,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
 
             GridSelectionFunctions.verifyRowSelected(firstRow);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
 
             // Click on a different row
             UIInteractions.simulateClickEvent(secondRow.nativeElement, false, true);
@@ -370,12 +370,12 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowSelected(firstRow);
             GridSelectionFunctions.verifyRowSelected(secondRow);
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, false, true);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
         });
         it('Should NOT select rows with clicking and holding Ctrl when selectRowOnClick has false value', () => {
             grid.selectRowOnClick = false;
             grid.hideRowSelectors = false;
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(2);
             const secondRow = grid.gridAPI.get_row_by_index(0);
             const thirdRow = grid.gridAPI.get_row_by_index(4);
@@ -384,7 +384,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.clickRowCheckbox(firstRow);
             fix.detectChanges();
             GridSelectionFunctions.verifyRowSelected(firstRow);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
 
             // Click on the second row checkbox
             GridSelectionFunctions.clickRowCheckbox(secondRow);
@@ -392,7 +392,7 @@ describe('IgxGrid - Row Selection #grid', () => {
 
             GridSelectionFunctions.verifyRowSelected(firstRow);
             GridSelectionFunctions.verifyRowSelected(secondRow);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
 
             // Click + Ctrl on the third row
             UIInteractions.simulateClickEvent(thirdRow.nativeElement);
@@ -401,13 +401,13 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowSelected(firstRow);
             GridSelectionFunctions.verifyRowSelected(secondRow);
             GridSelectionFunctions.verifyRowSelected(thirdRow, false);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
         });
         it('Should select multiple rows with clicking Space on a cell', (async () => {
             grid.tbody.nativeElement.focus();
             fix.detectChanges();
 
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(0);
             const secondRow = grid.gridAPI.get_row_by_index(1);
             let cell = grid.gridAPI.get_cell_by_index(0, 'ProductName');
@@ -419,7 +419,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyCellSelected(cell);
             GridSelectionFunctions.verifyRowSelected(firstRow);
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
             GridSelectionFunctions.verifyRowSelected(firstRow);
             GridSelectionFunctions.verifyRowSelected(secondRow, false);
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, false, true);
@@ -438,7 +438,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             await wait(DEBOUNCETIME);
             fix.detectChanges();
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
             GridSelectionFunctions.verifyRowSelected(firstRow);
             GridSelectionFunctions.verifyRowSelected(secondRow);
 
@@ -447,14 +447,14 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
             await wait(DEBOUNCETIME);
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(3);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(3);
             GridSelectionFunctions.verifyRowSelected(firstRow);
             GridSelectionFunctions.verifyRowSelected(secondRow, false);
         }));
 
         it('Should select multiple rows with Shift + Click', () => {
             expect(grid.selectRowOnClick).toBe(true);
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(1);
             const secondRow = grid.gridAPI.get_row_by_index(4);
             const mockEvent = new MouseEvent('click', { shiftKey: true });
@@ -469,8 +469,8 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
 
             expect(grid.selectedRows).toEqual([2, 3, 4, 5]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith({
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith({
                 added: [3, 4, 5],
                 cancel: false,
                 event: mockEvent,
@@ -487,7 +487,7 @@ describe('IgxGrid - Row Selection #grid', () => {
 
         it('Should NOT select multiple rows with Shift + Click when selectRowOnClick has false value', () => {
             grid.selectRowOnClick = false;
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             // Shift + Click
             const firstRow = grid.gridAPI.get_row_by_index(1);
             const secondRow = grid.gridAPI.get_row_by_index(4);
@@ -503,7 +503,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
 
             expect(grid.selectedRows).toEqual([]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
             GridSelectionFunctions.verifyRowSelected(secondRow, false);
             for (let index = 1; index < 4; index++) {
                 const row = grid.gridAPI.get_row_by_index(index);
@@ -594,9 +594,9 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowSelected(firstRow, false);
         });
 
-        it('Should be able to cancel rowSelected event', () => {
+        it('Should be able to cancel rowSelectionChanging event', () => {
             const firstRow = grid.gridAPI.get_row_by_index(0);
-            grid.rowSelected.subscribe((e: IRowSelectionEventArgs) => {
+            grid.rowSelectionChanging.subscribe((e: IRowSelectionEventArgs) => {
                 e.cancel = true;
             });
 
@@ -648,11 +648,11 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowSelected(grid.gridAPI.get_row_by_index(2));
         });
 
-        it('Should be able to programmatically overwrite the selection using rowSelected event', () => {
+        it('Should be able to programmatically overwrite the selection using rowSelectionChanging event', () => {
             const firstRow = grid.gridAPI.get_row_by_index(0);
             const secondRow = grid.gridAPI.get_row_by_index(1);
             const thirdRow = grid.gridAPI.get_row_by_index(2);
-            grid.rowSelected.subscribe((e: IRowSelectionEventArgs) => {
+            grid.rowSelectionChanging.subscribe((e: IRowSelectionEventArgs) => {
                 if (e.added.length > 0 && (e.added[0]) % 2 === 0) {
                     e.newSelection = e.oldSelection || [];
                 }
@@ -775,14 +775,14 @@ describe('IgxGrid - Row Selection #grid', () => {
         }));
 
         it('Header checkbox should NOT select/deselect all rows when selectionMode is single', () => {
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             GridSelectionFunctions.clickHeaderRowCheckbox(fix);
             fix.detectChanges();
 
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, false, false);
             GridSelectionFunctions.verifyRowsArraySelected([]);
             expect(grid.selectedRows).toEqual([]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
 
             GridSelectionFunctions.clickHeaderRowCheckbox(fix);
             fix.detectChanges();
@@ -790,7 +790,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             expect(grid.selectedRows).toEqual([]);
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, false, false);
             GridSelectionFunctions.verifyRowsArraySelected([]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
         });
 
         it('Should have checkbox on each row and do not have header checkbox', () => {
@@ -806,12 +806,12 @@ describe('IgxGrid - Row Selection #grid', () => {
         it('Should be able to select only one row when click on a checkbox', () => {
             const firstRow = grid.gridAPI.get_row_by_index(0);
             const secondRow = grid.gridAPI.get_row_by_index(1);
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
 
             GridSelectionFunctions.clickRowCheckbox(firstRow);
             fix.detectChanges();
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
             let args: IRowSelectionEventArgs = {
                 added: [1],
                 cancel: false,
@@ -820,7 +820,7 @@ describe('IgxGrid - Row Selection #grid', () => {
                 oldSelection: [],
                 removed: []
             };
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith(args);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith(args);
 
             expect(grid.selectedRows).toEqual([1]);
             GridSelectionFunctions.verifyRowSelected(firstRow);
@@ -833,7 +833,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowSelected(firstRow, false);
             GridSelectionFunctions.verifyRowSelected(secondRow);
             expect(grid.selectedRows).toEqual([2]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
             args = {
                 added: [2],
                 cancel: false,
@@ -842,14 +842,14 @@ describe('IgxGrid - Row Selection #grid', () => {
                 oldSelection: [1],
                 removed: [1]
             };
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith(args);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith(args);
         });
         it('Should NOT select a row on click when selectRowOnClick has false value', () => {
             grid.selectRowOnClick = false;
             grid.tbody.nativeElement.focus();
             fix.detectChanges();
 
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(0);
             const cell = grid.gridAPI.get_cell_by_index(0, 0);
             UIInteractions.simulateClickEvent(cell.nativeElement);
@@ -857,17 +857,17 @@ describe('IgxGrid - Row Selection #grid', () => {
 
             GridSelectionFunctions.verifyRowSelected(firstRow, false);
             expect(grid.selectedRows).toEqual([]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
         });
         it('Should not select multiple rows with clicking and holding Ctrl', () => {
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(2);
             const secondRow = grid.gridAPI.get_row_by_index(0);
 
             UIInteractions.simulateClickEvent(firstRow.nativeElement);
             fix.detectChanges();
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
             expect(grid.selectedRows).toEqual([3]);
             GridSelectionFunctions.verifyRowSelected(firstRow);
 
@@ -878,18 +878,18 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowSelected(firstRow, false);
             GridSelectionFunctions.verifyRowSelected(secondRow);
             expect(grid.selectedRows).toEqual([1]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
         });
         it('Should not select a row with clicking and holding Ctrl when selectRowOnClick has false value', () => {
             grid.selectRowOnClick = false;
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(2);
             const secondRow = grid.gridAPI.get_row_by_index(0);
 
             UIInteractions.simulateClickEvent(firstRow.nativeElement);
             fix.detectChanges();
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
             expect(grid.selectedRows).toEqual([]);
             GridSelectionFunctions.verifyRowSelected(firstRow, false);
 
@@ -900,13 +900,13 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowSelected(firstRow, false);
             GridSelectionFunctions.verifyRowSelected(secondRow, false);
             expect(grid.selectedRows).toEqual([]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
         });
         it('Should not select multiple rows with clicking Space on a cell', (async () => {
             grid.tbody.nativeElement.focus();
             fix.detectChanges();
 
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(0);
             const secondRow = grid.gridAPI.get_row_by_index(1);
             let cell = grid.gridAPI.get_cell_by_index(0, 'ProductName');
@@ -918,7 +918,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyCellSelected(cell);
             GridSelectionFunctions.verifyRowSelected(firstRow);
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
             expect(grid.selectedRows).toEqual([1]);
             GridSelectionFunctions.verifyRowSelected(firstRow);
             GridSelectionFunctions.verifyRowSelected(secondRow, false);
@@ -933,7 +933,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
             await wait(DEBOUNCETIME);
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
             expect(grid.selectedRows).toEqual([2]);
             GridSelectionFunctions.verifyRowSelected(firstRow, false);
             GridSelectionFunctions.verifyRowSelected(secondRow);
@@ -943,14 +943,14 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
             await wait(DEBOUNCETIME);
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(3);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(3);
             expect(grid.selectedRows).toEqual([]);
             GridSelectionFunctions.verifyRowSelected(firstRow, false);
             GridSelectionFunctions.verifyRowSelected(secondRow, false);
         }));
 
         it('Should not select multiple rows with Shift + Click', () => {
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(1);
             const secondRow = grid.gridAPI.get_row_by_index(4);
             const mockEvent = new MouseEvent('click', { shiftKey: true });
@@ -966,8 +966,8 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
 
             expect(grid.selectedRows).toEqual([5]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith({
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith({
                 added: [5],
                 cancel: false,
                 event: mockEvent,
@@ -984,7 +984,7 @@ describe('IgxGrid - Row Selection #grid', () => {
         });
         it('Should not select row with Shift + Click when selectRowOnClick has false value ', () => {
             grid.selectRowOnClick = false;
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
 
             // Shift + Click
             const firstRow = grid.gridAPI.get_row_by_index(1);
@@ -1001,7 +1001,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
 
             expect(grid.selectedRows).toEqual([]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
             GridSelectionFunctions.verifyRowSelected(secondRow, false);
             for (let index = 1; index < 4; index++) {
                 const row = grid.gridAPI.get_row_by_index(index);
@@ -1053,7 +1053,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             expect(grid.selectedRows).toEqual([1, 3, 5, 2, 4]);
         });
 
-        it('Should be able to cancel rowSelected event', () => {
+        it('Should be able to cancel rowSelectionChanging event', () => {
             const firstRow = grid.gridAPI.get_row_by_index(0);
             const secondRow = grid.gridAPI.get_row_by_index(1);
 
@@ -1064,7 +1064,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             expect(grid.selectedRows).toEqual([1]);
 
             // Cancel the event
-            grid.rowSelected.subscribe((e: IRowSelectionEventArgs) => {
+            grid.rowSelectionChanging.subscribe((e: IRowSelectionEventArgs) => {
                 e.cancel = true;
             });
 
@@ -1158,7 +1158,7 @@ describe('IgxGrid - Row Selection #grid', () => {
         }));
 
         it('Should be able to programmatically select all rows and keep the header checkbox intact,  #1298', () => {
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             grid.selectAllRows();
             grid.cdr.detectChanges();
             fix.detectChanges();
@@ -1178,11 +1178,11 @@ describe('IgxGrid - Row Selection #grid', () => {
 
             GridSelectionFunctions.verifyRowsArraySelected(grid.rowList.toArray(), false);
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
         });
 
         it('Should be able to select/deselect rows programmatically', () => {
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(0);
             const secondRow = grid.gridAPI.get_row_by_index(1);
             const thirdRow = grid.gridAPI.get_row_by_index(2);
@@ -1233,7 +1233,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyRowsArraySelected([secondRow, thirdRow, forthRow], false);
             GridSelectionFunctions.verifyRowSelected(firstRow);
             expect(grid.selectedRows).toEqual([1]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
 
             grid.deselectRows([1]);
             fix.detectChanges();
@@ -1241,7 +1241,7 @@ describe('IgxGrid - Row Selection #grid', () => {
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix);
             GridSelectionFunctions.verifyRowsArraySelected([firstRow, secondRow, thirdRow, forthRow], false);
             expect(grid.selectedRows).toEqual([]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
         });
 
         it('Should be able to correctly select all rows programmatically', () => {
@@ -1292,7 +1292,7 @@ describe('IgxGrid - Row Selection #grid', () => {
         }));
 
         it('Verify event parameters', () => {
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const firstRow = grid.gridAPI.get_row_by_index(1);
             const secondRow = grid.gridAPI.get_row_by_index(4);
 
@@ -1301,7 +1301,7 @@ describe('IgxGrid - Row Selection #grid', () => {
 
             GridSelectionFunctions.verifyRowSelected(firstRow);
             expect(grid.selectedRows).toEqual([gridData[1]]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
             let args: IRowSelectionEventArgs = {
                 added: [gridData[1]],
                 cancel: false,
@@ -1310,13 +1310,13 @@ describe('IgxGrid - Row Selection #grid', () => {
                 oldSelection: [],
                 removed: []
             };
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith(args);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith(args);
 
             UIInteractions.simulateClickEvent(secondRow.nativeElement, true);
             fix.detectChanges();
 
             expect(grid.selectedRows).toEqual([gridData[1], gridData[2], gridData[3], gridData[4]]);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
             args = {
                 added: [gridData[2], gridData[3], gridData[4]],
                 cancel: false,
@@ -1325,7 +1325,7 @@ describe('IgxGrid - Row Selection #grid', () => {
                 oldSelection: [gridData[1]],
                 removed: []
             };
-            expect(grid.rowSelected.emit).toHaveBeenCalledWith(args);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith(args);
         });
 
         it('Should persist through scrolling vertical', (async () => {
@@ -1690,24 +1690,24 @@ describe('IgxGrid - Row Selection #grid', () => {
         });
 
         it('Filtering: Should properly check the header checkbox state when filtering, #2469', () => {
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
 
             grid.filter('ProductID', 10, IgxNumberFilteringOperand.instance().condition('greaterThanOrEqualTo'), true);
             fix.detectChanges();
 
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
             expect(grid.selectedRows).toEqual([]);
 
             grid.clearFilter('ProductID');
             fix.detectChanges();
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
 
             GridSelectionFunctions.clickHeaderRowCheckbox(fix);
             fix.detectChanges();
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, true);
 
             grid.filter('ProductID', 0, IgxNumberFilteringOperand.instance().condition('greaterThanOrEqualTo'), true);
@@ -1728,11 +1728,11 @@ describe('IgxGrid - Row Selection #grid', () => {
 
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, true);
             expect(grid.selectedRows.length).toBe(19);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
         });
 
         it('Filtering: Should select correct rows when filter is applied', () => {
-            spyOn(grid.rowSelected, 'emit').and.callThrough();
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
             const secondRow = grid.gridAPI.get_row_by_index(1);
 
             GridSelectionFunctions.clickRowCheckbox(secondRow);
@@ -1740,19 +1740,19 @@ describe('IgxGrid - Row Selection #grid', () => {
 
             expect(secondRow.selected).toBeTruthy();
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, false, true);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
 
             grid.filter('ProductName', 'Ca', IgxStringFilteringOperand.instance().condition('contains'), true);
             fix.detectChanges();
 
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(1);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(1);
 
             GridSelectionFunctions.clickHeaderRowCheckbox(fix);
             fix.detectChanges();
 
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, true);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
 
             grid.clearFilter('ProductName');
             fix.detectChanges();
@@ -1766,12 +1766,12 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, true);
 
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
             GridSelectionFunctions.clickHeaderRowCheckbox(fix);
             fix.detectChanges();
 
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(3);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(3);
 
             grid.clearFilter('ProductName');
             fix.detectChanges();
@@ -1781,19 +1781,19 @@ describe('IgxGrid - Row Selection #grid', () => {
             expect(grid.gridAPI.get_row_by_index(1).selected).toBeTruthy();
             expect(grid.gridAPI.get_row_by_index(2).selected).toBeFalsy();
             expect(grid.gridAPI.get_row_by_index(6).selected).toBeFalsy();
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(3);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(3);
 
             GridSelectionFunctions.clickRowCheckbox(grid.gridAPI.get_row_by_index(2));
             fix.detectChanges();
 
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, false, true);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(4);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(4);
 
             grid.filter('ProductName', 'Ca', IgxStringFilteringOperand.instance().condition('contains'), true);
             fix.detectChanges();
 
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix, false, true);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(4);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(4);
 
             GridSelectionFunctions.clickHeaderRowCheckbox(fix);
             fix.detectChanges();
@@ -1802,14 +1802,14 @@ describe('IgxGrid - Row Selection #grid', () => {
             fix.detectChanges();
 
             GridSelectionFunctions.verifyHeaderRowCheckboxState(fix);
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(6);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(6);
 
             grid.clearFilter('ProductName');
             fix.detectChanges();
 
             expect(grid.gridAPI.get_row_by_index(2).selected).toBeFalsy();
             expect(grid.gridAPI.get_row_by_index(1).selected).toBeTruthy();
-            expect(grid.rowSelected.emit).toHaveBeenCalledTimes(6);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(6);
         });
 
         it('Should select only filtered records', () => {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
@@ -1173,7 +1173,7 @@ describe('IgxGrid - GroupBy #grid', () => {
             tick();
             fix.detectChanges();
 
-            const selectionSpy = spyOn(grid.rowSelected, 'emit');
+            const selectionSpy = spyOn(grid.rowSelectionChanging, 'emit');
             GridFunctions.simulateGridContentKeydown(fix, 'Space');
             fix.detectChanges();
 
@@ -1263,7 +1263,7 @@ describe('IgxGrid - GroupBy #grid', () => {
             tick();
             fix.detectChanges();
 
-            const selectionSpy = spyOn(grid.rowSelected, 'emit');
+            const selectionSpy = spyOn(grid.rowSelectionChanging, 'emit');
             GridFunctions.simulateGridContentKeydown(fix, 'Space');
             fix.detectChanges();
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
@@ -1173,8 +1173,14 @@ describe('IgxGrid - GroupBy #grid', () => {
             tick();
             fix.detectChanges();
 
+            const selectionSpy = spyOn(grid.rowSelected, 'emit');
             GridFunctions.simulateGridContentKeydown(fix, 'Space');
             fix.detectChanges();
+
+            expect(selectionSpy).toHaveBeenCalledTimes(1);
+            const args = selectionSpy.calls.mostRecent().args[0];
+            expect(args.added.length).toBe(2);
+            expect(grid.selectedRows.length).toEqual(2);
 
             for (const key of grRow.groupRow.records) {
                 expect(GridSelectionFunctions.verifyRowSelected(grid.gridAPI.get_row_by_key(key)));
@@ -1257,8 +1263,14 @@ describe('IgxGrid - GroupBy #grid', () => {
             tick();
             fix.detectChanges();
 
+            const selectionSpy = spyOn(grid.rowSelected, 'emit');
             GridFunctions.simulateGridContentKeydown(fix, 'Space');
             fix.detectChanges();
+
+            expect(selectionSpy).toHaveBeenCalledTimes(1);
+            const args = selectionSpy.calls.mostRecent().args[0];
+            expect(args.removed.length).toBe(2);
+            expect(grid.selectedRows.length).toEqual(0);
 
             for (const key of grRow.groupRow.records) {
                 expect(GridSelectionFunctions.verifyRowSelected(grid.gridAPI.get_row_by_key(key), false));

--- a/projects/igniteui-angular/src/lib/grids/grid/groupby-row.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/groupby-row.component.ts
@@ -278,8 +278,8 @@ export class IgxGridGroupByRowComponent implements OnDestroy {
      * @hidden @internal
      */
     public get selectedRowsInTheGroup(): any[] {
-        const selectedIds = this.gridSelection.filteredSelectedRowIds;
-        return this.groupRow.records.filter(rowID => selectedIds.indexOf(this.getRowID(rowID)) > -1);
+        const selectedIds = new Set(this.gridSelection.filteredSelectedRowIds);
+        return this.groupRow.records.filter(rowID => selectedIds.has(this.getRowID(rowID)));
     }
 
     /**

--- a/projects/igniteui-angular/src/lib/grids/grid/groupby-row.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/groupby-row.component.ts
@@ -218,13 +218,9 @@ export class IgxGridGroupByRowComponent implements OnDestroy {
         }
         event.stopPropagation();
         if (this.areAllRowsInTheGroupSelected) {
-            this.groupRow.records.forEach(row => {
-                this.gridSelection.deselectRow(this.getRowID(row), event);
-            });
+            this.gridSelection.deselectRows(this.groupRow.records.map(x => this.getRowID(x)));
         } else {
-            this.groupRow.records.forEach(row => {
-                this.gridSelection.selectRowById(this.getRowID(row), false, event);
-            });
+            this.gridSelection.selectRows(this.groupRow.records.map(x => this.getRowID(x)));
         }
     }
 

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/child-grid-row.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/child-grid-row.component.ts
@@ -70,7 +70,7 @@ export class IgxChildGridRowComponent implements AfterViewInit, OnInit {
      *
      * ```typescript
      * handleRowSelection(event) {
-     *  // the grid on which the rowSelected event was triggered
+     *  // the grid on which the rowSelectionChanging event was triggered
      *  const grid = event.row.grid;
      * }
      * ```
@@ -78,7 +78,7 @@ export class IgxChildGridRowComponent implements AfterViewInit, OnInit {
      * ```html
      *  <igx-grid
      *    [data]="data"
-     *    (rowSelected)="handleRowSelection($event)">
+     *    (rowSelectionChanging)="handleRowSelection($event)">
      *  </igx-grid>
      * ```
      */

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.selection.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.selection.spec.ts
@@ -627,14 +627,14 @@ describe('IgxHierarchicalGrid selection #hGrid', () => {
             }
         });
 
-        it('should have fire event rowSelected', () => {
+        it('should have fire event rowSelectionChanging', () => {
             hierarchicalGrid.expandChildren = true;
             fix.detectChanges();
             const childGrid = hierarchicalGrid.hgridAPI.getChildGrids(false)[0];
             const secondChildGrid = hierarchicalGrid.hgridAPI.getChildGrids(false)[1];
-            const parentSpy = spyOn<any>(hierarchicalGrid.rowSelected, 'emit').and.callThrough();
-            const childSpy = spyOn<any>(childGrid.rowSelected, 'emit').and.callThrough();
-            const secondChildSpy = spyOn<any>(secondChildGrid.rowSelected, 'emit').and.callThrough();
+            const parentSpy = spyOn<any>(hierarchicalGrid.rowSelectionChanging, 'emit').and.callThrough();
+            const childSpy = spyOn<any>(childGrid.rowSelectionChanging, 'emit').and.callThrough();
+            const secondChildSpy = spyOn<any>(secondChildGrid.rowSelectionChanging, 'emit').and.callThrough();
             const mockEvent = new MouseEvent('click');
 
             // Click on a row in child grid

--- a/projects/igniteui-angular/src/lib/grids/row.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/row.directive.ts
@@ -336,7 +336,7 @@ export class IgxRowDirective<T extends IgxGridBaseDirective & GridType> implemen
      *
      * ```typescript
      * handleRowSelection(event) {
-     *  // the grid on which the rowSelected event was triggered
+     *  // the grid on which the rowSelectionChanging event was triggered
      *  const grid = event.row.grid;
      * }
      * ```
@@ -344,7 +344,7 @@ export class IgxRowDirective<T extends IgxGridBaseDirective & GridType> implemen
      * ```html
      *  <igx-grid
      *    [data]="data"
-     *    (rowSelected)="handleRowSelection($event)">
+     *    (rowSelectionChanging)="handleRowSelection($event)">
      *  </igx-grid>
      * ```
      */

--- a/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
@@ -438,7 +438,6 @@ export class IgxGridSelectionService {
         const addedRows = allRowIDs.filter((rID) => !this.isRowSelected(rID));
         const newSelection = this.rowSelection.size ? this.getSelectedRows().concat(addedRows) : addedRows;
         this.indeterminateRows.clear();
-        this.selectedRowsChange.next();
         this.emitRowSelectionEvent(newSelection, addedRows, [], event);
     }
 
@@ -449,10 +448,10 @@ export class IgxGridSelectionService {
         }
         clearPrevSelection = !this.grid.isMultiRowSelectionEnabled || clearPrevSelection;
 
-        const newSelection = clearPrevSelection ? [rowID] : this.getSelectedRows().indexOf(rowID) !== -1 ?
-            this.getSelectedRows() : [...this.getSelectedRows(), rowID];
-        const removed = clearPrevSelection ? this.getSelectedRows() : [];
-        this.selectedRowsChange.next();
+        const selectedRows = this.getSelectedRows();
+        const newSelection = clearPrevSelection ? [rowID] : this.rowSelection.has(rowID) ?
+            selectedRows : [...selectedRows, rowID];
+        const removed = clearPrevSelection ? selectedRows : [];
         this.emitRowSelectionEvent(newSelection, [rowID], removed, event);
     }
 
@@ -463,9 +462,42 @@ export class IgxGridSelectionService {
         }
         const newSelection = this.getSelectedRows().filter(r => r !== rowID);
         if (this.rowSelection.size && this.rowSelection.has(rowID)) {
-            this.selectedRowsChange.next();
             this.emitRowSelectionEvent(newSelection, [], [rowID], event);
         }
+    }
+
+    /** Select the specified rows and emit event. */
+    public selectRows(keys: any[], clearPrevSelection?: boolean, event?): void {
+        if (!this.grid.isMultiRowSelectionEnabled) {
+            return;
+        }
+
+        const rowsToSelect = keys.filter(x => !this.isRowDeleted(x) && !this.rowSelection.has(x));
+        if (!rowsToSelect.length && !clearPrevSelection) {
+            // no valid/additional rows to select and no clear
+            return;
+        }
+
+        const selectedRows = this.getSelectedRows();
+        const newSelection = clearPrevSelection ? rowsToSelect : [...selectedRows, ...rowsToSelect];
+        const keysAsSet = new Set(rowsToSelect);
+        const removed = clearPrevSelection ? selectedRows.filter(x => !keysAsSet.has(x)) : [];
+        this.emitRowSelectionEvent(newSelection, rowsToSelect, removed, event);
+    }
+
+    public deselectRows(keys: any[], event?): void {
+        if (!this.rowSelection.size) {
+            return;
+        }
+
+        const rowsToDeselect = keys.filter(x => this.rowSelection.has(x));
+        if (!rowsToDeselect.length) {
+            return;
+        }
+
+        const keysAsSet = new Set(rowsToDeselect);
+        const newSelection = this.getSelectedRows().filter(r => !keysAsSet.has(r));
+        this.emitRowSelectionEvent(newSelection, [], rowsToDeselect, event);
     }
 
     /** Select specified rows. No event is emitted. */
@@ -508,7 +540,6 @@ export class IgxGridSelectionService {
 
         const added = this.getRowIDs(rows).filter(rID => !this.isRowSelected(rID));
         const newSelection = this.getSelectedRows().concat(added);
-        this.selectedRowsChange.next();
         this.emitRowSelectionEvent(newSelection, added, [], event);
     }
 

--- a/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
@@ -578,7 +578,7 @@ export class IgxGridSelectionService {
             oldSelection: currSelection, newSelection,
             added, removed, event, cancel: false
         };
-        this.grid.rowSelected.emit(args);
+        this.grid.rowSelectionChanging.emit(args);
         if (args.cancel) {
             return;
         }

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-selection.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-selection.service.ts
@@ -124,7 +124,7 @@ export class IgxTreeGridSelectionService extends IgxGridSelectionService {
         // retrieve rows/parents/children which has been added/removed from the selection
         this.handleAddedAndRemovedArgs(args);
 
-        this.grid.rowSelected.emit(args);
+        this.grid.rowSelectionChanging.emit(args);
 
         if (args.cancel) {
             return;

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-selection.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid-selection.spec.ts
@@ -331,7 +331,7 @@ describe('IgxTreeGrid - Selection #tGrid', () => {
         });
 
         it('Header checkbox should NOT select/deselect all rows when selectionMode is single', () => {
-            spyOn(treeGrid.rowSelected, 'emit').and.callThrough();
+            spyOn(treeGrid.rowSelectionChanging, 'emit').and.callThrough();
             treeGrid.rowSelection = GridSelectionMode.single;
             fix.detectChanges();
 
@@ -341,7 +341,7 @@ describe('IgxTreeGrid - Selection #tGrid', () => {
             TreeGridFunctions.verifyHeaderCheckboxSelection(fix, false);
             TreeGridFunctions.verifyDataRowsSelection(fix, [], false);
             expect(treeGrid.selectedRows).toEqual([]);
-            expect(treeGrid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(treeGrid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
 
             TreeGridFunctions.clickHeaderRowSelectionCheckbox(fix);
             fix.detectChanges();
@@ -349,7 +349,7 @@ describe('IgxTreeGrid - Selection #tGrid', () => {
             TreeGridFunctions.verifyHeaderCheckboxSelection(fix, false);
             TreeGridFunctions.verifyDataRowsSelection(fix, [], false);
             expect(treeGrid.selectedRows).toEqual([]);
-            expect(treeGrid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(treeGrid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
         });
 
         it('should be able to select row of any level', () => {
@@ -1602,13 +1602,13 @@ describe('IgxTreeGrid - Selection #tGrid', () => {
             TreeGridFunctions.verifyRowByIndexSelectionAndCheckboxState(fix, 6, true, true);
         }));
 
-        it(`Setting true to the cancel property of the rowSelected event should not modify the selected rows collection`, () => {
+        it(`Setting true to the cancel property of the rowSelectionChanging event should not modify the selected rows collection`, () => {
 
-            treeGrid.rowSelected.subscribe((e: IRowSelectionEventArgs) => {
+            treeGrid.rowSelectionChanging.subscribe((e: IRowSelectionEventArgs) => {
                 e.cancel = true;
             });
 
-            spyOn(treeGrid.rowSelected, 'emit').and.callThrough();
+            spyOn(treeGrid.rowSelectionChanging, 'emit').and.callThrough();
 
             treeGrid.selectionService.selectRowsWithNoEvent([317]);
             fix.detectChanges();
@@ -1625,7 +1625,7 @@ describe('IgxTreeGrid - Selection #tGrid', () => {
                 cancel: true
             };
 
-            expect(treeGrid.rowSelected.emit).toHaveBeenCalledWith(args);
+            expect(treeGrid.rowSelectionChanging.emit).toHaveBeenCalledWith(args);
 
             fix.detectChanges();
             expect(getVisibleSelectedRows(fix).length).toBe(4);
@@ -1685,11 +1685,11 @@ describe('IgxTreeGrid - Selection #tGrid', () => {
         });
 
         it('selectRowById event SHOULD be emitted correctly with valid arguments.', () => {
-            spyOn(treeGrid.rowSelected, 'emit').and.callThrough();
+            spyOn(treeGrid.rowSelectionChanging, 'emit').and.callThrough();
             treeGrid.selectionService.selectRowsWithNoEvent([317]);
             fix.detectChanges();
 
-            expect(treeGrid.rowSelected.emit).toHaveBeenCalledTimes(0);
+            expect(treeGrid.rowSelectionChanging.emit).toHaveBeenCalledTimes(0);
             expect(getVisibleSelectedRows(fix).length).toBe(4);
             TreeGridFunctions.verifyRowByIndexSelectionAndCheckboxState(fix, 0, false, null);
             TreeGridFunctions.verifyRowByIndexSelectionAndCheckboxState(fix, 3, true, true);
@@ -1709,7 +1709,7 @@ describe('IgxTreeGrid - Selection #tGrid', () => {
                 cancel: false
             };
 
-            expect(treeGrid.rowSelected.emit).toHaveBeenCalledWith(args);
+            expect(treeGrid.rowSelectionChanging.emit).toHaveBeenCalledWith(args);
 
             treeGrid.cdr.detectChanges();
 
@@ -1725,10 +1725,10 @@ describe('IgxTreeGrid - Selection #tGrid', () => {
         });
 
         it('After changing the newSelection arguments of onSelectedRowChange, the arguments SHOULD be correct.', () => {
-            treeGrid.rowSelected.subscribe((e: IRowSelectionEventArgs) => {
+            treeGrid.rowSelectionChanging.subscribe((e: IRowSelectionEventArgs) => {
                 e.newSelection = [847, 663];
             });
-            spyOn(treeGrid.rowSelected, 'emit').and.callThrough();
+            spyOn(treeGrid.rowSelectionChanging, 'emit').and.callThrough();
 
             treeGrid.selectionService.selectRowsWithNoEvent([317], true);
             fix.detectChanges();
@@ -1744,7 +1744,7 @@ describe('IgxTreeGrid - Selection #tGrid', () => {
                 cancel: false
             };
 
-            expect(treeGrid.rowSelected.emit).toHaveBeenCalledWith(selectionArgs);
+            expect(treeGrid.rowSelectionChanging.emit).toHaveBeenCalledWith(selectionArgs);
 
             treeGrid.cdr.detectChanges();
 

--- a/projects/igniteui-angular/src/lib/test-utils/grid-interfaces.spec.ts
+++ b/projects/igniteui-angular/src/lib/test-utils/grid-interfaces.spec.ts
@@ -41,9 +41,9 @@ export interface IEditDone {
     editDone(event): void;
 }
 
-/* Add to template: ` (rowSelected)="rowSelectionChange($event)"` */
+/* Add to template: ` (rowSelectionChanging)="rowSelectionChange($event)"` */
 export interface IGridRowSelectionChange {
-    rowSelected(event): void;
+    rowSelectionChanging(event): void;
 }
 
 /* Add to template: ` (columnResized)="columnResized($event)"` */

--- a/projects/igniteui-angular/src/lib/test-utils/grid-samples.spec.ts
+++ b/projects/igniteui-angular/src/lib/test-utils/grid-samples.spec.ts
@@ -237,13 +237,13 @@ export class RowSelectionWithoutPrimaryKeyComponent extends BasicGridComponent {
 @Component({
     template: GridTemplateStrings.declareGrid(
         ` rowSelection = "multiple"`,
-        EventSubscriptions.rowSelected,
+        EventSubscriptions.rowSelectionChanging,
         ColumnDefinitions.productBasic)
 })
 export class SelectionCancellableComponent extends BasicGridComponent {
     public data = SampleTestData.foodProductData();
 
-    public rowSelected(evt) {
+    public rowSelectionChanging(evt) {
         if (evt.added.length > 0 && (evt.added[0].ProductID) % 2 === 0) {
             evt.newSelection = evt.oldSelection || [];
         }

--- a/projects/igniteui-angular/src/lib/test-utils/template-strings.spec.ts
+++ b/projects/igniteui-angular/src/lib/test-utils/template-strings.spec.ts
@@ -524,7 +524,7 @@ export class EventSubscriptions {
 
     public static onEditDone = ` (cellEdit)="editDone($event)"`;
 
-    public static rowSelected = ` (rowSelected)="rowSelected($event)"`;
+    public static rowSelectionChanging = ` (rowSelectionChanging)="rowSelectionChanging($event)"`;
 
     public static columnResized = ` (columnResized)="columnResized($event)"`;
 

--- a/src/app/grid-groupby/grid-groupby.sample.html
+++ b/src/app/grid-groupby/grid-groupby.sample.html
@@ -69,7 +69,7 @@
 <div class="wrapper">
     <h3>Selection Performance</h3>
     <igx-grid [data]="data2" [allowFiltering]="true" cellSelection="none" width="1200px"
-    height="500px" rowSelection="multiple" [groupingExpressions]="perfGrpExpr" (rowSelected)="rowSelectionChanged($event)">
+    height="500px" rowSelection="multiple" [groupingExpressions]="perfGrpExpr" (rowSelectionChanging)="rowSelectionChanged($event)">
         <igx-column field="STATUS" header="Status" width="200px" [groupable]="true" [sortable]="true">
         </igx-column>
         <igx-column field="FIELD" header="Field" width="200px" [groupable]="true" [sortable]="true">

--- a/src/app/grid-groupby/grid-groupby.sample.html
+++ b/src/app/grid-groupby/grid-groupby.sample.html
@@ -69,7 +69,7 @@
 <div class="wrapper">
     <h3>Selection Performance</h3>
     <igx-grid [data]="data2" [allowFiltering]="true" cellSelection="none" width="1200px"
-    height="500px" rowSelection="multiple" [groupingExpressions]="perfGrpExpr">
+    height="500px" rowSelection="multiple" [groupingExpressions]="perfGrpExpr" (rowSelected)="rowSelectionChanged($event)">
         <igx-column field="STATUS" header="Status" width="200px" [groupable]="true" [sortable]="true">
         </igx-column>
         <igx-column field="FIELD" header="Field" width="200px" [groupable]="true" [sortable]="true">

--- a/src/app/grid-groupby/grid-groupby.sample.ts
+++ b/src/app/grid-groupby/grid-groupby.sample.ts
@@ -3,7 +3,7 @@ import { Component, ViewChild, OnInit, Inject } from '@angular/core';
 
 import {
     IgxGridComponent, SortingDirection, ISortingExpression,
-    DefaultSortingStrategy, DisplayDensity, IDisplayDensityOptions, DisplayDensityToken, GridSummaryPosition, GridSummaryCalculationMode
+    DefaultSortingStrategy, DisplayDensity, IDisplayDensityOptions, DisplayDensityToken, GridSummaryPosition, GridSummaryCalculationMode, IRowSelectionEventArgs
 } from 'igniteui-angular';
 
 @Component({
@@ -33,7 +33,7 @@ export class GridGroupBySampleComponent implements OnInit {
     constructor(@Inject(DisplayDensityToken) public displayDensityOptions: IDisplayDensityOptions) { }
 
     public ngOnInit(): void {
-        for (let i = 0; i < 60; i++) {
+        for (let i = 0; i < 2500; i++) {
             this.data2.push(...Array(10).fill({ STATUS: 'A', FIELD: 'some text' }));
             this.data2.push(...Array(10).fill({ STATUS: 'B', FIELD: 'some text' }));
             this.data2.push(...Array(10).fill({ STATUS: 'C', FIELD: 'some text' }));
@@ -173,5 +173,9 @@ export class GridGroupBySampleComponent implements OnInit {
     public hideGroupableRow() {
         this.grid1.showGroupArea = !this.grid1.showGroupArea;
         this.grid1.cdr.detectChanges();
+    }
+
+    public rowSelectionChanged(e: IRowSelectionEventArgs) {
+        console.log(e);
     }
 }

--- a/src/app/grid-selection/grid-selection.sample.html
+++ b/src/app/grid-selection/grid-selection.sample.html
@@ -17,7 +17,7 @@
     </div>
 
     <igx-grid #grid1 [data]="remote | async" [allowFiltering]="true" [primaryKey]="'ProductID'" (selected)="handleRowSelection()"
-            [width]="'800px'" [height]="'600px'"  (rowSelected)="log($event)">
+            [width]="'800px'" [height]="'600px'"  (rowSelectionChanging)="log($event)">
         <igx-column [field]="'ProductID'" [editable]="true" [width]="'80%'"></igx-column>
         <igx-column [field]="'ProductName'"></igx-column>
         <igx-column [field]="'UnitsInStock'"></igx-column>

--- a/src/app/grid-updates-test/grid-updates.component.html
+++ b/src/app/grid-updates-test/grid-updates.component.html
@@ -2,13 +2,13 @@
 <button (click)="stop()">Stop</button>
 
 <igx-grid
-    displayDensity="compact" 
+    displayDensity="compact"
     width="800px" height = "400px"
     [data]="data"
     [allowFiltering]="true"
     primaryKey = "id"
     filterMode="excelStyleFilter"
-    (rowSelected)="handleRowSelectionChange($event)"
+    (rowSelectionChanging)="handleRowSelectionChange($event)"
     rowSelection="single"
     #grid>
     <igx-column *ngFor="let each of nestedConfigColumns"

--- a/src/app/splitter/splitter.sample.html
+++ b/src/app/splitter/splitter.sample.html
@@ -43,7 +43,7 @@
 <div>Sample with Grids</div>
 <igx-splitter [type]="type" style='height: 60vh;'>
     <igx-splitter-pane minSize="100">
-        <igx-grid #grid1 class="grid" displayDensity="cosy" [rowSelection]="'single'" (rowSelected)="onCustomerSelection($event)"
+        <igx-grid #grid1 class="grid" displayDensity="cosy" [rowSelection]="'single'" (rowSelectionChanging)="onCustomerSelection($event)"
         [data]="data1" [isLoading]="true" [primaryKey]="'CustomerID'" [autoGenerate]="false">
             <igx-column field="CustomerID" [hidden]='true'></igx-column>
             <igx-column field="CompanyName"></igx-column>
@@ -53,7 +53,7 @@
         </igx-grid>
     </igx-splitter-pane>
     <igx-splitter-pane>
-        <igx-grid #grid2 class="grid" [rowSelection]="'single'" (rowSelected)="onOrderSelection($event)"  displayDensity="cosy" [data]="data2" [isLoading]="true" [primaryKey]="'OrderID'" [autoGenerate]="false">
+        <igx-grid #grid2 class="grid" [rowSelection]="'single'" (rowSelectionChanging)="onOrderSelection($event)"  displayDensity="cosy" [data]="data2" [isLoading]="true" [primaryKey]="'OrderID'" [autoGenerate]="false">
             <igx-column field="OrderID" [hidden]='true'></igx-column>
             <igx-column field="OrderDate"></igx-column>
             <igx-column field="ShipCountry"></igx-column>


### PR DESCRIPTION
Closes #9250 

Related to changes in PR #10088; see after screenshot - the bulk of the remaining slow down was caused by the Group selector click handler spamming single selects with event emits for each. Per this https://github.com/IgniteUI/igniteui-angular/issues/9405#issuecomment-881270263, with 30k-ish records in the group selection took a good 20s+ due to that.

Refactored two methods that do essentially the same as the single ones but in bulk and now the selection emits once but is also now decently quick. For comparison w/ the previous PR scenario:
![image](https://user-images.githubusercontent.com/3198469/141484212-5ad1a55a-1553-43b4-8f83-657e481025e4.png)

Further, with 30k rows the click handler is in the 115ms range and acceptable 300ms for 100k rows (local dev run w/ profiler running), so it scales more or less linearly. Also being finally profile at higher count, the previously fixed `selectedRowsInTheGroup` became the slowest link again, so further improved as well.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [x] This PR contains breaking changes
 - [x] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 