### PR TITLE
fix(date-picker): set calendar view date properly - 15.1.x

### DIFF
--- a/projects/igniteui-angular/src/lib/date-picker/date-picker.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/date-picker/date-picker.component.spec.ts
@@ -478,8 +478,6 @@ describe('IgxDatePicker', () => {
                 const today = new Date().getDate().toString();
                 expect(document.activeElement.textContent.trim()).toEqual(today);
                 expect(document.activeElement.classList).not.toContain(CSS_CLASS_DATE_SELECTED);
-
-                flush();
             }));
 
             it('should focus today\'s date when an invalid date is selected', fakeAsync(() => {

--- a/projects/igniteui-angular/src/lib/date-picker/date-picker.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/date-picker/date-picker.component.spec.ts
@@ -30,6 +30,7 @@ import { registerLocaleData } from "@angular/common";
 import localeES from "@angular/common/locales/es";
 
 const CSS_CLASS_CALENDAR = 'igx-calendar';
+const CSS_CLASS_DATE_SELECTED = 'igx-calendar__date--selected';
 const CSS_CLASS_DATE_PICKER = 'igx-date-picker';
 
 const DATE_PICKER_TOGGLE_ICON = 'today';
@@ -446,6 +447,56 @@ describe('IgxDatePicker', () => {
                 expect(toggle.clicked.observers).toHaveSize(0);
                 expect(clear.clicked.observers).toHaveSize(0);
             });
+        });
+
+        describe('UI Interaction', () => {
+            let fixture: ComponentFixture<any>;
+            let datePicker: IgxDatePickerComponent;
+
+            beforeEach(fakeAsync(() => {
+                fixture = TestBed.createComponent(IgxDatePickerTestComponent);
+                fixture.detectChanges();
+                datePicker = fixture.componentInstance.datePicker;
+            }));
+
+            it('should focus today\'s date when reopening the calendar', fakeAsync(() => {
+                datePicker.clear();
+                datePicker.open();
+                expect(datePicker.value).toEqual(null);
+                expect(datePicker.collapsed).toBeFalsy();
+
+                datePicker.close();
+                tick();
+                fixture.detectChanges();
+                expect(datePicker.collapsed).toBeTruthy();
+
+                datePicker.open();
+                tick();
+                fixture.detectChanges();
+                expect(datePicker.collapsed).toBeFalsy();
+
+                const today = new Date().getDate().toString();
+                expect(document.activeElement.textContent.trim()).toEqual(today);
+                expect(document.activeElement.classList).not.toContain(CSS_CLASS_DATE_SELECTED);
+
+                flush();
+            }));
+
+            it('should focus today\'s date when an invalid date is selected', fakeAsync(() => {
+                datePicker.clear();
+                expect(datePicker.value).toEqual(null);
+                expect(datePicker.collapsed).toBeTruthy();
+
+                datePicker.select(new Date('test'));
+                datePicker.open();
+                tick();
+                fixture.detectChanges();
+                expect(datePicker.collapsed).toBeFalsy();
+
+                const today = new Date().getDate().toString();
+                expect(document.activeElement.textContent.trim()).toEqual(today);
+                expect(document.activeElement.classList).not.toContain(CSS_CLASS_DATE_SELECTED);
+            }));
         });
     });
 

--- a/projects/igniteui-angular/src/lib/date-picker/date-picker.component.ts
+++ b/projects/igniteui-angular/src/lib/date-picker/date-picker.component.ts
@@ -987,15 +987,15 @@ export class IgxDatePickerComponent extends PickerBaseDirective implements Contr
 
     private setCalendarViewDate() {
         const { minValue, maxValue } = this.getMinMaxDates();
-        this._dateValue = this.dateValue || new Date();
-        if (minValue && DateTimeUtil.lessThanMinValue(this.dateValue, minValue)) {
+        const dateValue = DateTimeUtil.isValidDate(this.dateValue) ? this.dateValue : new Date();
+        if (minValue && DateTimeUtil.lessThanMinValue(dateValue, minValue)) {
             this._calendar.viewDate = this._targetViewDate = minValue;
             return;
         }
-        if (maxValue && DateTimeUtil.greaterThanMaxValue(this.dateValue, maxValue)) {
+        if (maxValue && DateTimeUtil.greaterThanMaxValue(dateValue, maxValue)) {
             this._calendar.viewDate = this._targetViewDate = maxValue;
             return;
         }
-        this._calendar.viewDate = this._targetViewDate = this.dateValue;
+        this._calendar.viewDate = this._targetViewDate = dateValue;
     }
 }


### PR DESCRIPTION
Closes #13052 

**Note**: When binding the date picker's value to an invalid date, e.g., `new Date('test')`, and opening the calendar, today's date should be focused.  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 