### PR TITLE
docs(*): mark mistakenly left exposed props as hidden

### DIFF
--- a/projects/igniteui-angular/src/lib/action-strip/action-strip.component.ts
+++ b/projects/igniteui-angular/src/lib/action-strip/action-strip.component.ts
@@ -188,6 +188,7 @@ export class IgxActionStripComponent extends DisplayDensityBase implements After
         private _viewContainer: ViewContainerRef,
         private renderer: Renderer2,
         @Optional() @Inject(DisplayDensityToken) protected _displayDensityOptions: IDisplayDensityOptions,
+        /** @hidden @internal **/
         public cdr: ChangeDetectorRef) {
         super(_displayDensityOptions);
     }

--- a/projects/igniteui-angular/src/lib/action-strip/grid-actions/grid-actions-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/action-strip/grid-actions/grid-actions-base.directive.ts
@@ -9,6 +9,7 @@ import { IgxIconService } from '../../icon/icon.service';
     standalone: true
 })
 export class IgxGridActionsBaseDirective implements AfterViewInit {
+    /** @hidden @internal **/
     @ViewChildren(IgxGridActionButtonComponent)
     public buttons: QueryList<IgxGridActionButtonComponent>;
 
@@ -24,6 +25,7 @@ export class IgxGridActionsBaseDirective implements AfterViewInit {
     @Input()
     public asMenuItems = false;
 
+    /** @hidden @internal **/
     public strip: IgxActionStripComponent;
 
     /**

--- a/projects/igniteui-angular/src/lib/action-strip/grid-actions/grid-editing-actions.component.ts
+++ b/projects/igniteui-angular/src/lib/action-strip/grid-actions/grid-editing-actions.component.ts
@@ -128,14 +128,7 @@ export class IgxGridEditingActionsComponent extends IgxGridActionsBaseDirective 
         this.strip.hide();
     }
 
-    /**
-     * Delete a row according to the context
-     *
-     * @example
-     * ```typescript
-     * this.gridEditingActions.deleteRowHandler();
-     * ```
-     */
+    /** @hidden @internal **/
     public deleteRowHandler(event?): void {
         if (event) {
             event.stopPropagation();
@@ -150,6 +143,7 @@ export class IgxGridEditingActionsComponent extends IgxGridActionsBaseDirective 
         this.strip.hide();
     }
 
+    /** @hidden @internal **/
     public addRowHandler(event?, asChild?: boolean): void {
         if (event) {
             event.stopPropagation();

--- a/projects/igniteui-angular/src/lib/core/density.ts
+++ b/projects/igniteui-angular/src/lib/core/density.ts
@@ -93,6 +93,7 @@ export class DisplayDensityBase implements DoCheck, OnInit {
         this.initialDensity = this._displayDensity;
     }
 
+    /** @hidden @internal **/
     public ngDoCheck() {
         if (!this._displayDensity && this.displayDensityOptions &&
                 this.oldDisplayDensityOptions.displayDensity !== this.displayDensityOptions.displayDensity) {

--- a/projects/igniteui-angular/src/lib/grids/columns/column-group.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column-group.component.ts
@@ -303,14 +303,7 @@ export class IgxColumnGroupComponent extends IgxColumnComponent implements After
             });
     }
 
-    /**
-     * Returns the children columns collection.
-     * ```typescript
-     * let columns =  this.columnGroup.allChildren;
-     * ```
-     *
-     * @memberof IgxColumnGroupComponent
-     */
+    /** @hidden @internal **/
     public override get allChildren(): IgxColumnComponent[] {
         return flatten(this.children.toArray());
     }

--- a/projects/igniteui-angular/src/lib/grids/columns/column-layout.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column-layout.component.ts
@@ -17,6 +17,7 @@ import { IgxColumnGroupComponent } from './column-group.component';
     standalone: true
 })
 export class IgxColumnLayoutComponent extends IgxColumnGroupComponent implements AfterContentInit {
+    /** @hidden @internal **/
     public childrenVisibleIndexes = [];
     /**
      * Gets the width of the column layout.

--- a/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
@@ -508,6 +508,7 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
         }
     }
 
+    /** @hidden @internal **/
     public autoSize: number;
 
     /**
@@ -899,6 +900,7 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
         return this.getCalcWidth();
     }
 
+    /** @hidden @internal **/
     public calcPixelWidth: number;
 
     /**
@@ -1457,15 +1459,7 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
         return this.parent && this.parent.columnLayout;
     }
 
-    /**
-     * Returns the children columns collection.
-     * Returns an empty array if the column does not contain children columns.
-     * ```typescript
-     * let childrenColumns =  this.column.allChildren;
-     * ```
-     *
-     * @memberof IgxColumnComponent
-     */
+    /** @hidden @internal **/
     public get allChildren(): IgxColumnComponent[] {
         return [];
     }
@@ -1489,16 +1483,19 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
         return lvl;
     }
 
+    /** @hidden @internal **/
     public get isLastPinned(): boolean {
         return this.grid.isPinningToStart &&
             this.grid.pinnedColumns[this.grid.pinnedColumns.length - 1] === this;
     }
 
+    /** @hidden @internal **/
     public get isFirstPinned(): boolean {
         const pinnedCols = this.grid.pinnedColumns.filter(x => !x.columnGroup);
         return !this.grid.isPinningToStart && pinnedCols[0] === this;
     }
 
+    /** @hidden @internal **/
     public get rightPinnedOffset(): string {
         return this.pinned && !this.grid.isPinningToStart ?
             - this.grid.pinnedWidth - this.grid.headerFeaturesWidth + 'px' :
@@ -1586,12 +1583,12 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
     public set expanded(_value: boolean) { }
 
     /**
-     * hidden
+     * @hidden
      */
     public defaultWidth: string;
 
     /**
-     * hidden
+     * @hidden
      */
     public widthSetByUser: boolean;
 
@@ -1761,6 +1758,7 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
     constructor(
         @Inject(IGX_GRID_BASE) public grid: GridType,
         @Optional() @Self() @Inject(NG_VALIDATORS) private _validators: Validator[],
+        /** @hidden @internal **/
         public cdr: ChangeDetectorRef,
         protected platform: PlatformUtil,
     ) {
@@ -1876,6 +1874,7 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
         }
     }
 
+    /** @hidden @internal **/
     public getInitialChildColumnSizes(children: QueryList<IgxColumnComponent>): Array<MRLColumnSizeInfo> {
         const columnSizes: MRLColumnSizeInfo[] = [];
         // find the smallest col spans
@@ -1991,6 +1990,7 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
         return columnSizes;
     }
 
+    /** @hidden @internal **/
     public getFilledChildColumnSizes(children: QueryList<IgxColumnComponent>): Array<string> {
         const columnSizes = this.getInitialChildColumnSizes(children);
 
@@ -2006,6 +2006,7 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
         return result;
     }
 
+    /** @hidden @internal **/
     public getResizableColUnderEnd(): MRLResizeColumnInfo[] {
         if (this.columnLayout || !this.columnLayoutChild || this.columnGroup) {
             return [{ target: this, spanUsed: 1 }];

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -5652,6 +5652,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
     }
 
 
+    /** @hidden @internal **/
     public combineSelectedCellAndColumnData(columnData: any[], formatters = false, headers = false) {
         const source = this.filteredSortedData;
         return this.extractDataFromSelection(source, formatters, headers, columnData);

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
@@ -811,6 +811,7 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
         }
     }
 
+    /** @hidden @internal **/
     public override ngOnDestroy() {
         if (!this.parent) {
             this.gridAPI.getChildGrids(true).forEach((grid) => {
@@ -1026,6 +1027,7 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
         }
     }
 
+    /** @hidden @internal **/
     public onContainerScroll() {
         this.hideOverlays();
     }

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/row-island.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/row-island.component.ts
@@ -95,6 +95,7 @@ export class IgxRowIslandComponent extends IgxHierarchicalGridBaseDirective
     @ContentChild(IgxPaginatorDirective, { read: TemplateRef })
     public islandPaginatorTemplate: TemplateRef<any>;
 
+    /** @hidden @internal **/
     @ContentChildren(IgxActionStripComponent, { read: IgxActionStripComponent, descendants: false })
     public actionStrips: QueryList<IgxActionStripComponent>;
 

--- a/projects/igniteui-angular/src/lib/grids/toolbar/grid-toolbar.base.ts
+++ b/projects/igniteui-angular/src/lib/grids/toolbar/grid-toolbar.base.ts
@@ -106,6 +106,7 @@ export abstract class BaseToolbarDirective implements OnDestroy {
 
     constructor(@Inject(IgxToolbarToken) protected toolbar: IgxToolbarToken) { }
 
+    /** @hidden @internal **/
     public ngOnDestroy() {
         this.$destroy.next();
         this.$destroy.complete();

--- a/projects/igniteui-angular/src/lib/paginator/paginator.component.ts
+++ b/projects/igniteui-angular/src/lib/paginator/paginator.component.ts
@@ -111,20 +111,19 @@ export class IgxPaginatorComponent extends DisplayDensityBase {
     private _overlaySettings: OverlaySettings = {};
     private defaultSelectValues = [5, 10, 15, 25, 50, 100, 500];
 
-    /**
-     * Sets the class of the IgxPaginatorComponent based
-     * on the provided displayDensity.
-     */
+    /** @hidden @internal **/
     @HostBinding('class.igx-paginator--cosy')
     public get classCosy(): boolean {
         return this.displayDensity === DisplayDensity.cosy;
     }
 
+    /** @hidden @internal **/
     @HostBinding('class.igx-paginator--compact')
     public get classCompact(): boolean {
         return this.displayDensity === DisplayDensity.compact;
     }
 
+    /** @hidden @internal **/
     @HostBinding('class.igx-paginator')
     public get classComfortable(): boolean {
         return this.displayDensity === DisplayDensity.comfortable;


### PR DESCRIPTION
More cleanup of public API - methods like `ngOnDestroy`, undocumented ones, exposed queries and host bindings. Also hiding a few properties that popped up on grid-related components and made no sense to be public

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 