### PR TITLE
feat(grid,h-grid): expand/collapse indicator template inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ import { IgxGridModule } from 'igniteui-angular';
     - **Behavioral Change** The `igxChip` styles have been revisited and the select container animaton has been removed when selecting/deselecting a chip.
     - **Behavioral Change** The remove button behavior have been revisited, now when the chip is in `disabled` state the remove button is hidden.
     - The `igxChip` have new input `variant` which can take any of the following values: `'primary'`, `'info'`, `'success'`, `'warning'`, `'danger'`
+- `IgxGrid`, `IgxHierarchicalGrid`:
+    - **Breaking Change** The `IgxHeaderExpandIndicatorDirective` and `IgxHeaderCollapseIndicatorDirective` directives, as well as the `headerExpandIndicatorTemplate` and `headerCollapseIndicatorTemplate` properties have been renamed to `IgxHeaderExpandedIndicatorDirective`, `IgxHeaderCollapsedIndicatorDirective`, `headerExpandedIndicatorTemplate` and `headerCollapsedIndicatorTemplate` respectively to properly reflect their purpose. Automatic migrations are available and will be applied on `ng update`.
 ### New Features
 - `IgxExpansionPanel`:
     - `IgxExpansionPanelTitleDirective` and `IgxExpansionPanelDescriptionDirective` show tooltip of the provided text content.
@@ -62,6 +64,7 @@ import { IgxGridModule } from 'igniteui-angular';
     - Added `showWeekNumbers` input that toggles whether or not the number of a week will be visible next to it
 - `IgxGrid`, `IgxHierarchicalGrid`:
     - `totalItemCount` can now also be bound as `Input` in remote virtualization scenarios.
+    - `rowExpandedIndicatorTemplate`, `rowCollapsedIndicatorTemplate`, `headerExpandedIndicatorTemplate`, `headerCollapsedIndicatorTemplate` can now also be bound as `Input` to provide templates for the row and header expand/collapse indicators respectively. This is in addition to the existing equivalent template directives to allow reuse.
 
 ## 15.1.0
 

--- a/projects/igniteui-angular/migrations/update-16_0_0/changes/classes.json
+++ b/projects/igniteui-angular/migrations/update-16_0_0/changes/classes.json
@@ -8,6 +8,14 @@
         {
             "name": "IgxColumMaxLengthValidatorDirective",
             "replaceWith": "IgxColumnMaxLengthValidatorDirective"
+        },
+        {
+            "name": "IgxHeaderExpandIndicatorDirective",
+            "replaceWith": "IgxHeaderExpandedIndicatorDirective"
+        },
+        {
+            "name": "IgxHeaderCollapseIndicatorDirective",
+            "replaceWith": "IgxHeaderCollapsedIndicatorDirective"
         }
     ]
 }

--- a/projects/igniteui-angular/migrations/update-16_0_0/changes/members.json
+++ b/projects/igniteui-angular/migrations/update-16_0_0/changes/members.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "../../common/schema/members-changes.schema.json",
+    "changes": [
+        {
+            "member": "headerExpandIndicatorTemplate",
+            "replaceWith": "headerExpandedIndicatorTemplate",
+            "definedIn": [
+                "IgxGridComponent",
+                "IgxTreeGridComponent",
+                "IgxHierarchicalGridComponent",
+                "IgxPivotGridComponent"
+            ]
+        },
+        {
+            "member": "headerCollapseIndicatorTemplate",
+            "replaceWith": "headerCollapsedIndicatorTemplate",
+            "definedIn": [
+                "IgxGridComponent",
+                "IgxTreeGridComponent",
+                "IgxHierarchicalGridComponent",
+                "IgxPivotGridComponent"
+            ]
+        }
+    ]
+}

