### PR TITLE
Do not add file & directory watchers in ServerHost

### DIFF
--- a/projects/igniteui-angular/migrations/common/ServerHost.ts
+++ b/projects/igniteui-angular/migrations/common/ServerHost.ts
@@ -38,15 +38,24 @@ export class ServerHost implements ts.server.ServerHost {
         return ts.sys.getFileSize(path);
     }
 
-    public watchFile(path: string, callback: ts.FileWatcherCallback, pollingInterval?: number):
+    //#region Watchers
+    // Atm we do not need to have file or dir watchers that access the actual FS
+    // as we are only working with NG's virtual FS
+    // Prior to https://github.com/microsoft/TypeScript/pull/49990 we were more or less required
+    // to add a watcher since it threw an error otherwise
+
+    public watchFile(_path: string, _callback: ts.FileWatcherCallback, _pollingInterval?: number):
         ts.FileWatcher {
-        return ts.sys.watchFile(path, callback, pollingInterval);
+        // return ts.sys.watchFile(path, callback, pollingInterval);
+        return undefined;
     }
 
-    public watchDirectory(path: string, callback: ts.DirectoryWatcherCallback, recursive?: boolean):
+    public watchDirectory(_path: string, _callback: ts.DirectoryWatcherCallback, _recursive?: boolean):
         ts.FileWatcher {
-        return ts.sys.watchDirectory(path, callback, recursive);
+        // return ts.sys.watchDirectory(path, callback, recursive);
+        return undefined;
     }
+    //#endregion
 
     public resolvePath(path: string): string {
         return ts.sys.resolvePath(path);

--- a/projects/igniteui-angular/migrations/update-15_1_0/changes/members.json
+++ b/projects/igniteui-angular/migrations/update-15_1_0/changes/members.json
@@ -1,0 +1,72 @@
+{
+    "$schema": "../../common/schema/members-changes.schema.json",
+    "changes": [
+        {
+            "member": "onGroupingDone",
+            "replaceWith": "groupingDone",
+            "definedIn": [
+                "IgxGridComponent"
+            ]
+        },
+        {
+            "member": "onDensityChanged",
+            "replaceWith": "densityChanged",
+            "definedIn": [
+                "IgxActionStripComponent",
+                "IgxButtonGroupComponent",
+                "IgxChipComponent",
+                "IgxComboComponent",
+                "IgxDatePickerComponent",
+                "IgxDateRangePickerComponent",
+                "IgxTimePickerComponent",
+                "IgxButtonDirective",
+                "IgxDropDownComponent",
+                "IgxGridComponent",
+                "IgxGridToolbarComponent",
+                "IgxTreeGridComponent",
+                "IgxHierarchicalGridComponent",
+                "IgxPivotGridComponent",
+                "IgxInputGroupComponent",
+                "IgxListComponent",
+                "IgxPaginatorComponent",
+                "IgxQueryBuilderComponent",
+                "IgxTreeComponent"
+            ]
+        },
+        {
+            "member": "onSlideChanged",
+            "replaceWith": "slideChanged",
+            "definedIn": [
+                "IgxCarouselComponent"
+            ]
+        },
+        {
+            "member": "onSlideAdded",
+            "replaceWith": "slideAdded",
+            "definedIn": [
+                "IgxCarouselComponent"
+            ]
+        },
+        {
+            "member": "onSlideRemoved",
+            "replaceWith": "slideRemoved",
+            "definedIn": [
+                "IgxCarouselComponent"
+            ]
+        },
+        {
+            "member": "onCarouselPaused",
+            "replaceWith": "carouselPaused",
+            "definedIn": [
+                "IgxCarouselComponent"
+            ]
+        },
+        {
+            "member": "onCarouselPlaying",
+            "replaceWith": "carouselPlaying",
+            "definedIn": [
+                "IgxCarouselComponent"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Closes https://github.com/IgniteUI/igniteui-angular/issues/12786

The member migrations hang because the `tsserver` adds file watchers to all files that are to be migrated and these watchers are later never disposed of. Atm, it seems to me like the intended behavior is for whoever adds the watcher(s), to get rid of them themselves after they are not longer needed. And since we are implementing the `ServerHost` which is what's communicating with the file system, we are the ones that have to dispose of the file & dir watchers when we're done modifying files.

Though, as our implementation revolves mainly around working with Angular's virtual file system, we do not need to be adding file/directory watchers at all.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 