### PR TITLE
fix(splitter): Preserve pane sizes when expanding/collapsing

### DIFF
--- a/projects/igniteui-angular/src/lib/splitter/splitter-pane/splitter-pane.component.ts
+++ b/projects/igniteui-angular/src/lib/splitter/splitter-pane/splitter-pane.component.ts
@@ -126,6 +126,7 @@ export class IgxSplitterPaneComponent {
 
     public set size(value) {
         this._size = value;
+        this.previousSize = value !== 'auto' ? value : this.previousSize;
         this.el.nativeElement.style.flex = this.flex;
     }
 
@@ -173,10 +174,10 @@ export class IgxSplitterPaneComponent {
      * ```
      */
     @Input()
-    public set collapsed(value) {
+    public set collapsed(value) {   
         if (this.owner) {
             // reset sibling sizes when pane collapse state changes.
-            this._getSiblings().forEach(sibling => sibling.size = 'auto');
+            this._getSiblings().forEach(sibling => sibling.size = value ? 'auto' : sibling.previousSize);
         }
         this._collapsed = value;
         this.display = this._collapsed ? 'none' : 'flex' ;
@@ -187,9 +188,21 @@ export class IgxSplitterPaneComponent {
         return this._collapsed;
     }
 
+    /**
+     * @hidden @internal
+     */
+     public set previousSize(value) {
+        this._previousSize = value;
+    }
+
+    public get previousSize() {
+        return this._previousSize;
+    }
+
     private _size = 'auto';
     private _dragSize;
     private _collapsed = false;
+    private _previousSize = 'auto';
 
 
     constructor(private el: ElementRef) { }

--- a/projects/igniteui-angular/src/lib/splitter/splitter.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/splitter/splitter.component.spec.ts
@@ -430,6 +430,34 @@ describe('IgxSplitter pane collapse', () => {
             expect(pane.size).toBe('auto');
         });
     });
+    
+    it('should preserve pane sizes when collapsing and expanding', () => {
+        fixture.componentInstance.type = SplitterType.Vertical;
+        fixture.detectChanges();
+        const panes = splitter.panes.toArray();
+        const pane1 = panes[0];
+        const pane2 = panes[1];
+        pane1.size = '50px';
+        pane2.size = '50px';
+        fixture.detectChanges();
+
+        const splitterBarComponent = fixture.debugElement.query(By.css(SPLITTERBAR_CLASS));
+        splitterBarComponent.nativeElement.focus();
+        UIInteractions.triggerEventHandlerKeyDown('ArrowDown', splitterBarComponent);
+        fixture.detectChanges();
+        splitterBarComponent.context.movingEnd.emit(-10);
+
+        const pane1_size = pane1.size;
+        const pane2_size = pane2.size;
+        pane1.collapsed = true;
+        fixture.detectChanges();
+        expect(pane2.size).toBe('auto');
+        pane1.collapsed = false;
+        fixture.detectChanges();
+        expect(pane1_size).toBe(pane1.size);
+        expect(pane2_size).toBe(pane2.size);
+
+    });
 });
 
 @Component({

--- a/projects/igniteui-angular/src/lib/splitter/splitter.component.ts
+++ b/projects/igniteui-angular/src/lib/splitter/splitter.component.ts
@@ -169,7 +169,7 @@ export class IgxSplitterComponent implements AfterContentInit {
     }
     public set type(value) {
         this._type = value;
-        this.resetPaneSizes();
+        this.resetPaneSizes(this.panes?.filter(x => x.collapsed).length === 0);
     }
 
     /**
@@ -294,7 +294,7 @@ export class IgxSplitterComponent implements AfterContentInit {
         this.assignFlexOrder();
         if (this.panes.filter(x => x.collapsed).length > 0) {
             // if any panes are collapsed, reset sizes.
-            this.resetPaneSizes();
+            this.resetPaneSizes(false);
         }
     }
 
@@ -302,10 +302,10 @@ export class IgxSplitterComponent implements AfterContentInit {
      * @hidden @internal
      * This method reset pane sizes.
      */
-    private resetPaneSizes() {
+    private resetPaneSizes(isTypeChanged) {
         if (this.panes) {
             // if type is changed runtime, should reset sizes.
-            this.panes.forEach(x => x.size = 'auto');
+            this.panes.forEach(x => x.size = isTypeChanged ? x.previousSize : 'auto');
         }
     }
 

--- a/src/app/splitter/splitter.sample.html
+++ b/src/app/splitter/splitter.sample.html
@@ -1,72 +1,12 @@
 <igx-switch (change)='changeType()' style="padding-left: 10px">Toggle Splitter Direction</igx-switch>
-<div>Simple sample</div>
-<igx-splitter style='height: 30vh;'>
-    <igx-splitter-pane size='20%'>
-        <div style='width:100%;'>
-           Pane 1
-        </div>
-    </igx-splitter-pane>
-    <igx-splitter-pane size='200px'>
-        <div style='width:100%;'>
-            Pane 2
-         </div>
-    </igx-splitter-pane>
-    <igx-splitter-pane>
-        <div style='width:100%;'>
-            Pane 3
-         </div>
-    </igx-splitter-pane>
-</igx-splitter>
-<div>Nested splitters sample</div>
-<igx-splitter style='height: 30vh;' [type]='0' >
-    <igx-splitter-pane>
-        <igx-splitter [type]='1' [style.width]='"100%"'>
-            <igx-splitter-pane>
-                Pane1.1
-            </igx-splitter-pane>
-            <igx-splitter-pane>
-                Pane1.2
-            </igx-splitter-pane>
-        </igx-splitter>
-    </igx-splitter-pane>
-    <igx-splitter-pane>
-        <igx-splitter [type]='1' [style.width]='"100%"'>
-            <igx-splitter-pane>
-                Pane2.1
-            </igx-splitter-pane>
-            <igx-splitter-pane>
-                Pane2.2
-            </igx-splitter-pane>
-        </igx-splitter>
-    </igx-splitter-pane>
-</igx-splitter>
-<div>Sample with Grids</div>
 <igx-splitter [type]="type" style='height: 60vh;'>
     <igx-splitter-pane minSize="100">
-        <igx-grid #grid1 class="grid" displayDensity="cosy" [rowSelection]="'single'" (rowSelectionChanging)="onCustomerSelection($event)"
-        [data]="data1" [isLoading]="true" [primaryKey]="'CustomerID'" [autoGenerate]="false">
-            <igx-column field="CustomerID" [hidden]='true'></igx-column>
-            <igx-column field="CompanyName"></igx-column>
-            <igx-column field="ContactName"></igx-column>
-            <igx-column field="ContactTitle"></igx-column>
-            <igx-column field="Country"></igx-column>
-        </igx-grid>
+        <div style="background-color: rgb(255, 112, 120); width: 100%; height: 100">Simple text</div>
     </igx-splitter-pane>
+    <!-- <igx-splitter-pane>
+        <div style="background-color: rgb(7, 234, 121); width: 100%; height: 100%;">More text</div>
+    </igx-splitter-pane> -->
     <igx-splitter-pane>
-        <igx-grid #grid2 class="grid" [rowSelection]="'single'" (rowSelectionChanging)="onOrderSelection($event)"  displayDensity="cosy" [data]="data2" [isLoading]="true" [primaryKey]="'OrderID'" [autoGenerate]="false">
-            <igx-column field="OrderID" [hidden]='true'></igx-column>
-            <igx-column field="OrderDate"></igx-column>
-            <igx-column field="ShipCountry"></igx-column>
-            <igx-column field="ShipCity"></igx-column>
-            <igx-column field="ShipAddress"></igx-column>
-        </igx-grid>
-    </igx-splitter-pane>
-    <igx-splitter-pane>
-        <igx-grid #grid3 class="grid" displayDensity="cosy" [data]="data3" [isLoading]="true" [primaryKey]="'ProductID'" [autoGenerate]="false">
-            <igx-column field="ProductID" [hidden]='true'></igx-column>
-            <igx-column field="UnitPrice"></igx-column>
-            <igx-column field="Quantity"></igx-column>
-            <igx-column field="Discount"></igx-column>
-        </igx-grid>
+        <div style="background-color: rgb(85, 115, 252); width: 100%; height: 100%;">More text</div>
     </igx-splitter-pane>
 </igx-splitter>

--- a/src/app/splitter/splitter.sample.html
+++ b/src/app/splitter/splitter.sample.html
@@ -1,12 +1,72 @@
 <igx-switch (change)='changeType()' style="padding-left: 10px">Toggle Splitter Direction</igx-switch>
+<div>Simple sample</div>
+<igx-splitter style='height: 30vh;'>
+    <igx-splitter-pane size='20%'>
+        <div style='width:100%;'>
+           Pane 1
+        </div>
+    </igx-splitter-pane>
+    <igx-splitter-pane size='200px'>
+        <div style='width:100%;'>
+            Pane 2
+         </div>
+    </igx-splitter-pane>
+    <igx-splitter-pane>
+        <div style='width:100%;'>
+            Pane 3
+         </div>
+    </igx-splitter-pane>
+</igx-splitter>
+<div>Nested splitters sample</div>
+<igx-splitter style='height: 30vh;' [type]='0' >
+    <igx-splitter-pane>
+        <igx-splitter [type]='1' [style.width]='"100%"'>
+            <igx-splitter-pane>
+                Pane1.1
+            </igx-splitter-pane>
+            <igx-splitter-pane>
+                Pane1.2
+            </igx-splitter-pane>
+        </igx-splitter>
+    </igx-splitter-pane>
+    <igx-splitter-pane>
+        <igx-splitter [type]='1' [style.width]='"100%"'>
+            <igx-splitter-pane>
+                Pane2.1
+            </igx-splitter-pane>
+            <igx-splitter-pane>
+                Pane2.2
+            </igx-splitter-pane>
+        </igx-splitter>
+    </igx-splitter-pane>
+</igx-splitter>
+<div>Sample with Grids</div>
 <igx-splitter [type]="type" style='height: 60vh;'>
     <igx-splitter-pane minSize="100">
-        <div style="background-color: rgb(255, 112, 120); width: 100%; height: 100">Simple text</div>
+        <igx-grid #grid1 class="grid" displayDensity="cosy" [rowSelection]="'single'" (rowSelectionChanging)="onCustomerSelection($event)"
+        [data]="data1" [isLoading]="true" [primaryKey]="'CustomerID'" [autoGenerate]="false">
+            <igx-column field="CustomerID" [hidden]='true'></igx-column>
+            <igx-column field="CompanyName"></igx-column>
+            <igx-column field="ContactName"></igx-column>
+            <igx-column field="ContactTitle"></igx-column>
+            <igx-column field="Country"></igx-column>
+        </igx-grid>
     </igx-splitter-pane>
-    <!-- <igx-splitter-pane>
-        <div style="background-color: rgb(7, 234, 121); width: 100%; height: 100%;">More text</div>
-    </igx-splitter-pane> -->
     <igx-splitter-pane>
-        <div style="background-color: rgb(85, 115, 252); width: 100%; height: 100%;">More text</div>
+        <igx-grid #grid2 class="grid" [rowSelection]="'single'" (rowSelectionChanging)="onOrderSelection($event)"  displayDensity="cosy" [data]="data2" [isLoading]="true" [primaryKey]="'OrderID'" [autoGenerate]="false">
+            <igx-column field="OrderID" [hidden]='true'></igx-column>
+            <igx-column field="OrderDate"></igx-column>
+            <igx-column field="ShipCountry"></igx-column>
+            <igx-column field="ShipCity"></igx-column>
+            <igx-column field="ShipAddress"></igx-column>
+        </igx-grid>
+    </igx-splitter-pane>
+    <igx-splitter-pane>
+        <igx-grid #grid3 class="grid" displayDensity="cosy" [data]="data3" [isLoading]="true" [primaryKey]="'ProductID'" [autoGenerate]="false">
+            <igx-column field="ProductID" [hidden]='true'></igx-column>
+            <igx-column field="UnitPrice"></igx-column>
+            <igx-column field="Quantity"></igx-column>
+            <igx-column field="Discount"></igx-column>
+        </igx-grid>
     </igx-splitter-pane>
 </igx-splitter>


### PR DESCRIPTION
Closes #11323 
 
NOTE:
What this PR does is to improve the workaround mentioned in the issue. Here we remove the necessity to have anything in the AfterViewInit hook, but to fix the issue just set a size property on the panes.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 