--- a/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
@@ -396,8 +396,8 @@ export interface GridType extends IGridDataBindable {
     sortHeaderIconTemplate: TemplateRef<IgxGridHeaderTemplateContext>;
     sortAscendingHeaderIconTemplate: TemplateRef<IgxGridHeaderTemplateContext>;
     sortDescendingHeaderIconTemplate: TemplateRef<IgxGridHeaderTemplateContext>;
-    headerCollapseIndicatorTemplate: TemplateRef<IgxGridTemplateContext>;
-    headerExpandIndicatorTemplate: TemplateRef<IgxGridTemplateContext>;
+    headerCollapsedIndicatorTemplate: TemplateRef<IgxGridTemplateContext>;
+    headerExpandedIndicatorTemplate: TemplateRef<IgxGridTemplateContext>;
     dragIndicatorIconTemplate: any;
     dragIndicatorIconBase: any;
     disableTransitions: boolean;

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -78,8 +78,8 @@ import { CharSeparatedValueData } from '../services/csv/char-separated-value-dat
 import { IgxColumnResizingService } from './resizing/resizing.service';
 import { FilteringStrategy, IFilteringStrategy } from '../data-operations/filtering-strategy';
 import {
-    IgxRowExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxHeaderExpandIndicatorDirective,
-    IgxHeaderCollapseIndicatorDirective, IgxExcelStyleHeaderIconDirective, IgxSortAscendingHeaderIconDirective,
+    IgxRowExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxHeaderExpandedIndicatorDirective,
+    IgxHeaderCollapsedIndicatorDirective, IgxExcelStyleHeaderIconDirective, IgxSortAscendingHeaderIconDirective,
     IgxSortDescendingHeaderIconDirective, IgxSortHeaderIconDirective
 } from './grid/grid.directives';
 import {
@@ -1452,25 +1452,125 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
      * The custom template, if any, that should be used when rendering a row expand indicator.
      */
     @ContentChild(IgxRowExpandedIndicatorDirective, { read: TemplateRef })
-    public rowExpandedIndicatorTemplate: TemplateRef<IgxGridRowTemplateContext> = null;
+    protected rowExpandedIndicatorDirectiveTemplate: TemplateRef<IgxGridRowTemplateContext> = null;
+
+    /**
+     * Gets the row expand indicator template.
+    */
+    @Input()
+    public get rowExpandedIndicatorTemplate(): TemplateRef<IgxGridRowTemplateContext> {
+        return this._rowExpandedIndicatorTemplate || this.rowExpandedIndicatorDirectiveTemplate;
+    }
+
+    /**
+     * Sets the row expand indicator template.
+     *```html
+     *<ng-template igxRowExpandedIndicator>
+     *  <igx-icon role="button">remove</igx-icon>
+     *</ng-template>
+     * ```
+     *```typescript
+     * @ViewChild('template', {read: TemplateRef })
+     * public template: TemplateRef<any>;
+     * this.grid.rowExpandedIndicatorTemplate = this.template;
+     * ```
+    */
+    public set rowExpandedIndicatorTemplate(template: TemplateRef<IgxGridRowTemplateContext>) {
+        this._rowExpandedIndicatorTemplate = template;
+    }
 
     /**
      * The custom template, if any, that should be used when rendering a row collapse indicator.
      */
     @ContentChild(IgxRowCollapsedIndicatorDirective, { read: TemplateRef })
-    public rowCollapsedIndicatorTemplate: TemplateRef<IgxGridRowTemplateContext> = null;
+    protected rowCollapsedIndicatorDirectiveTemplate: TemplateRef<IgxGridRowTemplateContext> = null;
+
+    /**
+     * Gets the row collapse indicator template.
+    */
+    @Input()
+    public get rowCollapsedIndicatorTemplate(): TemplateRef<IgxGridRowTemplateContext> {
+        return this._rowCollapsedIndicatorTemplate || this.rowCollapsedIndicatorDirectiveTemplate;
+    }
+
+    /**
+     * Sets the row collapse indicator template.
+     *```html
+     *<ng-template igxRowCollapsedIndicator>
+     *  <igx-icon role="button">add</igx-icon>
+     *</ng-template>
+     * ```
+     *```typescript
+     * @ViewChild('template', {read: TemplateRef })
+     * public template: TemplateRef<any>;
+     * this.grid.rowCollapsedIndicatorTemplate = this.template;
+     * ```
+    */
+    public set rowCollapsedIndicatorTemplate(template: TemplateRef<IgxGridRowTemplateContext>) {
+        this._rowCollapsedIndicatorTemplate = template;
+    }
 
     /**
      * The custom template, if any, that should be used when rendering a header expand indicator.
      */
-    @ContentChild(IgxHeaderExpandIndicatorDirective, { read: TemplateRef })
-    public headerExpandIndicatorTemplate: TemplateRef<IgxGridTemplateContext> = null;
+    @ContentChild(IgxHeaderExpandedIndicatorDirective, { read: TemplateRef })
+    protected headerExpandedIndicatorDirectiveTemplate: TemplateRef<IgxGridTemplateContext> = null;
+
+    /**
+     * Gets the header expand indicator template.
+    */
+    @Input()
+    public get headerExpandedIndicatorTemplate(): TemplateRef<IgxGridTemplateContext> {
+        return this._headerExpandIndicatorTemplate || this.headerExpandedIndicatorDirectiveTemplate;
+    }
+
+    /**
+     * Sets the header expand indicator template.
+     *```html
+     *<ng-template igxHeaderExpandedIndicator>
+     *  <igx-icon role="button">remove</igx-icon>
+     *</ng-template>
+     * ```
+     *```typescript
+     * @ViewChild('template', {read: TemplateRef })
+     * public template: TemplateRef<any>;
+     * this.grid.headerExpandedIndicatorTemplate = this.template;
+     * ```
+    */
+    public set headerExpandedIndicatorTemplate(template: TemplateRef<IgxGridTemplateContext>) {
+        this._headerExpandIndicatorTemplate = template;
+    }
 
     /**
      * The custom template, if any, that should be used when rendering a header collapse indicator.
      */
-    @ContentChild(IgxHeaderCollapseIndicatorDirective, { read: TemplateRef })
-    public headerCollapseIndicatorTemplate: TemplateRef<IgxGridTemplateContext> = null;
+    @ContentChild(IgxHeaderCollapsedIndicatorDirective, { read: TemplateRef })
+    protected headerCollapsedIndicatorDirectiveTemplate: TemplateRef<IgxGridTemplateContext> = null;
+
+    /**
+     * Gets the row collapse indicator template.
+    */
+    @Input()
+    public get headerCollapsedIndicatorTemplate(): TemplateRef<IgxGridTemplateContext> {
+        return this._headerCollapseIndicatorTemplate || this.headerCollapsedIndicatorDirectiveTemplate;
+    }
+
+    /**
+     * Sets the row collapse indicator template.
+     *```html
+     *<ng-template igxHeaderCollapsedIndicator>
+     *  <igx-icon role="button">add</igx-icon>
+     *</ng-template>
+     * ```
+     *```typescript
+     * @ViewChild('template', {read: TemplateRef })
+     * public template: TemplateRef<any>;
+     * this.grid.headerCollapsedIndicatorTemplate = this.template;
+     * ```
+    */
+    public set headerCollapsedIndicatorTemplate(template: TemplateRef<IgxGridTemplateContext>) {
+        this._headerCollapseIndicatorTemplate = template;
+    }
 
     /** @hidden @internal */
     @ContentChild(IgxExcelStyleHeaderIconDirective, { read: TemplateRef })
@@ -3086,6 +3186,10 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
     private _rowAddTextTemplate: TemplateRef<IgxGridEmptyTemplateContext>;
     private _rowEditActionsTemplate: TemplateRef<IgxGridRowEditActionsTemplateContext>;
     private _dragGhostCustomTemplate: TemplateRef<IgxGridRowDragGhostContext>;
+    private _rowExpandedIndicatorTemplate: TemplateRef<IgxGridRowTemplateContext>;
+    private _rowCollapsedIndicatorTemplate: TemplateRef<IgxGridRowTemplateContext>;
+    private _headerExpandIndicatorTemplate: TemplateRef<IgxGridTemplateContext>;
+    private _headerCollapseIndicatorTemplate: TemplateRef<IgxGridTemplateContext>;
 
     private _cdrRequests = false;
     private _resourceStrings;

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
@@ -962,9 +962,9 @@ export class IgxGridComponent extends IgxGridBaseDirective implements GridType, 
      */
     public get iconTemplate() {
         if (this.groupsExpanded) {
-            return this.headerExpandIndicatorTemplate || this.defaultExpandedTemplate;
+            return this.headerExpandedIndicatorTemplate || this.defaultExpandedTemplate;
         } else {
-            return this.headerCollapseIndicatorTemplate || this.defaultCollapsedTemplate;
+            return this.headerCollapsedIndicatorTemplate || this.defaultCollapsedTemplate;
         }
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.directives.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.directives.ts
@@ -78,8 +78,8 @@ export class IgxRowCollapsedIndicatorDirective {
     selector: '[igxHeaderExpandedIndicator]',
     standalone: true
 })
-export class IgxHeaderExpandIndicatorDirective {
-    public static ngTemplateContextGuard(_directive: IgxHeaderExpandIndicatorDirective,
+export class IgxHeaderExpandedIndicatorDirective {
+    public static ngTemplateContextGuard(_directive: IgxHeaderExpandedIndicatorDirective,
         context: unknown): context is IgxGridTemplateContext {
         return true
     }
@@ -92,8 +92,8 @@ export class IgxHeaderExpandIndicatorDirective {
     selector: '[igxHeaderCollapsedIndicator]',
     standalone: true
 })
-export class IgxHeaderCollapseIndicatorDirective {
-    public static ngTemplateContextGuard(_directive: IgxHeaderCollapseIndicatorDirective,
+export class IgxHeaderCollapsedIndicatorDirective {
+    public static ngTemplateContextGuard(_directive: IgxHeaderCollapsedIndicatorDirective,
         context: unknown): context is IgxGridTemplateContext {
         return true
     }

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.groupby.spec.ts
@@ -6,7 +6,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IgxStringFilteringOperand } from '../../data-operations/filtering-condition';
 import { IgxColumnComponent } from '../columns/column.component';
 import { IgxGridComponent } from './grid.component';
-import { IgxGroupAreaDropDirective, IgxGroupByRowTemplateDirective, IgxHeaderCollapseIndicatorDirective, IgxHeaderExpandIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxRowExpandedIndicatorDirective } from './grid.directives';
+import { IgxGroupAreaDropDirective, IgxGroupByRowTemplateDirective, IgxHeaderCollapsedIndicatorDirective, IgxHeaderExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxRowExpandedIndicatorDirective } from './grid.directives';
 import { IgxColumnMovingDragDirective } from '../moving/moving.drag.directive';
 import { IgxGridRowComponent } from './grid-row.component';
 import { IgxChipComponent } from '../../chips/chip.component';
@@ -3857,7 +3857,7 @@ export class GroupableGridComponent extends DataParent {
         </ng-template>
     `,
     standalone: true,
-    imports: [IgxGridComponent, IgxColumnComponent, IgxGroupByRowTemplateDirective, IgxRowExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxHeaderExpandIndicatorDirective, IgxHeaderCollapseIndicatorDirective]
+    imports: [IgxGridComponent, IgxColumnComponent, IgxGroupByRowTemplateDirective, IgxRowExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxHeaderExpandedIndicatorDirective, IgxHeaderCollapsedIndicatorDirective]
 })
 export class CustomTemplateGridComponent extends DataParent {
     @ViewChild(IgxGridComponent, { read: IgxGridComponent, static: true })

--- a/projects/igniteui-angular/src/lib/grids/grid/public_api.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/public_api.ts
@@ -1,6 +1,6 @@
 import { IGX_GRID_COMMON_DIRECTIVES } from '../public_api';
 import { IgxGridComponent } from './grid.component';
-import { IgxExcelStyleHeaderIconDirective, IgxGridDetailTemplateDirective, IgxGroupAreaDropDirective, IgxGroupByRowTemplateDirective, IgxHeaderCollapseIndicatorDirective, IgxHeaderExpandIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxRowExpandedIndicatorDirective, IgxSortAscendingHeaderIconDirective, IgxSortDescendingHeaderIconDirective, IgxSortHeaderIconDirective } from './grid.directives';
+import { IgxExcelStyleHeaderIconDirective, IgxGridDetailTemplateDirective, IgxGroupAreaDropDirective, IgxGroupByRowTemplateDirective, IgxHeaderCollapsedIndicatorDirective, IgxHeaderExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxRowExpandedIndicatorDirective, IgxSortAscendingHeaderIconDirective, IgxSortDescendingHeaderIconDirective, IgxSortHeaderIconDirective } from './grid.directives';
 
 export * from './grid.component';
 export * from './grid.directives';
@@ -12,8 +12,8 @@ export const IGX_GRID_DIRECTIVES = [
     IgxGridDetailTemplateDirective,
     IgxRowExpandedIndicatorDirective,
     IgxRowCollapsedIndicatorDirective,
-    IgxHeaderExpandIndicatorDirective,
-    IgxHeaderCollapseIndicatorDirective,
+    IgxHeaderExpandedIndicatorDirective,
+    IgxHeaderCollapsedIndicatorDirective,
     IgxExcelStyleHeaderIconDirective,
     IgxSortHeaderIconDirective,
     IgxSortAscendingHeaderIconDirective,

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
@@ -662,8 +662,8 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
             this.dragIndicatorIconTemplate;
         this.rowExpandedIndicatorTemplate = this.rootGrid.rowExpandedIndicatorTemplate;
         this.rowCollapsedIndicatorTemplate = this.rootGrid.rowCollapsedIndicatorTemplate;
-        this.headerCollapseIndicatorTemplate = this.rootGrid.headerCollapseIndicatorTemplate;
-        this.headerExpandIndicatorTemplate = this.rootGrid.headerExpandIndicatorTemplate;
+        this.headerCollapsedIndicatorTemplate = this.rootGrid.headerCollapsedIndicatorTemplate;
+        this.headerExpandedIndicatorTemplate = this.rootGrid.headerExpandedIndicatorTemplate;
         this.excelStyleHeaderIconTemplate = this.rootGrid.excelStyleHeaderIconTemplate;
         this.sortAscendingHeaderIconTemplate = this.rootGrid.sortAscendingHeaderIconTemplate;
         this.sortDescendingHeaderIconTemplate = this.rootGrid.sortDescendingHeaderIconTemplate;
@@ -938,9 +938,9 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
     public get iconTemplate() {
         const expanded = this.hasExpandedRecords() && this.hasExpandableChildren;
         if (!expanded && this.showExpandAll) {
-            return this.headerCollapseIndicatorTemplate || this.defaultCollapsedTemplate;
+            return this.headerCollapsedIndicatorTemplate || this.defaultCollapsedTemplate;
         } else {
-            return this.headerExpandIndicatorTemplate || this.defaultExpandedTemplate;
+            return this.headerExpandedIndicatorTemplate || this.defaultExpandedTemplate;
         }
     }
 

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.spec.ts
@@ -10,7 +10,7 @@ import { IgxHierarchicalRowComponent } from './hierarchical-row.component';
 import { By } from '@angular/platform-browser';
 import { DisplayDensity } from '../../core/density';
 import { IgxStringFilteringOperand } from '../../data-operations/filtering-condition';
-import { IgxHeaderCollapseIndicatorDirective, IgxHeaderExpandIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxRowExpandedIndicatorDirective } from '../grid/public_api';
+import { IgxHeaderCollapsedIndicatorDirective, IgxHeaderExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxRowExpandedIndicatorDirective } from '../grid/public_api';
 import { GridSelectionMode } from '../common/enums';
 import { GridFunctions } from '../../test-utils/grid-functions.spec';
 import { IgxGridCellComponent } from '../cell.component';
@@ -1953,7 +1953,7 @@ export class IgxHierarchicalGridToggleRIAndColsComponent  extends IgxHierarchica
         </ng-template>
     </igx-hierarchical-grid>`,
     standalone: true,
-    imports: [IgxHierarchicalGridComponent, IgxColumnComponent, IgxRowIslandComponent, IgxRowExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxHeaderExpandIndicatorDirective, IgxHeaderCollapseIndicatorDirective]
+    imports: [IgxHierarchicalGridComponent, IgxColumnComponent, IgxRowIslandComponent, IgxRowExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxHeaderExpandedIndicatorDirective, IgxHeaderCollapsedIndicatorDirective]
 })
 export class IgxHierarchicalGridCustomTemplateComponent extends IgxHierarchicalGridTestBaseComponent {}
 
@@ -2013,8 +2013,8 @@ export class IgxHierarchicalGridCustomTemplateComponent extends IgxHierarchicalG
         IgxExcelStyleSearchComponent,
         IgxRowExpandedIndicatorDirective,
         IgxRowCollapsedIndicatorDirective,
-        IgxHeaderExpandIndicatorDirective,
-        IgxHeaderCollapseIndicatorDirective
+        IgxHeaderExpandedIndicatorDirective,
+        IgxHeaderCollapsedIndicatorDirective
     ]
 })
 export class IgxHierarchicalGridCustomFilteringTemplateComponent extends IgxHierarchicalGridTestBaseComponent {}

--- a/projects/igniteui-angular/src/lib/grids/public_api.ts
+++ b/projects/igniteui-angular/src/lib/grids/public_api.ts
@@ -5,7 +5,7 @@ import { IgxAdvancedFilteringDialogComponent } from './filtering/advanced-filter
 import { IGX_GRID_EXCEL_STYLE_FILTER_DIRECTIVES } from './filtering/excel-style/public_api';
 import { IgxGridFooterComponent } from './grid-footer/grid-footer.component';
 import { IgxRowAddTextDirective, IgxRowEditActionsDirective, IgxRowEditTabStopDirective, IgxRowEditTextDirective } from './grid.rowEdit.directive';
-import { IgxExcelStyleHeaderIconDirective, IgxGroupAreaDropDirective, IgxHeaderCollapseIndicatorDirective, IgxHeaderExpandIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxRowExpandedIndicatorDirective, IgxSortAscendingHeaderIconDirective, IgxSortDescendingHeaderIconDirective, IgxSortHeaderIconDirective } from './grid/grid.directives';
+import { IgxExcelStyleHeaderIconDirective, IgxGroupAreaDropDirective, IgxHeaderCollapsedIndicatorDirective, IgxHeaderExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxRowExpandedIndicatorDirective, IgxSortAscendingHeaderIconDirective, IgxSortDescendingHeaderIconDirective, IgxSortHeaderIconDirective } from './grid/grid.directives';
 import { IGX_GRID_HEADERS_DIRECTIVES } from './headers/public_api';
 import { IgxDragIndicatorIconDirective, IgxRowDragGhostDirective } from './row-drag.directive';
 import { IgxRowDirective } from './row.directive';
@@ -72,8 +72,8 @@ export const IGX_GRID_COMMON_DIRECTIVES = [
     IgxAdvancedFilteringDialogComponent,
     IgxRowExpandedIndicatorDirective,
     IgxRowCollapsedIndicatorDirective,
-    IgxHeaderExpandIndicatorDirective,
-    IgxHeaderCollapseIndicatorDirective,
+    IgxHeaderExpandedIndicatorDirective,
+    IgxHeaderCollapsedIndicatorDirective,
     IgxExcelStyleHeaderIconDirective,
     IgxSortAscendingHeaderIconDirective,
     IgxSortDescendingHeaderIconDirective,

--- a/src/app/hierarchical-grid/hierarchical-grid.sample.ts
+++ b/src/app/hierarchical-grid/hierarchical-grid.sample.ts
@@ -11,7 +11,7 @@ import { NgIf, NgFor } from '@angular/common';
 import { IgxRowDragGhostDirective } from '../../../projects/igniteui-angular/src/lib/grids/row-drag.directive';
 import { IgxPaginatorDirective } from '../../../projects/igniteui-angular/src/lib/paginator/paginator-interfaces';
 import { IgxRowIslandComponent as IgxRowIslandComponent_1 } from '../../../projects/igniteui-angular/src/lib/grids/hierarchical-grid/row-island.component';
-import { IgxHeaderCollapseIndicatorDirective, IgxHeaderExpandIndicatorDirective, IgxRowExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective } from '../../../projects/igniteui-angular/src/lib/grids/grid/grid.directives';
+import { IgxHeaderCollapsedIndicatorDirective, IgxHeaderExpandedIndicatorDirective, IgxRowExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective } from '../../../projects/igniteui-angular/src/lib/grids/grid/grid.directives';
 import { IgxColumnGroupComponent } from '../../../projects/igniteui-angular/src/lib/grids/columns/column-group.component';
 import { IgxIconComponent } from '../../../projects/igniteui-angular/src/lib/icon/icon.component';
 import { IgxCellTemplateDirective } from '../../../projects/igniteui-angular/src/lib/grids/columns/templates.directive';
@@ -37,7 +37,7 @@ import { IgxButtonGroupComponent } from '../../../projects/igniteui-angular/src/
     styleUrls: ['hierarchical-grid.sample.scss'],
     templateUrl: 'hierarchical-grid.sample.html',
     standalone: true,
-    imports: [IgxButtonGroupComponent, IgxButtonDirective, IgxHierarchicalGridComponent_1, IgxGridExcelStyleFilteringComponent, IgxExcelStyleColumnOperationsTemplateDirective, IgxExcelStyleHeaderComponent, IgxExcelStyleSortingComponent, IgxExcelStyleFilterOperationsTemplateDirective, IgxExcelStyleSearchComponent, IgxGridToolbarComponent, GridSearchBoxComponent, IgxGridToolbarActionsComponent, IgxGridToolbarPinningComponent, IgxGridToolbarHidingComponent, IgxGridToolbarExporterComponent, IgxGridFooterComponent, IgxPaginatorComponent, IgxColumnComponent, IgxCellTemplateDirective, IgxIconComponent, IgxColumnGroupComponent, IgxHeaderCollapseIndicatorDirective, IgxHeaderExpandIndicatorDirective, IgxRowExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxRowIslandComponent_1, IgxPaginatorDirective, IgxRowDragGhostDirective, NgIf, NgFor]
+    imports: [IgxButtonGroupComponent, IgxButtonDirective, IgxHierarchicalGridComponent_1, IgxGridExcelStyleFilteringComponent, IgxExcelStyleColumnOperationsTemplateDirective, IgxExcelStyleHeaderComponent, IgxExcelStyleSortingComponent, IgxExcelStyleFilterOperationsTemplateDirective, IgxExcelStyleSearchComponent, IgxGridToolbarComponent, GridSearchBoxComponent, IgxGridToolbarActionsComponent, IgxGridToolbarPinningComponent, IgxGridToolbarHidingComponent, IgxGridToolbarExporterComponent, IgxGridFooterComponent, IgxPaginatorComponent, IgxColumnComponent, IgxCellTemplateDirective, IgxIconComponent, IgxColumnGroupComponent, IgxHeaderCollapsedIndicatorDirective, IgxHeaderExpandedIndicatorDirective, IgxRowExpandedIndicatorDirective, IgxRowCollapsedIndicatorDirective, IgxRowIslandComponent_1, IgxPaginatorDirective, IgxRowDragGhostDirective, NgIf, NgFor]
 })
 export class HierarchicalGridSampleComponent implements AfterViewInit {
     public columnsReady = false;


### PR DESCRIPTION
Expose the previously available through directives templates as `@Input`

The breaking change is super minor - The existing directive names are correct and remain the same. I don't see any docs/samples using the directives and I doubt the actual class imports were used or the improperly exposed content query props, but still added the note and migrations just in case.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [x] This PR contains breaking changes
 - [x] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 