### PR TITLE
docs(col-group): fix body/edit template docs; selectable setter

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/columns/column-group.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column-group.component.ts
@@ -147,15 +147,13 @@ export class IgxColumnGroupComponent extends IgxColumnComponent implements After
         return this.children && this.children.some(child => child.selectable);
     }
 
+    /**
+     * @hidden
+     */
     public override set selectable(value: boolean) {}
 
     /**
-     * Returns a reference to the body template.
-     * ```typescript
-     * let bodyTemplate = this.columnGroup.bodyTemplate;
-     * ```
-     *
-     * @memberof IgxColumnGroupComponent
+     * @hidden
      */
     public override get bodyTemplate(): TemplateRef<any> {
         return this._bodyTemplate;
@@ -174,12 +172,7 @@ export class IgxColumnGroupComponent extends IgxColumnComponent implements After
     public override collapsibleIndicatorTemplate: TemplateRef<IgxColumnTemplateContext>;
 
     /**
-     * Returns a reference to the inline editor template.
-     * ```typescript
-     * let inlineEditorTemplate = this.columnGroup.inlineEditorTemplate;
-     * ```
-     *
-     * @memberof IgxColumnGroupComponent
+     * @hidden
      */
     public override get inlineEditorTemplate(): TemplateRef<any> {
         return this._inlineEditorTemplate;


### PR DESCRIPTION
`IgxColumnGroupComponent` has hidden and non-functional setter overrides for `bodyTemplate` and `inlineEditorTemplate`, but had the getters left public, which is pretty useless. Hidden those as well as the `selectable` setter, since it only works as getter on the group.


### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 