### PR TITLE
Chore(*): Export DropPosition api

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/public_api.ts
+++ b/projects/igniteui-angular/src/lib/grids/public_api.ts
@@ -38,3 +38,4 @@ export * from './summaries/summary.module';
 export * from './grouping/tree-grid-group-by-area.component';
 export * from './grouping/grid-group-by-area.component';
 export * from './grouping/group-by-area.directive';
+export { DropPosition } from './moving/moving.service';


### PR DESCRIPTION
Export missing DropPosition api. #12663.

After this change is merged and deployed [DropPosition link](https://infragistics.com/products/ignite-ui-angular/docs/typescript/latest/enums/dropposition.html) should work.