### PR TITLE
fix(column): Do not treat formatters as events so that they generate …

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
@@ -658,7 +658,6 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
     @Input()
     public cellStyles = null;
 
-    /* treatAsRef */
     /* alternateType: CellValueFormatterEventHandler */
     /* blazorOnlyScript */
     /**
@@ -699,7 +698,6 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
     @Input()
     public formatter: (value: any, rowData?: any) => any;
 
-    /* treatAsRef*/
     /* alternateType: SummaryValueFormatterEventHandler */
     /* blazorOnlyScript */
     /**

--- a/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
@@ -658,7 +658,8 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
     @Input()
     public cellStyles = null;
 
-    /* csTreatAsEvent: CellValueFormatterEventHandler */
+    /* treatAsRef */
+    /* alternateType: CellValueFormatterEventHandler */
     /* blazorOnlyScript */
     /**
      * Applies display format to cell values in the column. Does not modify the underlying data.
@@ -698,7 +699,8 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
     @Input()
     public formatter: (value: any, rowData?: any) => any;
 
-    /* csTreatAsEvent: SummaryValueFormatterEventHandler */
+    /* treatAsRef*/
+    /* alternateType: SummaryValueFormatterEventHandler */
     /* blazorOnlyScript */
     /**
      * The summaryFormatter is used to format the display of the column summaries.
@@ -1113,7 +1115,7 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
         return this._sortStrategy;
     }
 
-    
+
     /**
      * Sets the column `sortStrategy`.
      * ```typescript


### PR DESCRIPTION
…properties with correct type.

Note: This also needs a small fix in the api analyzer since otherwise it treats them as methods.

Related to https://infragistics.visualstudio.com/NetAdvantage/_workitems/edit/26068/
 