### PR TITLE
fix(migrations): main path contains root path

### DIFF
--- a/projects/igniteui-angular/migrations/common/ServerHost.ts
+++ b/projects/igniteui-angular/migrations/common/ServerHost.ts
@@ -47,13 +47,13 @@ export class ServerHost implements ts.server.ServerHost {
     public watchFile(_path: string, _callback: ts.FileWatcherCallback, _pollingInterval?: number):
         ts.FileWatcher {
         // return ts.sys.watchFile(path, callback, pollingInterval);
-        return undefined;
+        return { close: () => {} };
     }
 
     public watchDirectory(_path: string, _callback: ts.DirectoryWatcherCallback, _recursive?: boolean):
         ts.FileWatcher {
         // return ts.sys.watchDirectory(path, callback, recursive);
-        return undefined;
+        return { close: () => {} };
     }
     //#endregion
 

--- a/projects/igniteui-angular/migrations/common/ServerHost.ts
+++ b/projects/igniteui-angular/migrations/common/ServerHost.ts
@@ -106,7 +106,7 @@ export class ServerHost implements ts.server.ServerHost {
         // check directory contents in Tree (w/ relative paths)
         path = pathFs.relative(this.getCurrentDirectory(), path);
         // return directory contents w/ absolute paths for LS
-        return this.host.getDir(path).subdirs.map(e => pathFs.resolve(e));
+        return this.host.getDir(path).subdirs.map(e => pathFs.resolve(path, e));
     }
 
     /**
@@ -116,7 +116,7 @@ export class ServerHost implements ts.server.ServerHost {
         // check directory contents in Tree (w/ relative paths)
         path = pathFs.relative(this.getCurrentDirectory(), path);
         // return directory contents w/ absolute paths for LS
-        return this.host.getDir(path).subfiles.map(e => pathFs.resolve(e));
+        return this.host.getDir(path).subfiles.map(e => pathFs.resolve(path, e));
     }
 
     public require(initialPath: string, moduleName: string) {

--- a/projects/igniteui-angular/migrations/common/UpdateChanges.ts
+++ b/projects/igniteui-angular/migrations/common/UpdateChanges.ts
@@ -78,8 +78,12 @@ export class UpdateChanges {
             this._projectService.openClientFile(scriptInfo.fileName);
 
 
-            const project = this._projectService.findProject(scriptInfo.containingProjects[0].projectName);
-            project.getLanguageService().getSemanticDiagnostics(mainAbsPath);
+            try {
+                const project = this._projectService.findProject(scriptInfo.containingProjects[0].projectName);
+                project.getLanguageService().getSemanticDiagnostics(mainAbsPath);
+            } catch (err) {
+                return this._projectService;
+            }
         }
 
         return this._projectService;

--- a/projects/igniteui-angular/migrations/common/UpdateChanges.ts
+++ b/projects/igniteui-angular/migrations/common/UpdateChanges.ts
@@ -63,9 +63,13 @@ export class UpdateChanges {
             if (!wsProject) {
                 return null;
             }
-            const mainRelPath = wsProject.architect?.build?.options['main'] ?
-                path.join(wsProject.root, wsProject.architect?.build?.options['main']) :
-                `src/main.ts`;
+            const mainConfigPath = wsProject.architect?.build?.options['main'];
+            let mainRelPath = `src/main.ts`;
+            if (mainConfigPath) {
+                mainRelPath = mainConfigPath.startsWith(wsProject.root) ?
+                    mainConfigPath :
+                    path.join(wsProject.root, mainConfigPath);
+            }
             // patch TSConfig so it includes angularOptions.strictTemplates
             // ivy ls requires this in order to function properly on templates
             this.patchTsConfig();

--- a/projects/igniteui-angular/migrations/common/tsUtils.ts
+++ b/projects/igniteui-angular/migrations/common/tsUtils.ts
@@ -260,7 +260,12 @@ const getTypeDefinitions = (langServ: tss.LanguageService, entryPath: string, po
  */
 export const getTypeDefinitionAtPosition =
     (langServ: tss.LanguageService, entryPath: string, position: number): MemberInfo | null => {
-        const definition = langServ.getDefinitionAndBoundSpan(entryPath, position)?.definitions[0];
+        let definition;
+        try {
+            definition = langServ.getDefinitionAndBoundSpan(entryPath, position)?.definitions[0];
+        } catch (err) {
+            return null;
+        }
         if (!definition) {
             return null;
         }
@@ -352,7 +357,12 @@ export const isMemberIgniteUI =
             matchPosition = langServ.getBraceMatchingAtPosition(entryPath, matchPosition - 1)[0]?.start ?? matchPosition;
         }
 
-        const typeDef = getTypeDefinitionAtPosition(langServ, entryPath, matchPosition);
+        let typeDef;
+        try {
+            typeDef = getTypeDefinitionAtPosition(langServ, entryPath, matchPosition);
+        } catch (err) {
+            false;
+        }
         if (!typeDef) {
             return false;
         }

--- a/projects/igniteui-angular/migrations/update-16_1_0/index.spec.ts
+++ b/projects/igniteui-angular/migrations/update-16_1_0/index.spec.ts
@@ -47,7 +47,7 @@ describe(`Update to ${version}`, () => {
             public title: IgxStepSubTitleDirective;
         }
         `);
-        const tree = await schematicRunner.runSchematicAsync(migrationName, { shouldInvokeLS: false }, appTree).toPromise();
+        const tree = await schematicRunner.runSchematic(migrationName, { shouldInvokeLS: false }, appTree);
 
         const expectedContent = `import { Component, ViewChild } from '@angular/core';
         import { IgxStepSubtitleDirective } from 'igniteui-angular';
@@ -72,18 +72,18 @@ describe(`Update to ${version}`, () => {
             `<igx-stepper>
                 <igx-step>
                    <p igxStepTitle>Home</p>
-                   <p igxStepSubTitle>Home Sub Title</p>                   
+                   <p igxStepSubTitle>Home Sub Title</p>
                 </igx-step>
             </igx-stepper>`);
 
-        const tree = await schematicRunner.runSchematicAsync(migrationName, {}, appTree)
-            .toPromise();
+        const tree = await schematicRunner.runSchematic(migrationName, {}, appTree);
+
         expect(tree.readContent('/testSrc/appPrefix/component/test.component.html'))
             .toEqual(
             `<igx-stepper>
                 <igx-step>
                    <p igxStepTitle>Home</p>
-                   <p igxStepSubtitle>Home Sub Title</p>                   
+                   <p igxStepSubtitle>Home Sub Title</p>
                 </igx-step>
             </igx-stepper>`);
 
@@ -108,9 +108,7 @@ describe(`Update to ${version}`, () => {
         }
         `);
 
-        const tree = await schematicRunner
-            .runSchematicAsync(migrationName, {}, appTree)
-            .toPromise();
+        const tree = await schematicRunner.runSchematic(migrationName, {}, appTree);
 
         expect(
             tree.readContent('/testSrc/appPrefix/component/test.component.ts')
@@ -133,7 +131,7 @@ describe(`Update to ${version}`, () => {
         );
     });
 
-    it('Should remove multiSelection property set to "true" and replace it with selectionMode property set to "multi"', async () => {
+    it('Should remove button-group multiSelection property set to "true" and replace it with selectionMode property set to "multi"', async () => {
         appTree.create(
             `/testSrc/appPrefix/component/test.component.html`,
             `<igx-buttongroup [multiSelection]="true">
@@ -145,9 +143,8 @@ describe(`Update to ${version}`, () => {
                 </button>
             </igx-buttongroup>`);
 
-        const tree = await schematicRunner.runSchematicAsync(migrationName, {}, appTree)
-            .toPromise();
-    
+        const tree = await schematicRunner.runSchematic(migrationName, {}, appTree);
+
         expect(tree.readContent('/testSrc/appPrefix/component/test.component.html'))
             .toEqual(
             `<igx-buttongroup [selectionMode]="'multi'">
@@ -160,7 +157,7 @@ describe(`Update to ${version}`, () => {
             </igx-buttongroup>`);
     });
 
-    it('Should remove multiSelection property set to "false"', async () => {
+    it('Should remove button-group multiSelection property set to "false"', async () => {
         appTree.create(
             '/testSrc/appPrefix/component/test.component.html',
             `<igx-buttongroup [multiSelection]="false">
@@ -172,8 +169,7 @@ describe(`Update to ${version}`, () => {
                 </button>
             </igx-buttongroup>`);
 
-        const tree = await schematicRunner.runSchematicAsync(migrationName, {}, appTree)
-            .toPromise();
+        const tree = await schematicRunner.runSchematic(migrationName, {}, appTree);
 
         expect(tree.readContent('/testSrc/appPrefix/component/test.component.html'))
             .toEqual(
@@ -185,5 +181,27 @@ describe(`Update to ${version}`, () => {
                     Button 2
                 </button>
             </igx-buttongroup>`);
+    });
+
+    it('Should not update button-group without multiSelection prop', async () => {
+        const content = `<igx-buttongroup alignment="horizontal">
+                <button igxButton>
+                    Button 1
+                </button>
+                <button igxButton>
+                    Button 2
+                </button>
+            </igx-buttongroup>
+            <igx-buttongroup>
+                <button igxButton>
+                    Button 1
+                </button>
+            </igx-buttongroup>`;
+
+        appTree.create(`/testSrc/appPrefix/component/test.component.html`, content);
+
+        const tree = await schematicRunner.runSchematic(migrationName, {}, appTree);
+
+        expect(tree.readContent('/testSrc/appPrefix/component/test.component.html')).toEqual(content);
     });
 });

--- a/projects/igniteui-angular/migrations/update-16_1_0/index.ts
+++ b/projects/igniteui-angular/migrations/update-16_1_0/index.ts
@@ -4,7 +4,7 @@ import {
     Tree
 } from '@angular-devkit/schematics';
 import { UpdateChanges } from '../common/UpdateChanges';
-import { FileChange, findElementNodes, getAttribute, getSourceOffset, parseFile } from '../common/util';
+import { FileChange, findElementNodes, getAttribute, getSourceOffset, hasAttribute, parseFile } from '../common/util';
 import { nativeImport } from '../common/import-helper.js';
 import { Element } from '@angular/compiler';
 
@@ -23,11 +23,11 @@ export default (): Rule => async (host: Tree, context: SchematicContext) => {
     const applyChanges = () => {
         for (const [path, change] of changes.entries()) {
           let buffer = host.read(path).toString();
-    
+
           change.sort((c, c1) => c.position - c1.position)
             .reverse()
             .forEach(c => buffer = c.apply(buffer));
-    
+
           host.overwrite(path, buffer);
         }
       };
@@ -42,7 +42,9 @@ export default (): Rule => async (host: Tree, context: SchematicContext) => {
 
     for (const path of update.templateFiles) {
         const buttonGroups = findElementNodes(parseFile(new HtmlParser(), host, path), 'igx-buttongroup');
-        buttonGroups.map(node => getSourceOffset(node as Element))
+        buttonGroups
+            .filter(node => hasAttribute(node as Element, prop))
+            .map(node => getSourceOffset(node as Element))
             .forEach(offset => {
                 const { startTag, file, node } = offset;
                 const { name, value } = getAttribute(node, prop)[0];


### PR DESCRIPTION
Closes #13476

Migrations that are using language service and trying to update .ts files are not currently working for certain monorepos. The workaround for the moment is to catch such exceptions and skip the migration for such cases.

The way migrations are working now is that they are searching for the `main.ts` file and updating the files in that project. However when some of the logic is put in a separate project under the monorepo (one of the cases is when "projectType": "library"), then the language service doesn't have access to all the files, and an exception is thrown. 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 