### PR TITLE
feat(migrations): add i18n and schematics as automatic updates

### DIFF
--- a/projects/igniteui-angular-i18n/package.json
+++ b/projects/igniteui-angular-i18n/package.json
@@ -21,5 +21,13 @@
   "bugs": {
     "url": "https://github.com/IgniteUI/igniteui-angular/issues"
   },
-  "homepage": "https://github.com/IgniteUI/igniteui-angular/projects/igniteui-angular-i18n#readme"
+  "homepage": "https://github.com/IgniteUI/igniteui-angular/projects/igniteui-angular-i18n#readme",
+  "ng-update": {
+    "packageGroup": [
+        "igniteui-angular-i18n",
+        "igniteui-angular",
+        "@infragistics/igniteui-angular",
+        "@igniteui/angular-schematics"
+    ]
+  }
 }

--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -89,7 +89,13 @@
         "@igniteui/angular-schematics": "~16.0.1200"
     },
     "ng-update": {
-        "migrations": "./migrations/migration-collection.json"
+        "migrations": "./migrations/migration-collection.json",
+        "packageGroup": [
+            "igniteui-angular",
+            "@infragistics/igniteui-angular",
+            "igniteui-angular-i18n",
+            "@igniteui/angular-schematics"
+        ]
     },
     "schematics": "./schematics/collection.json",
     "exports": {


### PR DESCRIPTION
Closes #13467

Add `igniteui-angular-i18n` & `@igniteui/angular-schematics` to be automatically update along with `igniteui-angular`. Adding the same for the `igniteui-angular-i18n` package.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 