### PR TITLE
fix(grid): slightly different attr for formatters

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
@@ -658,7 +658,7 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
     @Input()
     public cellStyles = null;
 
-    /* alternateType: CellValueFormatterEventHandler */
+    /* blazorAlternateType: CellValueFormatterEventHandler */
     /* blazorOnlyScript */
     /**
      * Applies display format to cell values in the column. Does not modify the underlying data.
@@ -698,7 +698,7 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
     @Input()
     public formatter: (value: any, rowData?: any) => any;
 
-    /* alternateType: SummaryValueFormatterEventHandler */
+    /* blazorAlternateType: SummaryValueFormatterEventHandler */
     /* blazorOnlyScript */
     /**
      * The summaryFormatter is used to format the display of the column summaries.

--- a/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
@@ -852,7 +852,7 @@ export interface IgxGridRowEditTextTemplateContext {
 
 export interface IgxGridRowEditActionsTemplateContext {
     /* blazorCSSuppress */
-    /* alternateType: RowEditActionsImplicit */
+    /* blazorAlternateType: RowEditActionsImplicit */
     $implicit: (commit: boolean, event?: Event) => void
 }
 


### PR DESCRIPTION
We should use `blazorAlternateType` here since we only want the C# output to use these formatter types. The typescript declarations that we generate from the api analyzer should continue using the original function type. This will fix the web components typedoc build.