### PR TITLE
fix(radio-group): FormControl disabled doesn't work

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/radio/radio-group.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/radio/radio-group.directive.ts
@@ -339,6 +339,15 @@ export class IgxRadioGroupDirective implements AfterContentInit, AfterViewInit, 
             this.queryChange$.next();
             setTimeout(() => this._initRadioButtons());
         });
+
+
+        if (this.ngControl) {
+            this.radioButtons.forEach((button) => {
+                if (this.ngControl.disabled) {
+                    button.disabled = this.ngControl.disabled;
+                }
+            });
+        }
     }
 
     /**
@@ -359,16 +368,16 @@ export class IgxRadioGroupDirective implements AfterContentInit, AfterViewInit, 
         if (this.radioButtons) {
             this.radioButtons.forEach((button) => {
                 button.blurRadio
-                .pipe(takeUntil(this.destroy$))
-                .subscribe(() => {
-                    this.updateValidityOnBlur()
-                });
+                    .pipe(takeUntil(this.destroy$))
+                    .subscribe(() => {
+                        this.updateValidityOnBlur()
+                    });
 
                 fromEvent(button.nativeElement, 'keyup')
-                .pipe(takeUntil(this.destroy$))
-                .subscribe((event: KeyboardEvent) => {
-                    this.updateOnKeyUp(event)
-                });
+                    .pipe(takeUntil(this.destroy$))
+                    .subscribe((event: KeyboardEvent) => {
+                        this.updateOnKeyUp(event)
+                    });
             });
         }
     }


### PR DESCRIPTION
Closes #13236

The disabled option of FormControl does nothing for individual radio buttons when used on a radio group.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 