### PR TITLE
Grids' template context cleanup

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
@@ -772,7 +772,7 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
 
     /** @hidden */
     @Input()
-    public collapsibleIndicatorTemplate: TemplateRef<any>;
+    public collapsibleIndicatorTemplate: TemplateRef<IgxColumnTemplateContext>;
 
     /**
      * Row index where the current field should end.
@@ -867,6 +867,7 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
     protected summaryTemplateDirective: IgxSummaryTemplateDirective;
     /**
      * @hidden
+     * @see {@link bodyTemplate}
      */
     @ContentChild(IgxCellTemplateDirective, { read: IgxCellTemplateDirective })
     protected cellTemplate: IgxCellTemplateDirective;

--- a/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
@@ -780,32 +780,37 @@ export interface IgxCellTemplateContext {
     cell: CellType
 }
 
+export interface IgxRowSelectorTemplateDetails {
+    index: number;
+    /** @deprecated Use `key` */
+    rowID: any;
+    key: any;
+    selected: boolean;
+    select?: () => void;
+    deselect?: () => void;
+}
+
 export interface IgxRowSelectorTemplateContext {
-    $implicit: {
-        index: number,
-        rowID: any,
-        key: any,
-        selected: boolean,
-        select?: () => void,
-        deselect?: () => void
-    }
+    $implicit: IgxRowSelectorTemplateDetails;
 }
 
+export interface IgxGroupByRowSelectorTemplateDetails {
+    selectedCount: number;
+    totalCount: number;
+    groupRow: IGroupByRecord;
+}
 export interface IgxGroupByRowSelectorTemplateContext {
-    $implicit: {
-        selectedCount: number,
-        totalCount: number,
-        groupRow: IGroupByRecord
-    }
+    $implicit: IgxGroupByRowSelectorTemplateDetails;
 }
 
+export interface IgxHeadSelectorTemplateDetails {
+    selectedCount: number;
+    totalCount: number;
+    selectAll?: () => void;
+    deselectAll?: () => void;
+}
 export interface IgxHeadSelectorTemplateContext {
-    $implicit: {
-        selectedCount: number;
-        totalCount: number;
-        selectAll?: () => void;
-        deselectAll?: () => void;
-    };
+    $implicit: IgxHeadSelectorTemplateDetails;
 }
 
 export interface IgxSummaryTemplateContext {

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -228,7 +228,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
      * ```
      */
     @Input()
-    public emptyGridTemplate: TemplateRef<any>;
+    public emptyGridTemplate: TemplateRef<void>;
 
     /**
      * Gets/Sets a custom template for adding row UI when grid is empty.
@@ -239,7 +239,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
      * ```
      */
     @Input()
-    public addRowEmptyTemplate: TemplateRef<any>;
+    public addRowEmptyTemplate: TemplateRef<void>;
 
     /**
      * Gets/Sets a custom template when loading.
@@ -250,7 +250,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
      * ```
      */
     @Input()
-    public loadingGridTemplate: TemplateRef<any>;
+    public loadingGridTemplate: TemplateRef<void>;
 
     /**
      * Get/Set IgxSummaryRow height

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
@@ -149,7 +149,7 @@ export class IgxGridComponent extends IgxGridBaseDirective implements GridType, 
      * ```
      */
     @Input()
-    public dropAreaTemplate: TemplateRef<any>;
+    public dropAreaTemplate: TemplateRef<void>;
 
     /**
      * @hidden @internal

--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.component.ts
@@ -372,7 +372,7 @@ export class IgxPivotGridComponent extends IgxGridBaseDirective implements OnIni
      * @hidden @interal
      */
     @Input()
-    public addRowEmptyTemplate: TemplateRef<any>;
+    public addRowEmptyTemplate: TemplateRef<void>;
 
     /**
      * @hidden @internal
@@ -2170,7 +2170,7 @@ export class IgxPivotGridComponent extends IgxGridBaseDirective implements OnIni
      * ```
      */
     @Input()
-    public emptyPivotGridTemplate: TemplateRef<any>;
+    public emptyPivotGridTemplate: TemplateRef<void>;
 
     /**
     * @hidden @internal

--- a/projects/igniteui-angular/src/lib/grids/public_api.ts
+++ b/projects/igniteui-angular/src/lib/grids/public_api.ts
@@ -17,7 +17,7 @@ export {
     CellType, RowType, IGX_GRID_BASE, ValidationStatus, IGridFormGroupCreatedEventArgs, IGridValidationState, IGridValidationStatusEventArgs, IRecordValidationState, IFieldValidationState, ColumnType,
     IgxGridMasterDetailContext, IgxGroupByRowTemplateContext, IgxGridTemplateContext, IgxGridRowTemplateContext, IgxGridRowDragGhostContext, IgxGridEmptyTemplateContext, IgxGridRowEditTemplateContext,
     IgxGridRowEditTextTemplateContext, IgxGridRowEditActionsTemplateContext, IgxGridHeaderTemplateContext, IgxColumnTemplateContext, IgxCellTemplateContext, IgxGroupByRowSelectorTemplateContext,
-    IgxHeadSelectorTemplateContext, IgxSummaryTemplateContext
+    IgxHeadSelectorTemplateContext, IgxSummaryTemplateContext, IgxHeadSelectorTemplateDetails, IgxGroupByRowSelectorTemplateDetails, IgxRowSelectorTemplateContext, IgxRowSelectorTemplateDetails
 } from './common/grid.interface';
 export * from './summaries/grid-summary';
 export * from './grid-common.module';

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
@@ -277,7 +277,7 @@ export class IgxTreeGridComponent extends IgxGridBaseDirective implements GridTy
     protected _filterStrategy = new TreeGridFilteringStrategy();
     protected _transactions: HierarchicalTransactionService<HierarchicalTransaction, HierarchicalState>;
     private _data;
-    private _rowLoadingIndicatorTemplate: TemplateRef<any>;
+    private _rowLoadingIndicatorTemplate: TemplateRef<void>;
     private _expansionDepth = Infinity;
     private _filteredData = null;
 
@@ -377,11 +377,11 @@ export class IgxTreeGridComponent extends IgxGridBaseDirective implements GridTy
      * @memberof IgxTreeGridComponent
      */
     @Input()
-    public get rowLoadingIndicatorTemplate(): TemplateRef<any> {
+    public get rowLoadingIndicatorTemplate(): TemplateRef<void> {
         return this._rowLoadingIndicatorTemplate;
     }
 
-    public set rowLoadingIndicatorTemplate(value: TemplateRef<any>) {
+    public set rowLoadingIndicatorTemplate(value: TemplateRef<void>) {
         this._rowLoadingIndicatorTemplate = value;
         this.notifyChanges();
     }


### PR DESCRIPTION
Cherry picked changes made for Elements/Blazor in #12229:
- Don't use anonymous object types for contexts as it makes those harder to use for automated analysis
- Exposed one missing and the added types
- Explicitly types as `void` the ones that provide no context whatsoever instead of `any`


### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 