### PR TITLE
Fix overlay modal wrapper without animations - 12.3.x

### DIFF
--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -2961,8 +2961,12 @@ describe('igxOverlay', () => {
 
             expect(wrapperElement).toBeDefined();
             const styles = css(wrapperElement);
-            expect(styles.findIndex((e) => e.includes('--background-color: var(--igx-overlay-background-color, hsla(var(--igx-grays-500), 0.54));'))).toBeGreaterThan(-1);
-            expect(styles.findIndex((e) => e.includes('background: var(--background-color);'))).toBeGreaterThan(-1);
+            const backgroundColorCssCustomProperty =
+                '--background-color: var(--igx-overlay-background-color, hsla(var(--igx-grays-500), 0.54));';
+            const backgroundCSS = 'background: var(--background-color);';
+            expect(styles.findIndex((e) => e.indexOf(backgroundColorCssCustomProperty) > -1))
+                .toBeGreaterThan(-1);
+            expect(styles.findIndex((e) => e.indexOf(backgroundCSS) > -1)).toBeGreaterThan(-1);
 
             fixture.componentInstance.overlay.detachAll();
         }));
@@ -2984,8 +2988,12 @@ describe('igxOverlay', () => {
                 .parentElement.getElementsByClassName(CLASS_OVERLAY_WRAPPER_MODAL)[0] as HTMLElement;
             expect(wrapperElement).toBeDefined();
             const styles = css(wrapperElement);
-            expect(styles.findIndex((e) => e.includes('--background-color: var(--igx-overlay-background-color, hsla(var(--igx-grays-500), 0.54));'))).toBeGreaterThan(-1);
-            expect(styles.findIndex((e) => e.includes('background: var(--background-color);'))).toBeGreaterThan(-1);
+            const backgroundColorCssCustomProperty =
+                '--background-color: var(--igx-overlay-background-color, hsla(var(--igx-grays-500), 0.54));';
+            const backgroundCSS = 'background: var(--background-color);';
+            expect(styles.findIndex((e) => e.indexOf(backgroundColorCssCustomProperty) > -1))
+                .toBeGreaterThan(-1);
+            expect(styles.findIndex((e) => e.indexOf(backgroundCSS) > -1)).toBeGreaterThan(-1);
         }));
 
         it('Should allow interaction only for the shown component when is modal.', fakeAsync(() => {

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -2958,15 +2958,7 @@ describe('igxOverlay', () => {
 
             const wrapperElement = (fixture.nativeElement as HTMLElement)
                 .parentElement.getElementsByClassName(CLASS_OVERLAY_WRAPPER_MODAL)[0] as HTMLElement;
-
             expect(wrapperElement).toBeDefined();
-            const styles = css(wrapperElement);
-            const backgroundColorCssCustomProperty =
-                '--background-color: var(--igx-overlay-background-color, hsla(var(--igx-grays-500), 0.54));';
-            const backgroundCSS = 'background: var(--background-color);';
-            expect(styles.findIndex((e) => e.indexOf(backgroundColorCssCustomProperty) > -1))
-                .toBeGreaterThan(-1);
-            expect(styles.findIndex((e) => e.indexOf(backgroundCSS) > -1)).toBeGreaterThan(-1);
 
             fixture.componentInstance.overlay.detachAll();
         }));
@@ -2987,13 +2979,8 @@ describe('igxOverlay', () => {
             const wrapperElement = (fixture.nativeElement as HTMLElement)
                 .parentElement.getElementsByClassName(CLASS_OVERLAY_WRAPPER_MODAL)[0] as HTMLElement;
             expect(wrapperElement).toBeDefined();
-            const styles = css(wrapperElement);
-            const backgroundColorCssCustomProperty =
-                '--background-color: var(--igx-overlay-background-color, hsla(var(--igx-grays-500), 0.54));';
-            const backgroundCSS = 'background: var(--background-color);';
-            expect(styles.findIndex((e) => e.indexOf(backgroundColorCssCustomProperty) > -1))
-                .toBeGreaterThan(-1);
-            expect(styles.findIndex((e) => e.indexOf(backgroundCSS) > -1)).toBeGreaterThan(-1);
+
+            fixture.componentInstance.overlay.detachAll();
         }));
 
         it('Should allow interaction only for the shown component when is modal.', fakeAsync(() => {

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -2946,24 +2946,47 @@ describe('igxOverlay', () => {
 
         // 3. Interaction
         // 3.1 Modal
-        // it('Should apply a greyed-out mask layers when is modal.', fakeAsync(() => {
-        //     const fixture = TestBed.createComponent(EmptyPageComponent);
-        //     const overlay = fixture.componentInstance.overlay;
-        //     const overlaySettings: OverlaySettings = {
-        //         modal: true,
-        //     };
+        it('Should apply a greyed-out mask layers when is modal.', fakeAsync(() => {
+            const fixture = TestBed.createComponent(EmptyPageComponent);
+            const overlay = fixture.componentInstance.overlay;
+            const overlaySettings: OverlaySettings = {
+                modal: true,
+            };
 
-        //     overlay.show(overlay.attach(SimpleDynamicComponent, overlaySettings));
-        //     tick();
+            overlay.show(overlay.attach(SimpleDynamicComponent, overlaySettings));
+            tick(100);
 
-        //     const wrapperElement = (fixture.nativeElement as HTMLElement)
-        //         .parentElement.getElementsByClassName(CLASS_OVERLAY_WRAPPER_MODAL)[0] as HTMLElement;
-        //     const styles = css(wrapperElement);
-        //     const expectedBackgroundColor = 'background: var(--background-color)';
-        //     const appliedBackgroundStyles = styles[2];
-        //     console.log(appliedBackgroundStyles);
-        //     expect(appliedBackgroundStyles).toContain(expectedBackgroundColor);
-        // }));
+            const wrapperElement = (fixture.nativeElement as HTMLElement)
+                .parentElement.getElementsByClassName(CLASS_OVERLAY_WRAPPER_MODAL)[0] as HTMLElement;
+
+            expect(wrapperElement).toBeDefined();
+            const styles = css(wrapperElement);
+            expect(styles.findIndex((e) => e.includes('--background-color: var(--igx-overlay-background-color, hsla(var(--igx-grays-500), 0.54));'))).toBeGreaterThan(-1);
+            expect(styles.findIndex((e) => e.includes('background: var(--background-color);'))).toBeGreaterThan(-1);
+
+            fixture.componentInstance.overlay.detachAll();
+        }));
+
+        it('Should apply a greyed-out mask layers when is modal and has no animation.', fakeAsync(() => {
+            const fixture = TestBed.createComponent(EmptyPageComponent);
+            const overlay = fixture.componentInstance.overlay;
+            const overlaySettings: OverlaySettings = {
+                modal: true,
+                positionStrategy: new GlobalPositionStrategy({
+                    openAnimation: null,
+                    closeAnimation: null
+                })
+            };
+            overlay.show(overlay.attach(SimpleDynamicComponent, overlaySettings));
+            tick(100);
+
+            const wrapperElement = (fixture.nativeElement as HTMLElement)
+                .parentElement.getElementsByClassName(CLASS_OVERLAY_WRAPPER_MODAL)[0] as HTMLElement;
+            expect(wrapperElement).toBeDefined();
+            const styles = css(wrapperElement);
+            expect(styles.findIndex((e) => e.includes('--background-color: var(--igx-overlay-background-color, hsla(var(--igx-grays-500), 0.54));'))).toBeGreaterThan(-1);
+            expect(styles.findIndex((e) => e.includes('background: var(--background-color);'))).toBeGreaterThan(-1);
+        }));
 
         it('Should allow interaction only for the shown component when is modal.', fakeAsync(() => {
             // Utility handler meant for later detachment

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
@@ -411,8 +411,8 @@ export class IgxOverlayService implements OnDestroy {
             document,
             true,
             info.settings.target);
+        this.addModalClasses(info);
         if (info.settings.positionStrategy.settings.openAnimation) {
-            this.buildAnimationPlayers(info);
             this.playOpenAnimation(info);
         } else {
             //  to eliminate flickering show the element just before opened fires
@@ -532,6 +532,7 @@ export class IgxOverlayService implements OnDestroy {
         if (eventArgs.cancel) {
             return;
         }
+        this.removeModalClasses(info);
         if (info.settings.positionStrategy.settings.closeAnimation) {
             this.playCloseAnimation(info, event);
         } else {
@@ -724,7 +725,6 @@ export class IgxOverlayService implements OnDestroy {
         //  to eliminate flickering show the element just before animation start
         info.wrapperElement.style.visibility = '';
         info.visible = true;
-        this.addModalClasses(info);
         info.openAnimationPlayer.play();
     }
 
@@ -752,7 +752,6 @@ export class IgxOverlayService implements OnDestroy {
 
         this.animationStarting.emit({ id: info.id, animationPlayer: info.closeAnimationPlayer, animationType: 'close' });
         info.event = event;
-        this.removeModalClasses(info);
         info.closeAnimationPlayer.play();
     }
 

--- a/src/app/overlay/overlay.sample.html
+++ b/src/app/overlay/overlay.sample.html
@@ -62,6 +62,10 @@
                     (change)="onSwitchChange($event)">Open in outlet</igx-switch>
             </div>
             <div>
+                <igx-switch class="settings" [(ngModel)]="hasAnimation" name="outlet" [value]="hasAnimation"
+                    (change)="onSwitchChange($event)">Has animation</igx-switch>
+            </div>
+            <div>
                 <igx-input-group>
                     <input igxInput name="dropDownItems" type="number" [(ngModel)]="itemsCount">
                     <label igxLabel for="dropDownItems">Drop down items</label>

--- a/src/app/overlay/overlay.sample.ts
+++ b/src/app/overlay/overlay.sample.ts
@@ -49,6 +49,7 @@ export class OverlaySampleComponent implements OnInit {
     public closeOnOutsideClick = true;
     public modal = true;
     public useOutlet = false;
+    public hasAnimation = true;
     public animationLength = 300; // in ms
 
     private xAddition = 0;
@@ -347,6 +348,10 @@ export class OverlaySampleComponent implements OnInit {
                 = `${this.animationLength}ms`;
             (this._overlaySettings.positionStrategy.settings.closeAnimation.options.params as IAnimationParams).duration
                 = `${this.animationLength}ms`;
+            if (!this.hasAnimation) {
+                this._overlaySettings.positionStrategy.settings.openAnimation = null;
+                this._overlaySettings.positionStrategy.settings.closeAnimation = null;
+            }
         }
         this.igxDropDown.toggle(this._overlaySettings);
     }


### PR DESCRIPTION
We should add modal classes when there is no open animation and remove them when there is no close animation.

Closes #10944 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 