### PR TITLE
Combo filtering enhancements

### DIFF
--- a/projects/igniteui-angular/src/lib/simple-combo/simple-combo.component.ts
+++ b/projects/igniteui-angular/src/lib/simple-combo/simple-combo.component.ts
@@ -192,7 +192,12 @@ export class IgxSimpleComboComponent extends IgxComboBaseDirective implements Co
                     }
                     return current === this.selection[0];
                 });
-                this.dropdown.navigateItem(index);
+                if (!this.isRemote) {
+                    // navigate to item only if we have local data
+                    // as with remote data this will fiddle with igxFor's scroll handler
+                    // and will trigger another chunk load which will break the visualization
+                    this.dropdown.navigateItem(index);
+                }
             }
         });
         this.dropdown.opening.pipe(takeUntil(this.destroy$)).subscribe(() => {

--- a/src/app/combo/combo.sample.html
+++ b/src/app/combo/combo.sample.html
@@ -22,13 +22,15 @@
                         <label igxLabel>States</label>
                         <igx-hint>Please select the state you've visited</igx-hint>
                     </igx-simple-combo>
-                    <igx-combo [allowCustomValues]="true" [placeholder]="'Falsy Values'" name="falsyValueCombo" [width]="'100%'"
-                        required [data]="uniqueFalsyData" displayKey="field" valueKey="value" [disabled]="isDisabled">
+                    <igx-combo [allowCustomValues]="true" [placeholder]="'Falsy Values'" name="falsyValueCombo"
+                        [width]="'100%'" required [data]="uniqueFalsyData" displayKey="field" valueKey="value"
+                        [disabled]="isDisabled">
                         <label igxLabel>Falsy unique values (combo)</label>
                         <igx-hint>Select a unique falsy value</igx-hint>
                     </igx-combo>
-                    <igx-simple-combo [allowCustomValues]="true" [placeholder]="'Falsy Values'" name="falsyValueCombo" [width]="'100%'"
-                        required [data]="uniqueFalsyData" displayKey="field" valueKey="value" [disabled]="isDisabled">
+                    <igx-simple-combo [allowCustomValues]="true" [placeholder]="'Falsy Values'" name="falsyValueCombo"
+                        [width]="'100%'" required [data]="uniqueFalsyData" displayKey="field" valueKey="value"
+                        [disabled]="isDisabled">
                         <label igxLabel>Falsy unique values (simple-combo)</label>
                         <igx-hint>Select a unique falsy value</igx-hint>
                     </igx-simple-combo>
@@ -62,6 +64,19 @@
                     </div>
                 </form>
             </div>
+
+            <div>
+                <h5 class="sample-title">Remote Binding</h5>
+                <igx-combo #remoteCombo class="input-container" [itemsMaxHeight]="250" [itemHeight]="48"
+                    [data]="rData | async" [valueKey]="'ProductID'" [displayKey]="'ProductName'"
+                    (dataPreLoad)="dataLoading()" (searchInputUpdate)="searchInput($event)"
+                    (selectionChanging)="handleSelectionChanging($event)" (closing)="onClosing()"
+                    (opening)="onOpening()" placeholder="Location(s)">
+                </igx-combo>
+                <igx-toast #loadingToast></igx-toast>
+
+            </div>
+
             <div class="input-row">
                 <igx-combo #playgroundCombo class="input-container" [placeholder]="'Locations'"
                     [showSearchCaseIcon]='true' (addition)="handleAddition($event)"
@@ -111,8 +126,8 @@
                 <button igxButton="raised" igxRipple (click)="changeItemTemplate()">Change Item Template</button>
             </div>
             <div class="btn-container">
-                <igx-switch (change)="changeFiltering($event)" >Use custom filter function</igx-switch>
-                <igx-switch (change)="changeFilteringKey($event)" >Filter by group key</igx-switch>
+                <igx-switch (change)="changeFiltering($event)">Use custom filter function</igx-switch>
+                <igx-switch (change)="changeFilteringKey($event)">Filter by group key</igx-switch>
             </div>
         </div>
         <ng-template #customItemTemplate let-display let-key="valueKey">

--- a/src/app/combo/combo.sample.ts
+++ b/src/app/combo/combo.sample.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, ElementRef, OnInit, TemplateRef, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import {
     ButtonGroupAlignment,
@@ -8,9 +8,12 @@ import {
     GlobalPositionStrategy,
     HorizontalAlignment,
     IChangeSwitchEventArgs,
+    IComboSearchInputEventArgs,
     IComboSelectionChangingEventArgs,
+    IForOfState,
     IgxComboComponent,
     IgxSimpleComboComponent,
+    IgxToastComponent,
     OverlaySettings,
     scaleInCenter,
     scaleOutCenter,
@@ -19,6 +22,7 @@ import {
 import { cloneDeep } from 'lodash';
 import { IComboFilteringOptions } from 'projects/igniteui-angular/src/lib/combo/combo.common';
 import { take } from 'rxjs/operators';
+import { RemoteNWindService } from './remote-nwind.service';
 
 @Component({
     // eslint-disable-next-line @angular-eslint/component-selector
@@ -29,10 +33,19 @@ import { take } from 'rxjs/operators';
 export class ComboSampleComponent implements OnInit, AfterViewInit {
     @ViewChild('playgroundCombo', { static: true })
     public igxCombo: IgxComboComponent;
+
+    @ViewChild('loadingToast')
+    public loadingToast: IgxToastComponent;
+
+    @ViewChild('remoteCombo')
+    public remoteCombo: IgxComboComponent;
+
     @ViewChild('playgroundCombo', { read: ElementRef, static: true })
     private comboRef: ElementRef;
+
     @ViewChild('customItemTemplate', { read: TemplateRef, static: true })
     private customItemTemplate;
+
     @ViewChild('simpleCombo', { read: IgxSimpleComboComponent, static: true })
     private simpleCombo;
 
@@ -42,10 +55,15 @@ export class ComboSampleComponent implements OnInit, AfterViewInit {
     public customValuesFlag = true;
     public autoFocusSearch = true;
     public items: any[] = [];
-    public values1:  Array<any> = ['Arizona'];
+    public values1: Array<any> = ['Arizona'];
     public singleValue = 'Arizona';
-    public values2:  Array<any>;
+    public values2: Array<any>;
     public isDisabled = false;
+    public rData: any;
+    private searchText: string = '';
+    private defaultVirtState: IForOfState = { chunkSize: 6, startIndex: 0 };
+    private hasSelection: boolean;
+    public prevRequest: any;
 
     public valueKeyVar = 'field';
     public currentDataType = '';
@@ -56,11 +74,15 @@ export class ComboSampleComponent implements OnInit, AfterViewInit {
 
     public genres = [];
     public user: UntypedFormGroup;
-    public uniqueFalsyData: any [];
+    public uniqueFalsyData: any[];
     private overlaySettings: OverlaySettings[] = [null, null, null, null];
     private initialItemTemplate: TemplateRef<any> = null;
 
-    constructor(fb: UntypedFormBuilder) {
+    constructor(
+        private remoteService: RemoteNWindService,
+        public cdr: ChangeDetectorRef,
+        fb: UntypedFormBuilder) {
+
         this.user = fb.group({
             date: [''],
             dateTime: [''],
@@ -72,19 +94,21 @@ export class ComboSampleComponent implements OnInit, AfterViewInit {
         });
 
         this.genres = [
-            { type: 'Action' , movies: ['The Matrix', 'Kill Bill: Vol.1', 'The Dark Knight Rises']},
-            { type: 'Adventure' , movies: ['Interstellar', 'Inglourious Basterds', 'Inception']},
-            { type: 'Comedy' , movies: ['Wild Tales', 'In Bruges', 'Three Billboards Outside Ebbing, Missouri',
-                'Untouchable', '3 idiots']},
-            { type: 'Crime' , movies: ['Training Day', 'Heat', 'American Gangster']},
-            { type: 'Drama' , movies: ['Fight Club', 'A Beautiful Mind', 'Good Will Hunting', 'City of God']},
-            { type: 'Biography' , movies: ['Amadeus', 'Bohemian Rhapsody']},
-            { type: 'Mystery' , movies: ['The Prestige', 'Memento', 'Cloud Atlas']},
-            { type: 'Musical' , movies: ['All That Jazz']},
-            { type: 'Romance' , movies: ['Love Actually', 'In The Mood for Love']},
-            { type: 'Sci-Fi' , movies: ['The Fifth Element']},
-            { type: 'Thriller' , movies: ['The Usual Suspects']},
-            { type: 'Western' , movies: ['Django Unchained']}];
+            { type: 'Action', movies: ['The Matrix', 'Kill Bill: Vol.1', 'The Dark Knight Rises'] },
+            { type: 'Adventure', movies: ['Interstellar', 'Inglourious Basterds', 'Inception'] },
+            {
+                type: 'Comedy', movies: ['Wild Tales', 'In Bruges', 'Three Billboards Outside Ebbing, Missouri',
+                    'Untouchable', '3 idiots']
+            },
+            { type: 'Crime', movies: ['Training Day', 'Heat', 'American Gangster'] },
+            { type: 'Drama', movies: ['Fight Club', 'A Beautiful Mind', 'Good Will Hunting', 'City of God'] },
+            { type: 'Biography', movies: ['Amadeus', 'Bohemian Rhapsody'] },
+            { type: 'Mystery', movies: ['The Prestige', 'Memento', 'Cloud Atlas'] },
+            { type: 'Musical', movies: ['All That Jazz'] },
+            { type: 'Romance', movies: ['Love Actually', 'In The Mood for Love'] },
+            { type: 'Sci-Fi', movies: ['The Fifth Element'] },
+            { type: 'Thriller', movies: ['The Usual Suspects'] },
+            { type: 'Western', movies: ['Django Unchained'] }];
 
         const division = {
             'New England 01': ['Connecticut', 'Maine', 'Massachusetts'],
@@ -164,6 +188,8 @@ export class ComboSampleComponent implements OnInit, AfterViewInit {
         this.igxCombo.searchInputUpdate.subscribe((e) => {
             console.log(e);
         });
+
+        this.rData = this.remoteService.remoteData;
     }
 
     public ngAfterViewInit() {
@@ -172,7 +198,8 @@ export class ComboSampleComponent implements OnInit, AfterViewInit {
             target: this.comboRef.nativeElement,
             positionStrategy: new ElasticPositionStrategy({
                 verticalDirection: VerticalAlignment.Top, verticalStartPoint: VerticalAlignment.Bottom,
-                horizontalDirection: HorizontalAlignment.Left, horizontalStartPoint: HorizontalAlignment.Right }),
+                horizontalDirection: HorizontalAlignment.Left, horizontalStartPoint: HorizontalAlignment.Right
+            }),
             modal: false,
             closeOnOutsideClick: true
         };
@@ -187,6 +214,13 @@ export class ComboSampleComponent implements OnInit, AfterViewInit {
             modal: false,
             closeOnOutsideClick: true
         };
+        const initSize = {
+            startIndex: 0,
+            chunkSize: Math.ceil(250 / this.remoteCombo.itemHeight),
+        };
+        this.remoteService.getData(initSize, null, (data) => {
+            this.remoteCombo.totalItemCount = data['@odata.count'];
+        });
     }
 
     public changeOverlaySettings(index: number) {
@@ -195,7 +229,7 @@ export class ComboSampleComponent implements OnInit, AfterViewInit {
 
     public changeItemTemplate() {
         const comboTemplate = this.initialItemTemplate ? null : this.igxCombo.itemTemplate;
-        this.igxCombo.itemTemplate = this.initialItemTemplate ? this.initialItemTemplate : this.customItemTemplate ;
+        this.igxCombo.itemTemplate = this.initialItemTemplate ? this.initialItemTemplate : this.customItemTemplate;
         this.initialItemTemplate = comboTemplate;
     }
 
@@ -235,5 +269,54 @@ export class ComboSampleComponent implements OnInit, AfterViewInit {
         return collection.filter(i => filteringOptions.caseSensitive ?
             i[filteringOptions.filteringKey]?.includes(searchTerm) || i[this.igxCombo.groupKey]?.includes(searchTerm) :
             i[filteringOptions.filteringKey]?.toString().toLowerCase().includes(searchTerm) || i[this.igxCombo.groupKey]?.toString().toLowerCase().includes(searchTerm))
+    }
+
+    public dataLoading() {
+        if (this.prevRequest) {
+            this.prevRequest.unsubscribe();
+        }
+        this.loadingToast.positionSettings.verticalDirection = VerticalAlignment.Middle;
+        this.loadingToast.autoHide = false;
+        this.loadingToast.open('Loading Remote Data...');
+        this.cdr.detectChanges();
+
+        this.prevRequest = this.remoteService.getData(
+            this.remoteCombo.virtualizationState,
+            this.searchText,
+            (data) => {
+                this.remoteCombo.totalItemCount = data['@odata.count'];
+                this.loadingToast.close();
+                this.cdr.detectChanges();
+            }
+        );
+    }
+
+    public searchInput(searchData: IComboSearchInputEventArgs) {
+        this.searchText = searchData?.searchText || '';
+        this.remoteService.getData(
+            this.searchText ? this.remoteCombo.virtualizationState : this.defaultVirtState,
+            this.searchText,
+            (data) => {
+                this.remoteCombo.totalItemCount = data['@odata.count'];
+            }
+        );
+    }
+
+    public onOpening() {
+        this.remoteService.getData(
+            this.hasSelection ? this.remoteCombo.virtualizationState : this.defaultVirtState,
+            this.searchText,
+            (data) => {
+                this.remoteCombo.totalItemCount = data['@odata.count'];
+            }
+        );
+    }
+
+    public onClosing() {
+        this.searchText = '';
+    }
+
+    public handleSelectionChanging(evt: IComboSelectionChangingEventArgs) {
+        this.hasSelection = !!evt?.newSelection.length;
     }
 }

--- a/src/app/combo/remote-nwind.service.ts
+++ b/src/app/combo/remote-nwind.service.ts
@@ -1,0 +1,50 @@
+/* eslint-disable id-blacklist */
+import { HttpClient } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { IForOfState } from 'igniteui-angular';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class RemoteNWindService {
+    public remoteData: BehaviorSubject<any[]>;
+    private url = 'https://services.odata.org/V4/Northwind/Northwind.svc/Products';
+
+    constructor(private http: HttpClient) {
+        this.remoteData = new BehaviorSubject([]);
+    }
+
+    public getData(data?: IForOfState, searchText?: string, cb?: (any) => void): any {
+        debugger;
+        const dataState = data;
+        return this.http
+            .get(this.buildUrl(dataState, searchText))
+            .subscribe((d: any) => {
+                this.remoteData.next(d.value);
+                if (cb) {
+                    cb(d);
+                }
+            });
+    }
+
+    private buildUrl(dataState: any, searchText?: string): string {
+        let qS = '?';
+        let requiredChunkSize: number;
+        if (dataState) {
+            const skip = dataState.startIndex;
+
+            requiredChunkSize = dataState.chunkSize === 0 ?
+                // Set initial chunk size, the best value is igxForContainerSize divided on igxForItemSize
+                10 : dataState.chunkSize;
+            qS += `$skip=${skip}&$top=${requiredChunkSize}&$count=true`;
+
+            if (searchText) {
+                qS += `&$filter=contains(ProductName, '` + searchText + `')`;
+            }
+        }
+        return `${this.url}${qS}`;
+    }
+
+    private toTitleCase(str) {
+        return str.replace(/\w\S*/g, (txt) => txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase());
+    }
+}


### PR DESCRIPTION
The issue described in https://github.com/IgniteUI/igniteui-angular/issues/11885 is on application level, so we have to update the sample of the remote binding combo. We may also want to consider adding a remote binding sample for the simple combo as well as the components do require somewhat different setup because they operate very differently. However, as I was playing around with both combos I noticed that if you scroll down a simple combo with remote data bound to it and you select an item, after closing and reopening, the combo loses all items in the dropdown. The reason was that we attempt to navigate to the currently selected item upon opening, however, with remote data bound, this triggers the `igxFor`'s `chunkPreload` which occurs on `scroll`. This causes the `igxFor`'s state to be incorrect and even though the correct items are fetched from the server and are visible in the `HTML`, the directive will scroll them out of view. This is why we should only navigate to the currently selected item (upon opening) only if the combo is with local data.

Note for testing: The `same-origin policy` has to be disabled to truly test it with a remote service. Alternatively, a mocked service can be created that simulates remote behavior by returning the data source in a given timeout.

### Additional information (check all that apply):
 - [x] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 