### PR TITLE
fix(igxGrid): Fix end edit with Enter when trigger is blur by moving …

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -1135,9 +1135,6 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy, CellT
 
         if (this.editable && editMode && !this.intRow.deleted) {
             if (editableCell) {
-                if (this.grid.validationTrigger === 'blur') {
-                    this.grid.tbody.nativeElement.focus({ preventScroll: true });
-                }
                 editableArgs = this.grid.crudService.updateCell(false, event);
 
                 /* This check is related with the following issue #6517:

--- a/projects/igniteui-angular/src/lib/grids/common/crud.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/crud.service.ts
@@ -201,6 +201,10 @@ export class IgxCellCrudState {
             return;
         }
 
+        if (this.grid.validationTrigger === 'blur') {
+            this.grid.tbody.nativeElement.focus({ preventScroll: true });
+        }
+
         let doneArgs;
         if (isEqual(this.cell.value, this.cell.editValue)) {
             doneArgs = this.exitCellEdit(event);
@@ -237,7 +241,6 @@ export class IgxCellCrudState {
         if (!this.cell) {
             return;
         }
-
         const newValue = this.cell.castToNumber(this.cell.editValue);
         const args = this.cell?.createDoneEditEventArgs(newValue, event);
 


### PR DESCRIPTION
…it to more common place.

Note: In 14.1.x if you end edit via Enter key and validation trigger is blur  the value is not persisted.

Closes #  

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 