### PR TITLE
test(overlay): fix block strategy tests

### DIFF
--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -1212,17 +1212,18 @@ describe('igxOverlay', () => {
             spyOn(scrollStrat, 'attach').and.callThrough();
             spyOn(scrollStrat, 'detach').and.callThrough();
             const scrollSpy = spyOn<any>(scrollStrat, 'onScroll').and.callThrough();
-            overlay.show(overlay.attach(SimpleDynamicComponent, overlaySettings));
+            const overlayId = overlay.attach(SimpleDynamicComponent, overlaySettings);
+            overlay.show(overlayId);
             tick();
 
             expect(scrollStrat.attach).toHaveBeenCalledTimes(1);
             expect(scrollStrat.initialize).toHaveBeenCalledTimes(1);
             expect(scrollStrat.detach).toHaveBeenCalledTimes(0);
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             expect(scrollSpy).toHaveBeenCalledTimes(1);
 
-            overlay.hide('0');
-            overlay.detach('0');
+            overlay.hide(overlayId);
+            overlay.detach(overlayId);
             tick();
             expect(scrollStrat.detach).toHaveBeenCalledTimes(1);
         }));
@@ -1258,7 +1259,7 @@ describe('igxOverlay', () => {
             expect(scrollStrat.attach).toHaveBeenCalledTimes(1);
             expect(scrollStrat.initialize).toHaveBeenCalledTimes(1);
             expect(scrollStrat.detach).toHaveBeenCalledTimes(0);
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             expect(scrollSpy).toHaveBeenCalledTimes(1);
             overlay.hide('0');
             overlay.detach('0');
@@ -1299,7 +1300,7 @@ describe('igxOverlay', () => {
             expect(scrollSpy).toHaveBeenCalledTimes(1);
             expect(overlay.reposition).not.toHaveBeenCalled();
 
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             expect(scrollSpy).toHaveBeenCalledTimes(2);
             expect(overlay.reposition).toHaveBeenCalledTimes(1);
             expect(overlay.reposition).toHaveBeenCalledWith(id);
@@ -1795,12 +1796,12 @@ describe('igxOverlay', () => {
             expect(overlayChildPosition.y).toEqual(0);
             expect(buttonElement.getBoundingClientRect().y).toEqual(0);
 
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
             expect(document.documentElement.scrollTop).toEqual(0);
 
             document.documentElement.scrollTop += 25;
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
             expect(document.documentElement.scrollTop).toEqual(25);
             contentElement = (fixture.nativeElement as HTMLElement)
@@ -1810,7 +1811,7 @@ describe('igxOverlay', () => {
             expect(buttonElement.getBoundingClientRect().y).toEqual(-25);
 
             document.documentElement.scrollTop += 500;
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
             contentElement = (fixture.nativeElement as HTMLElement)
                 .parentElement.getElementsByClassName(CLASS_OVERLAY_CONTENT)[0] as HTMLElement;
@@ -2374,18 +2375,21 @@ describe('igxOverlay', () => {
 
             const scrollSpy = spyOn<any>(scrollStrategy, 'onScroll').and.callThrough();
 
-            overlay.show(overlay.attach(SimpleDynamicComponent, overlaySettings));
+            const overlayId = overlay.attach(SimpleDynamicComponent, overlaySettings);
+            overlay.show(overlayId);
             tick();
             expect(scrollStrategy.initialize).toHaveBeenCalledTimes(1);
             expect(scrollStrategy.attach).toHaveBeenCalledTimes(1);
             expect(scrollStrategy.detach).toHaveBeenCalledTimes(0);
             expect(overlay.hide).toHaveBeenCalledTimes(0);
             document.documentElement.scrollTop += scrollTolerance;
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
             expect(scrollSpy).toHaveBeenCalledTimes(1);
             expect(overlay.hide).toHaveBeenCalledTimes(0);
             expect(scrollStrategy.detach).toHaveBeenCalledTimes(0);
+
+            overlay.detach(overlayId);
         }));
 
         it('Should persist the component open state when scrolling and absolute scroll strategy is used.', fakeAsync(() => {
@@ -2414,7 +2418,7 @@ describe('igxOverlay', () => {
             expect(scrollStrategy.attach).toHaveBeenCalledTimes(1);
 
             document.documentElement.scrollTop += scrollTolerance;
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
             expect(scrollSpy).toHaveBeenCalledTimes(1);
             expect(scrollStrategy.detach).toHaveBeenCalledTimes(0);
@@ -2858,18 +2862,21 @@ describe('igxOverlay', () => {
 
             const scrollSpy = spyOn<any>(scrollStrategy, 'onScroll').and.callThrough();
 
-            overlay.show(overlay.attach(SimpleDynamicComponent, overlaySettings));
+            const overlayId = overlay.attach(SimpleDynamicComponent, overlaySettings);
+            overlay.show(overlayId);
             tick();
             expect(scrollStrategy.initialize).toHaveBeenCalledTimes(1);
             expect(scrollStrategy.attach).toHaveBeenCalledTimes(1);
             expect(scrollStrategy.detach).toHaveBeenCalledTimes(0);
             expect(overlay.hide).toHaveBeenCalledTimes(0);
             document.documentElement.scrollTop += scrollTolerance;
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
             expect(scrollSpy).toHaveBeenCalledTimes(1);
             expect(overlay.hide).toHaveBeenCalledTimes(0);
             expect(scrollStrategy.detach).toHaveBeenCalledTimes(0);
+
+            overlay.detach(overlayId);
         }));
 
         it('Should persist the component open state when scrolling and absolute scroll strategy is used.', fakeAsync(() => {
@@ -2898,7 +2905,7 @@ describe('igxOverlay', () => {
             expect(scrollStrategy.attach).toHaveBeenCalledTimes(1);
 
             document.documentElement.scrollTop += scrollTolerance;
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
             expect(scrollSpy).toHaveBeenCalledTimes(1);
             expect(scrollStrategy.detach).toHaveBeenCalledTimes(0);
@@ -3273,7 +3280,7 @@ describe('igxOverlay', () => {
 
             document.documentElement.scrollTop = 100;
             document.documentElement.scrollLeft = 50;
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
 
             expect(componentRect).toEqual(componentElement.getBoundingClientRect());
@@ -3285,7 +3292,7 @@ describe('igxOverlay', () => {
         it('Should retain the component state when scrolling and block scroll strategy is used.', fakeAsync(async () => {
             TestBed.overrideComponent(EmptyPageComponent, {
                 set: {
-                    styles: [`button { position: absolute, bottom: -2000px; } `]
+                    styles: [`button { position: absolute; bottom: -2000px; } `]
                 }
             });
             await TestBed.compileComponents();
@@ -3305,17 +3312,17 @@ describe('igxOverlay', () => {
             overlay.show(overlayId);
             tick();
             expect(document.documentElement.scrollTop).toEqual(0);
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
             expect(document.documentElement.scrollTop).toEqual(0);
 
             document.documentElement.scrollTop += 25;
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
             expect(document.documentElement.scrollTop).toEqual(0);
 
             document.documentElement.scrollTop += 1000;
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
 
             const wrapperElement = (fixture.nativeElement as HTMLElement)
@@ -3695,7 +3702,7 @@ describe('igxOverlay', () => {
 
             document.documentElement.scrollTop = 100;
             document.documentElement.scrollLeft = 50;
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
 
             expect(componentRect).toEqual(componentElement.getBoundingClientRect());
@@ -3733,7 +3740,7 @@ describe('igxOverlay', () => {
 
                 document.documentElement.scrollTop = 40;
                 document.documentElement.scrollLeft = 30;
-                document.dispatchEvent(new Event('scroll'));
+                document.documentElement.dispatchEvent(new Event('scroll'));
                 tick();
 
                 expect(componentRect).toEqual(componentElement.getBoundingClientRect());
@@ -3818,7 +3825,7 @@ describe('igxOverlay', () => {
                 expect(document.documentElement.scrollTop).toEqual(0);
 
                 document.documentElement.scrollTop += scrollTolerance;
-                document.dispatchEvent(new Event('scroll'));
+                document.documentElement.dispatchEvent(new Event('scroll'));
                 tick();
                 expect(document.documentElement.scrollTop).toEqual(scrollTolerance);
                 const wrapperElement = (fixture.nativeElement as HTMLElement)
@@ -3905,7 +3912,7 @@ describe('igxOverlay', () => {
                 const componentRect = componentElement.getBoundingClientRect();
 
                 document.documentElement.scrollTop += scrollTolerance;
-                document.dispatchEvent(new Event('scroll'));
+                document.documentElement.dispatchEvent(new Event('scroll'));
                 tick();
                 expect(document.documentElement.scrollTop).toEqual(scrollTolerance);
                 expect(document.getElementsByClassName(CLASS_OVERLAY_WRAPPER).length).toEqual(1);
@@ -3946,7 +3953,7 @@ describe('igxOverlay', () => {
             const componentRect = componentElement.getBoundingClientRect();
 
             document.documentElement.scrollTop += scrollTolerance;
-            document.dispatchEvent(new Event('scroll'));
+            document.documentElement.dispatchEvent(new Event('scroll'));
             tick();
             const newElementRect = componentElement.getBoundingClientRect();
             expect(document.documentElement.scrollTop).toEqual(scrollTolerance);


### PR DESCRIPTION
Fix overlay's block scroll strategy test that didn't setup the test bed correctly and didn't dispatch the event on the correct target
Also properly detach to clear active strategies and dispatch scroll consistently (except for close strategy)

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [x] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 