### PR TITLE
chore(CellType): revert unintentionally exposed defaultErrorTemplate

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/cell.component.ts
@@ -127,6 +127,7 @@ export class IgxGridCellComponent implements OnInit, OnChanges, OnDestroy, CellT
 
     /**
      * Gets the default error template.
+     * @hidden @internal
      */
     @ViewChild('defaultError', { read: TemplateRef, static: true })
     public defaultErrorTemplate: TemplateRef<any>;

--- a/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
@@ -69,7 +69,6 @@ export interface CellType {
     title?: any;
     width: string;
     visibleColumnIndex?: number;
-    defaultErrorTemplate?: TemplateRef<any>;
     update: (value: any) => void;
     setEditMode?(value: boolean): void;
     calculateSizeToFit?(range: any): number;

--- a/projects/igniteui-angular/src/lib/test-utils/grid-validation-samples.spec.ts
+++ b/projects/igniteui-angular/src/lib/test-utils/grid-validation-samples.spec.ts
@@ -68,8 +68,8 @@ export class IgxGridValidationTestBaseComponent {
             *ngFor="let c of columns"
             [editable]='true' [sortable]="true" [filterable]="true" [field]="c.field"
             [header]="c.field" [resizable]="true" [dataType]="c.dataType">
-            <ng-template igxCellValidationError let-cell='cell'>
-                <div *ngIf="cell.validation.errors?.['forbiddenName'] else cell.defaultErrorTemplate">
+            <ng-template igxCellValidationError let-cell='cell' let-defaultErrorTemplate="defaultErrorTemplate">
+                <div *ngIf="cell.validation.errors?.['forbiddenName'] else defaultErrorTemplate">
                     This name is forbidden.
                 </div>
             </ng-template>
@@ -118,8 +118,8 @@ export class IgxGridCustomEditorsComponent extends IgxGridValidationTestCustomEr
             *ngFor="let c of columns"
             [editable]='true' [sortable]="true" [filterable]="true" [field]="c.field"
             [header]="c.field" [resizable]="true" [dataType]="c.dataType" >
-            <ng-template igxCellValidationError let-cell='cell'>
-                <div *ngIf="cell.validation.errors?.['forbiddenName'] else cell.defaultErrorTemplate">
+            <ng-template igxCellValidationError let-cell='cell' let-defaultErrorTemplate="defaultErrorTemplate">
+                <div *ngIf="cell.validation.errors?.['forbiddenName'] else defaultErrorTemplate">
                     This name is forbidden.
                 </div>
             </ng-template>


### PR DESCRIPTION
Removed recently exposed `defaultErrorTemplate` on `CellType` to resolve a test setup error, since there's an exposed context property for that and that's the only place this template is of any use.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [x] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 