### PR TITLE
Remove unnecessary leaf records from pivot data.

### DIFF
--- a/projects/igniteui-angular/src/lib/data-operations/pivot-strategy.ts
+++ b/projects/igniteui-angular/src/lib/data-operations/pivot-strategy.ts
@@ -110,14 +110,7 @@ export class PivotColumnDimensionsStrategy implements IPivotDimensionStrategy {
                     if (k.indexOf(pivotKeys.records) !== -1) {
                         if (hierarchy[k] && hierarchy[k].length > 0 && k !== pivotKeys.records) {
                             const unprocessed = hierarchy[k].filter(r => !r.processed);
-                            const res = this.processHierarchy(unprocessed, columns, values, pivotKeys);
-                            if (res.length !== unprocessed.length) {
-                                // some records should be removed from the final flat collection
-                                // since this is no longer the final pipe just mark it for removal.
-                                unprocessed.forEach(element => {
-                                    element.remove = true;
-                                });
-                            }
+                            this.processHierarchy(unprocessed, columns, values, pivotKeys);
                         }
                         //delete hierarchy[k];
                     }
@@ -126,10 +119,6 @@ export class PivotColumnDimensionsStrategy implements IPivotDimensionStrategy {
                     }
                 });
                 delete hierarchy.processed;
-                if (this.isLeaf(hierarchy, pivotKeys)) {
-                    delete hierarchy[pivotKeys.records]; /* remove the helper records of the actual records so that
-                        expand indicators can be rendered properly */
-                }
                 for (const property in flatCols) {
                     if (flatCols.hasOwnProperty(property)) {
                         hierarchy[property] = flatCols[property];

--- a/projects/igniteui-angular/src/lib/data-operations/pivot-strategy.ts
+++ b/projects/igniteui-angular/src/lib/data-operations/pivot-strategy.ts
@@ -110,7 +110,14 @@ export class PivotColumnDimensionsStrategy implements IPivotDimensionStrategy {
                     if (k.indexOf(pivotKeys.records) !== -1) {
                         if (hierarchy[k] && hierarchy[k].length > 0 && k !== pivotKeys.records) {
                             const unprocessed = hierarchy[k].filter(r => !r.processed);
-                            this.processHierarchy(unprocessed, columns, values, pivotKeys);
+                            const res = this.processHierarchy(unprocessed, columns, values, pivotKeys);
+                            if (res.length !== unprocessed.length) {
+                                // some records should be removed from the final flat collection
+                                // since this is no longer the final pipe just mark it for removal.
+                                unprocessed.forEach(element => {
+                                    element.remove = true;
+                                });
+                            }
                         }
                         //delete hierarchy[k];
                     }

--- a/projects/igniteui-angular/src/lib/data-operations/pivot-strategy.ts
+++ b/projects/igniteui-angular/src/lib/data-operations/pivot-strategy.ts
@@ -121,7 +121,6 @@ export class PivotColumnDimensionsStrategy implements IPivotDimensionStrategy {
                         delete hierarchy[k];
                     }
                 });
-                delete hierarchy.processed;
                 for (const property in flatCols) {
                     if (flatCols.hasOwnProperty(property)) {
                         hierarchy[property] = flatCols[property];

--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.pipes.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.pipes.spec.ts
@@ -706,7 +706,7 @@ describe('Pivot pipes', () => {
         const rowPipeResult = rowPipe.transform(data, pivotConfig, expansionStates);
         const columnPipeResult = columnPipe.transform(rowPipeResult, pivotConfig, new Map<any, boolean>());
         const rowStatePipeResult = rowStatePipe.transform(columnPipeResult, pivotConfig, expansionStates);
-        expect(rowStatePipeResult.length).toEqual(44);
+        expect(rowStatePipeResult.length).toEqual(36);
         expect(rowStatePipeResult[0]['AllPeriods']).toEqual('All Periods');
         expect(rowStatePipeResult[0]['AllProducts']).toEqual('All');
         expect(rowStatePipeResult[0]['ProductCategory']).not.toBeDefined();

--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.pipes.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.pipes.ts
@@ -68,8 +68,9 @@ export class IgxPivotRowExpansionPipe implements PipeTransform {
             PivotUtil.flattenHierarchy(data, config, row, expansionStates, pivotKeys, totalLlv, prevDims, 0);
             prevDims.push(row);
         }
-        this.cleanState(data, pivotKeys);
-        return data;
+        const finalData = data.filter(x => !x.remove);
+        this.cleanState(finalData, pivotKeys);
+        return finalData;
     }
 
     private cleanState(data, pivotKeys) {

--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.pipes.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.pipes.ts
@@ -77,6 +77,7 @@ export class IgxPivotRowExpansionPipe implements PipeTransform {
     private cleanState(data, pivotKeys) {
         data.forEach(rec => {
             const keys = Object.keys(rec);
+            delete rec.processed;
             //remove all record keys from final data since we don't need them anymore.
             keys.forEach(k => {
                 if (k.indexOf(pivotKeys.records) !== -1) {

--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.pipes.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.pipes.ts
@@ -68,7 +68,7 @@ export class IgxPivotRowExpansionPipe implements PipeTransform {
             PivotUtil.flattenHierarchy(data, config, row, expansionStates, pivotKeys, totalLlv, prevDims, 0);
             prevDims.push(row);
         }
-        const finalData = data.filter(x => x[pivotKeys.records]);
+        const finalData = config.columnStrategy ? data : data.filter(x => x[pivotKeys.records]);
         this.cleanState(finalData, pivotKeys);
         return finalData;
     }

--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.pipes.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.pipes.ts
@@ -68,7 +68,7 @@ export class IgxPivotRowExpansionPipe implements PipeTransform {
             PivotUtil.flattenHierarchy(data, config, row, expansionStates, pivotKeys, totalLlv, prevDims, 0);
             prevDims.push(row);
         }
-        const finalData = data.filter(x => !x.remove);
+        const finalData = data.filter(x => x[pivotKeys.records]);
         this.cleanState(finalData, pivotKeys);
         return finalData;
     }

--- a/src/app/pivot-grid/pivot-grid.sample.ts
+++ b/src/app/pivot-grid/pivot-grid.sample.ts
@@ -71,6 +71,10 @@ export class PivotGridSampleComponent {
                     memberName: 'ProductCategory',
                     enabled: true
                 }
+            },
+            {
+                memberName: 'SellerName',
+                enabled: true
             }
         ],
         values: [


### PR DESCRIPTION
Closes #10609
Closes #10610  

Previously the column pipe was removing these, but the column pipe just applies aggregations now, so moving that logic to the last pipe (expand/collapse pipe).

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 