### PR TITLE
refactor(filtering): remove redundant defaults object export

### DIFF
--- a/projects/igniteui-angular/src/lib/data-operations/filtering-state.interface.ts
+++ b/projects/igniteui-angular/src/lib/data-operations/filtering-state.interface.ts
@@ -1,9 +1,5 @@
 import { IFilteringExpressionsTree } from './filtering-expressions-tree';
-import { FilteringStrategy, IFilteringStrategy } from './filtering-strategy';
-
-export const filteringStateDefaults = {
-    strategy: new FilteringStrategy()
-};
+import { IFilteringStrategy } from './filtering-strategy';
 
 export declare interface IFilteringState {
     expressionsTree: IFilteringExpressionsTree;


### PR DESCRIPTION
Removing a redundant filteringStateDefaults export. See https://github.com/IgniteUI/igniteui-angular/pull/12639

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 