### PR TITLE
[IgxSimpleCombo]: clear input on blur when combo is collapsed - 13.2.x

### DIFF
--- a/projects/igniteui-angular/src/lib/simple-combo/simple-combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/simple-combo/simple-combo.component.spec.ts
@@ -1102,6 +1102,23 @@ describe('IgxSimpleCombo', () => {
             expect(combo.selection.length).toEqual(1);
         });
 
+        it('should clear input on blur when dropdown is collapsed with no match', () => {
+            input.triggerEventHandler('focus', {});
+            fixture.detectChanges();
+
+            UIInteractions.simulateTyping('new', input);
+
+            const toggleButton = fixture.debugElement.query(By.css('.' + CSS_CLASS_TOGGLEBUTTON));
+            toggleButton.triggerEventHandler('click', UIInteractions.getMouseEvent('click'));
+            fixture.detectChanges();
+
+            UIInteractions.triggerEventHandlerKeyDown('Tab', input);
+            fixture.detectChanges();
+
+            expect(combo.value).toEqual('');
+            expect(combo.selection.length).toEqual(0);
+        });
+
         it('should empty any invalid item values', () => {
             combo.valueKey = 'key';
             combo.displayKey = 'value';

--- a/projects/igniteui-angular/src/lib/simple-combo/simple-combo.component.ts
+++ b/projects/igniteui-angular/src/lib/simple-combo/simple-combo.component.ts
@@ -92,6 +92,8 @@ export class IgxSimpleComboComponent extends IgxComboBaseDirective implements Co
     // stores the last filtered value - move to common?
     private _internalFilter = '';
 
+    private _collapsing = false;
+
     /** @hidden @internal */
     public get filteredData(): any[] | null {
         return this._filteredData;
@@ -202,6 +204,7 @@ export class IgxSimpleComboComponent extends IgxComboBaseDirective implements Co
             }
         });
         this.dropdown.opening.pipe(takeUntil(this.destroy$)).subscribe(() => {
+            this._collapsing = false;
             const filtered = this.filteredData.find(this.findAllMatches);
             if (filtered === undefined || filtered === null) {
                 this.filterValue = this.searchValue = this.comboInput.value;
@@ -217,11 +220,12 @@ export class IgxSimpleComboComponent extends IgxComboBaseDirective implements Co
         });
         this.dropdown.closing.pipe(takeUntil(this.destroy$)).subscribe((args) => {
             if (this.getEditElement() && !args.event) {
-                this.comboInput.focus();
+                this._collapsing = true;
             } else {
                 this.clearOnBlur();
                 this._onTouchedCallback();
             }
+            this.comboInput.focus();
         });
         this.dropdown.closed.pipe(takeUntil(this.destroy$)).subscribe(() => {
             this.filterValue = this._internalFilter = this.comboInput.value;
@@ -246,7 +250,7 @@ export class IgxSimpleComboComponent extends IgxComboBaseDirective implements Co
         if (this.collapsed && this.comboInput.focused) {
             this.open();
         }
-        if (!this.comboInput.value.trim() && this.selectionService.size(this.id) > 0) {
+        if (!this.comboInput.value.trim() && this.selection.length) {
             // handle clearing of input by space
             this.clearSelection();
             this._onChangeCallback(null);
@@ -282,6 +286,7 @@ export class IgxSimpleComboComponent extends IgxComboBaseDirective implements Co
         }
         if (!this.collapsed && event.key === this.platformUtil.KEYMAP.TAB) {
             this.clearOnBlur();
+            this.close();
         }
         this.composing = false;
         super.handleKeyDown(event);
@@ -314,6 +319,16 @@ export class IgxSimpleComboComponent extends IgxComboBaseDirective implements Co
     public handleItemClick(): void {
         this.close();
         this.comboInput.focus();
+    }
+
+    /** @hidden @internal */
+    public onBlur(): void {
+        // when clicking the toggle button to close the combo and immediately clicking outside of it
+        // the collapsed state is not modified as the dropdown is still not closed
+        if (this.collapsed || this._collapsing) {
+            this.clearOnBlur();
+        }
+        super.onBlur();
     }
 
     /** @hidden @internal */
@@ -452,15 +467,11 @@ export class IgxSimpleComboComponent extends IgxComboBaseDirective implements Co
 
     private clearOnBlur(): void {
         const filtered = this.filteredData.find(this.findMatch);
-        if (filtered === undefined || filtered === null || this.getElementKey(filtered) !== this.selectedItem) {
-            this.clearAndClose();
+        // selecting null in primitive data returns undefined as the search text is '', but the item is null
+        if (filtered === undefined && this.selectedItem !== null || !this.selection.length) {
+            this.clear();
             return;
         }
-    }
-
-    private getElementKey(element: any): any {
-        const elementVal = this.valueKey ? element[this.valueKey] : element;
-        return elementVal;
     }
 
     private getElementVal(element: any): string {
@@ -468,13 +479,10 @@ export class IgxSimpleComboComponent extends IgxComboBaseDirective implements Co
         return String(elementVal);
     }
 
-    private clearAndClose(): void {
+    private clear(): void {
         this.clearSelection(true);
         this._internalFilter = '';
         this.searchValue = '';
-        if (!this.collapsed) {
-            this.close();
-        }
     }
 
     private isValid(value: any): boolean {

--- a/projects/igniteui-angular/src/lib/simple-combo/simple-combo.component.ts
+++ b/projects/igniteui-angular/src/lib/simple-combo/simple-combo.component.ts
@@ -203,7 +203,10 @@ export class IgxSimpleComboComponent extends IgxComboBaseDirective implements Co
                 }
             }
         });
-        this.dropdown.opening.pipe(takeUntil(this.destroy$)).subscribe(() => {
+        this.dropdown.opening.pipe(takeUntil(this.destroy$)).subscribe((args) => {
+            if (args.cancel) {
+                return;
+            }
             this._collapsing = false;
             const filtered = this.filteredData.find(this.findAllMatches);
             if (filtered === undefined || filtered === null) {
@@ -219,6 +222,9 @@ export class IgxSimpleComboComponent extends IgxComboBaseDirective implements Co
             this._internalFilter = this.comboInput.value;
         });
         this.dropdown.closing.pipe(takeUntil(this.destroy$)).subscribe((args) => {
+            if (args.cancel) {
+                return;
+            }
             if (this.getEditElement() && !args.event) {
                 this._collapsing = true;
             } else {


### PR DESCRIPTION
Closes #12100 

This PR also fixes an issue where the **closing event** was emitted once when closing the combo via the toggle button, but twice when closing it when clicking outside of it.

![closing](https://user-images.githubusercontent.com/49126110/194587258-7609cc8e-7d97-44d7-b8f9-c7067c8ad639.gif)

**NOTE FOR TESTING** : 

* Verify that the input is cleared when closing the combo via the toggle button and immediately clicking outside of the combo, i.e., the below should **not** be reproducible:

![collapsed-demo](https://user-images.githubusercontent.com/49126110/194587700-6b5024d7-9c8e-4b3e-9b20-ba918804f1b7.gif)

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 