### PR TITLE
Migrate css custom properties

### DIFF
--- a/projects/igniteui-angular/migrations/update-15_0_0/index.spec.ts
+++ b/projects/igniteui-angular/migrations/update-15_0_0/index.spec.ts
@@ -109,6 +109,31 @@ describe(`Update to ${version}`, () => {
         );
     });
 
+    it('should NOT replace CSS custom properties prefix for internal variables', async () => {
+        appTree.create(
+            `/testSrc/appPrefix/component/test.component.scss`,
+`::ng-deep {
+	.custom-body {
+		width: var(--igx-icon-size);
+	}
+}`
+        );
+
+        const tree = await schematicRunner
+            .runSchematicAsync(migrationName, {}, appTree)
+            .toPromise();
+
+        expect(
+            tree.readContent('/testSrc/appPrefix/component/test.component.scss')
+        ).toEqual(
+`::ng-deep {
+	.custom-body {
+		width: var(--igx-icon-size);
+	}
+}`
+        );
+    });
+
     it('should remove the $palette prop from component themes', async () => {
         appTree.create(
             `/testSrc/appPrefix/component/test.component.scss`,

--- a/projects/igniteui-angular/migrations/update-15_0_0/index.spec.ts
+++ b/projects/igniteui-angular/migrations/update-15_0_0/index.spec.ts
@@ -30,6 +30,85 @@ describe(`Update to ${version}`, () => {
 
     const migrationName = 'migration-26';
 
+    it('should replace CSS custom properties prefix from --igx-primary to --ig-primary', async () => {
+        appTree.create(
+            `/testSrc/appPrefix/component/test.component.scss`,
+`::ng-deep {
+	.custom-body {
+		color: var(--igx-primary-500-contrast);
+		background: hsla(var(--igx-primary-500));
+	}
+}`
+        );
+
+        const tree = await schematicRunner
+            .runSchematicAsync(migrationName, {}, appTree)
+            .toPromise();
+
+        expect(
+            tree.readContent('/testSrc/appPrefix/component/test.component.scss')
+        ).toEqual(
+`::ng-deep {
+	.custom-body {
+		color: var(--ig-primary-500-contrast);
+		background: hsla(var(--ig-primary-500));
+	}
+}`
+        );
+    });
+
+    it('should replace CSS custom properties from  -igx-grays to -ig-gray', async () => {
+        appTree.create(
+            `/testSrc/appPrefix/component/test.component.scss`,
+`::ng-deep {
+	.custom-body {
+		color: var(--igx-grays-900);
+	}
+}`
+        );
+
+        const tree = await schematicRunner
+            .runSchematicAsync(migrationName, {}, appTree)
+            .toPromise();
+
+        expect(
+            tree.readContent('/testSrc/appPrefix/component/test.component.scss')
+        ).toEqual(
+`::ng-deep {
+	.custom-body {
+		color: var(--ig-gray-900);
+	}
+}`
+        );
+    });
+
+    it('should replace CSS custom properties prefix from --igx-h[number]- to --ig-h[number]-', async () => {
+        appTree.create(
+            `/testSrc/appPrefix/component/test.component.scss`,
+`::ng-deep {
+	.custom-body {
+		font-family: var(--igx-h1-font-family);
+		font-size: var(--igx-h3-font-size);
+	}
+}`
+        );
+
+        const tree = await schematicRunner
+            .runSchematicAsync(migrationName, {}, appTree)
+            .toPromise();
+
+        expect(
+            tree.readContent('/testSrc/appPrefix/component/test.component.scss')
+        ).toEqual(
+`::ng-deep {
+	.custom-body {
+		font-family: var(--ig-h1-font-family);
+		font-size: var(--ig-h3-font-size);
+	}
+}`
+        );
+    });
+
     it('should remove the $palette prop from component themes', async () => {
         appTree.create(
             `/testSrc/appPrefix/component/test.component.scss`,

--- a/projects/igniteui-angular/migrations/update-15_0_0/index.ts
+++ b/projects/igniteui-angular/migrations/update-15_0_0/index.ts
@@ -9,6 +9,42 @@ const version = '15.0.0';
 
 export default (): Rule => async (host: Tree, context: SchematicContext) => {
     context.logger.info(`Applying migration for Ignite UI for Angular to version ${version}`);
+
     const update = new UpdateChanges(__dirname, host, context);
     update.applyChanges();
+
+
+    // replace CSS custom properties prefix from --igx to --ig and grays to gray
+    const CUSTOM_CSS_PROPERTIES = [
+        '--igx-primary-',
+        '--igx-secondary-',
+        '--igx-grays-',
+        '--igx-surface-',
+        '--igx-info-',
+        '--igx-success-',
+        '--igx-warn-',
+        '--igx-error-',
+        '--igx-radius-factor',
+        '--igx-elevation',
+        '--igx-font-family',
+        '--igx-h(\\d)-',
+        '--igx-subtitle-(\\d)-',
+        '--igx-body-(\\d)-',
+        '--igx-button-',
+        '--igx-caption-',
+        '--igx-overline-'
+    ];
+    for (const entryPath of update.sassFiles) {
+        let content = host.read(entryPath).toString();
+        CUSTOM_CSS_PROPERTIES.forEach(cssProperty => {
+            const regex = new RegExp(cssProperty, 'g');
+            if (regex.test(content)) {
+                let newCssProperty = cssProperty.replace(/igx/g, 'ig');
+                newCssProperty = newCssProperty.replace(/grays/g, 'gray');
+                newCssProperty = newCssProperty.replace('(\\d)', '$1');
+                content = content.replace(regex, newCssProperty);
+                host.overwrite(entryPath, content);
+            }
+        });
+    }
 };


### PR DESCRIPTION
Migrate all custom CSS properties (aka CSS variables) prefix from `--igx-` to `--ig-`. Also migrates if CSS custom property contains `grays` migrate it to `gray`, e.g. `--igx-grays-200` will be migrated to `--ig-gray-200`.

Closes #12389   

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [x] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 