### PR TITLE
test(date-util): make format check w/ space more flexible

### DIFF
--- a/projects/igniteui-angular/src/lib/date-common/util/date-time.util.spec.ts
+++ b/projects/igniteui-angular/src/lib/date-common/util/date-time.util.spec.ts
@@ -199,7 +199,7 @@ describe(`DateTimeUtil Unit tests`, () => {
         expect(result).toEqual('MM/dd/yyyy');
 
         result = DateTimeUtil.getDefaultInputFormat('bg-BG');
-        expect(result).toEqual('dd.MM.yyyy г.');
+        expect(result.normalize('NFKC')).toEqual('dd.MM.yyyy г.');
 
         expect(() => {
             result = DateTimeUtil.getDefaultInputFormat(null);


### PR DESCRIPTION
Chromium (110 onwards I believe) changed the Intl-returned format for year suffix like bg-BG's `г.` to be separated with Narrow No-Break Space (`&#8239`) instead of regular space (32). This normalizes it for checks

Closes #  

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 