### PR TITLE
Workaround for grid features that directly modify the columnsList ContentChildren collection.

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
@@ -518,7 +518,7 @@ export interface GridType extends IGridDataBindable {
     clearGrouping?(field: string): void;
     groupBy?(expression: IGroupingExpression | Array<IGroupingExpression>): void;
     resolveOutlet?(): IgxOverlayOutletDirective;
-
+    updateColumns(columns: ColumnType[]): void;
     getSelectedRanges(): GridSelectionRange[];
     deselectAllColumns(): void;
     deselectColumns(columns: string[] | ColumnType[]): void;

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -3325,7 +3325,8 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
         this._setupServices();
         this._setupListeners();
         this.rowListDiffer = this.differs.find([]).create(null);
-        this.columnListDiffer = this.differs.find([]).create(null);
+        // compare based on field, not on object ref.
+        this.columnListDiffer = this.differs.find([]).create((index, col: ColumnType) => col.field);
         this.calcWidth = this.width && this.width.indexOf('%') === -1 ? parseInt(this.width, 10) : 0;
         this.shouldGenerate = this.autoGenerate;
     }
@@ -6220,14 +6221,25 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
      * @hidden
      */
     protected _moveColumns(from: IgxColumnComponent, to: IgxColumnComponent, pos: DropPosition) {
-        Promise.resolve().then(() => {
-            const list = this.columnList.toArray();
-            this._reorderColumns(from, to, pos, list);
-            const newList = this._resetColumnList(list);
-            this.columnList.reset(newList);
-            this.columnList.notifyOnChanges();
-            this._columns = this.columnList.toArray();
-        });
+        const list = this.columnList.toArray();
+        this._reorderColumns(from, to, pos, list);
+        const newList = this._resetColumnList(list);
+        this.updateColumns(newList);
+    }
+
+
+    /**
+     * Update internal column's collection.
+     * @hidden
+     */
+    public updateColumns(newColumns:IgxColumnComponent[]) {
+        // update internal collections to retain order.
+        this._pinnedColumns = newColumns
+            .filter((c) => c.pinned);
+        this._unpinnedColumns = newColumns.filter((c) => !c.pinned);
+        this.columnList.reset(newColumns);
+        this.columnList.notifyOnChanges();
+        this._columns = this.columnList.toArray();
     }
 
     /**
@@ -6745,7 +6757,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
             .filter((c) => c.pinned).sort((a, b) => this._pinnedColumns.indexOf(a) - this._pinnedColumns.indexOf(b));
         this._unpinnedColumns = this.hasColumnGroups ? this.columnList.filter((c) => !c.pinned) :
             this.columnList.filter((c) => !c.pinned)
-                .sort((a, b) => a.index - b.index);
+                .sort((a, b) => this._unpinnedColumns.findIndex(x => x.field === a.field) - this._unpinnedColumns.findIndex(x => x.field === b.field));
     }
 
     protected extractDataFromSelection(source: any[], formatters = false, headers = false, columnData?: any[]): any[] {

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -6235,7 +6235,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
     public updateColumns(newColumns:IgxColumnComponent[]) {
         // update internal collections to retain order.
         this._pinnedColumns = newColumns
-            .filter((c) => c.pinned);
+        .filter((c) => c.pinned).sort((a, b) => this._pinnedColumns.indexOf(a) - this._pinnedColumns.indexOf(b));
         this._unpinnedColumns = newColumns.filter((c) => !c.pinned);
         this.columnList.reset(newColumns);
         this.columnList.notifyOnChanges();

--- a/projects/igniteui-angular/src/lib/grids/state.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/state.directive.ts
@@ -228,8 +228,7 @@ export class IgxGridStateDirective {
                         newColumns.push(ref.instance);
                     }
                 });
-                context.currGrid.columnList.reset(newColumns);
-                context.currGrid.columnList.notifyOnChanges();
+                context.grid.updateColumns(newColumns);
             }
         },
         groupBy: {

--- a/src/app/grid-master-detail/grid-master-detail.sample.html
+++ b/src/app/grid-master-detail/grid-master-detail.sample.html
@@ -1,5 +1,7 @@
 <div class="wrapper">
-    <igx-grid #grid1 [data]="data" [width]="'820px'" [height]="'700px'" [autoGenerate]='false' [moving]="true">
+    <button igxButton="outlined" (click)="saveState()">SAVE STATE</button>
+    <button igxButton="raised" (click)="restoreState()">RESTORE STATE</button>
+    <igx-grid igxGridState #grid1 [data]="data" [width]="'820px'" [height]="'700px'" [autoGenerate]='false' [moving]="true">
         <igx-column *ngFor="let c of columns" [sortable]="true" [field]="c.field" [header]="c.field" [width]="c.width"
             [hidden]='c.hidden' [sortable]="true" [groupable]="true" [editable]="true" [hasSummary]="true" [dataType]='c.dataType'>
         </igx-column>
@@ -18,7 +20,7 @@
         </igx-column-layout> -->
         <ng-template igxGridDetail let-dataItem>
             <div>
-                <div><span class='categoryStyle'>Country:</span> {{dataItem.Country}}</div>
+                <div *ngIf="dataItem.Country"><span class='categoryStyle'>Country:</span> {{dataItem.Country}}</div>
                 <div><span class='categoryStyle'>City:</span> {{dataItem.City}}</div>
                 <div><span class='categoryStyle'>Address:</span> {{dataItem.Address}}</div>
             </div>

--- a/src/app/grid-master-detail/grid-master-detail.sample.ts
+++ b/src/app/grid-master-detail/grid-master-detail.sample.ts
@@ -1,7 +1,7 @@
 /* eslint-disable max-len */
 import { Component, ViewChild, OnInit, Inject } from '@angular/core';
 
-import { IgxGridComponent } from 'igniteui-angular';
+import { IgxGridComponent, IgxGridStateDirective } from 'igniteui-angular';
 import { DisplayDensity, IDisplayDensityOptions, DisplayDensityToken } from 'projects/igniteui-angular/src/lib/core/density';
 
 @Component({
@@ -65,4 +65,17 @@ export class GridMasterDetailSampleComponent implements OnInit {
     public toggleFirstRow() {
         this.grid1.toggleRow(this.data[0]);
     }
+
+    @ViewChild(IgxGridStateDirective, { static: true })
+    public state!: IgxGridStateDirective;
+
+    public saveState() {
+        const state = this.state.getState() as string;
+        window.sessionStorage.setItem('grid-state', state);
+      }
+    
+      public restoreState() {
+        const state = window.sessionStorage.getItem('grid-state');
+        this.state.setState(state as string);
+      }
 }


### PR DESCRIPTION
Note: This is a workaround. It would be best for grid features (like moving and state directive) to not modify collections that are bound to angular's templates as they are changed any time a structural directive like ngIf, ngFor etc. is resolved in any internal template. Hence depending on such a collection to retain state is not ideal.

Closes #11298   

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 