### PR TITLE
refactor(themes): use already ingested border-radius

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/source-map": "0.5.2",
         "fflate": "^0.7.3",
         "hammerjs": "^2.0.8",
-        "igniteui-theming": "^3.1.0-beta.4",
+        "igniteui-theming": "^3.1.0",
         "igniteui-trial-watermark": "^2.0.0",
         "lodash-es": "^4.17.21",
         "rxjs": "^6.6.7",
@@ -12382,9 +12382,9 @@
       }
     },
     "node_modules/igniteui-theming": {
-      "version": "3.1.0-beta.4",
-      "resolved": "https://registry.npmjs.org/igniteui-theming/-/igniteui-theming-3.1.0-beta.4.tgz",
-      "integrity": "sha512-Kfuk5joLp5oVmq1Dqgd0BWUoL6fRn9Ybjusksp/60ad2TGQdvqT0NUQkq2bkTd6o0H5JCWVTXtcYDjA7UcwT2g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/igniteui-theming/-/igniteui-theming-3.1.0.tgz",
+      "integrity": "sha512-7FtztYXu45h7AyKgNFQuMA1wPQ5UhZTDqsAmGoOTLvrhLELe0ar1Ikq487IByDsOnyl6jhv1I4ruA7DfsFTJQw==",
       "peerDependencies": {
         "sass": "^1.58.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/source-map": "0.5.2",
         "fflate": "^0.7.3",
         "hammerjs": "^2.0.8",
-        "igniteui-theming": "^3.0.4",
+        "igniteui-theming": "^3.1.0-beta.1",
         "igniteui-trial-watermark": "^2.0.0",
         "lodash-es": "^4.17.21",
         "rxjs": "^6.6.7",
@@ -12382,9 +12382,9 @@
       }
     },
     "node_modules/igniteui-theming": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/igniteui-theming/-/igniteui-theming-3.0.4.tgz",
-      "integrity": "sha512-VUYLTdh/+SLWqxBqVxU3xFytDbbmlWhnT9ElkKbkBc0JwR6yyUMZ8kYHmupByHgO81l9FR/mX+wMB4uHkz4TvQ==",
+      "version": "3.1.0-beta.1",
+      "resolved": "https://registry.npmjs.org/igniteui-theming/-/igniteui-theming-3.1.0-beta.1.tgz",
+      "integrity": "sha512-sj2ZNPW87theDMt7/IBHuyOpL3inGxwoes/MzI50fR7xKuaS6C7v9Hq0F+plpFYlkC+b5IQlYIpd1UnrBor5Vw==",
       "peerDependencies": {
         "sass": "^1.58.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/source-map": "0.5.2",
         "fflate": "^0.7.3",
         "hammerjs": "^2.0.8",
-        "igniteui-theming": "^3.1.0-beta.3",
+        "igniteui-theming": "^3.1.0-beta.4",
         "igniteui-trial-watermark": "^2.0.0",
         "lodash-es": "^4.17.21",
         "rxjs": "^6.6.7",
@@ -12382,9 +12382,9 @@
       }
     },
     "node_modules/igniteui-theming": {
-      "version": "3.1.0-beta.3",
-      "resolved": "https://registry.npmjs.org/igniteui-theming/-/igniteui-theming-3.1.0-beta.3.tgz",
-      "integrity": "sha512-IT7yVlqkiSUIMiEKmcFryH5yJ14CDXQfGOFOwVOpKMQYdVPfAQnDOLXs+48D0bQepNiaKZJP2wwfX9HJpbz2YA==",
+      "version": "3.1.0-beta.4",
+      "resolved": "https://registry.npmjs.org/igniteui-theming/-/igniteui-theming-3.1.0-beta.4.tgz",
+      "integrity": "sha512-Kfuk5joLp5oVmq1Dqgd0BWUoL6fRn9Ybjusksp/60ad2TGQdvqT0NUQkq2bkTd6o0H5JCWVTXtcYDjA7UcwT2g==",
       "peerDependencies": {
         "sass": "^1.58.1"
       }

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@types/source-map": "0.5.2",
     "fflate": "^0.7.3",
     "hammerjs": "^2.0.8",
-    "igniteui-theming": "^3.1.0-beta.3",
+    "igniteui-theming": "^3.1.0-beta.4",
     "igniteui-trial-watermark": "^2.0.0",
     "lodash-es": "^4.17.21",
     "rxjs": "^6.6.7",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@types/source-map": "0.5.2",
     "fflate": "^0.7.3",
     "hammerjs": "^2.0.8",
-    "igniteui-theming": "^3.1.0-beta.4",
+    "igniteui-theming": "^3.1.0",
     "igniteui-trial-watermark": "^2.0.0",
     "lodash-es": "^4.17.21",
     "rxjs": "^6.6.7",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@types/source-map": "0.5.2",
     "fflate": "^0.7.3",
     "hammerjs": "^2.0.8",
-    "igniteui-theming": "^3.0.4",
+    "igniteui-theming": "^3.1.0-beta.1",
     "igniteui-trial-watermark": "^2.0.0",
     "lodash-es": "^4.17.21",
     "rxjs": "^6.6.7",

--- a/projects/igniteui-angular/src/lib/core/styles/components/action-strip/_action-strip-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/action-strip/_action-strip-theme.scss
@@ -48,7 +48,7 @@
     }
 
     @if not($actions-border-radius) {
-        $actions-border-radius: border-radius(map.get($theme, 'actions-border-radius')...);
+        $actions-border-radius: map.get($theme, 'actions-border-radius');
     }
 
     @return extend($theme, (

--- a/projects/igniteui-angular/src/lib/core/styles/components/button-group/_button-group-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/button-group/_button-group-theme.scss
@@ -132,10 +132,6 @@
         $shadow: elevation($elevation);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         selector: $selector,

--- a/projects/igniteui-angular/src/lib/core/styles/components/button/_button-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/button/_button-theme.scss
@@ -167,10 +167,6 @@
             $_active-shadow: elevation($active-elevation);
         }
 
-        @if not($_border-radius) {
-            $_border-radius: border-radius(map.get($_schema, 'border-radius')...);
-        }
-
         $themes: map.merge($themes, (
             $_name: extend( digest-schema($_schema), (
                 name: $name,

--- a/projects/igniteui-angular/src/lib/core/styles/components/calendar/_calendar-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/calendar/_calendar-theme.scss
@@ -323,18 +323,6 @@
         $week-number-color: text-contrast($week-number-background);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
-    @if not($month-border-radius) {
-        $month-border-radius: border-radius(map.get($theme, 'month-border-radius')...);
-    }
-
-    @if not($date-border-radius) {
-        $date-border-radius: border-radius(map.get($theme, 'date-border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         selector: $selector,

--- a/projects/igniteui-angular/src/lib/core/styles/components/card/_card-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/card/_card-theme.scss
@@ -88,10 +88,6 @@
         $hover-shadow: elevation($hover-elevation);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         background: $background,

--- a/projects/igniteui-angular/src/lib/core/styles/components/carousel/_carousel-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/carousel/_carousel-theme.scss
@@ -89,10 +89,6 @@
         }
     }
 
-    @if not($border-radius){
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
 

--- a/projects/igniteui-angular/src/lib/core/styles/components/checkbox/_checkbox-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/checkbox/_checkbox-theme.scss
@@ -67,14 +67,6 @@
     $theme: digest-schema($checkbox-schema);
     $meta: map.get($theme, '_meta');
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
-    @if not($border-radius-ripple) {
-        $border-radius-ripple: border-radius(map.get($theme, 'border-radius-ripple')...);
-    }
-
     @return extend($theme, (
         name: $name,
         label-color: $label-color,

--- a/projects/igniteui-angular/src/lib/core/styles/components/chip/_chip-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/chip/_chip-theme.scss
@@ -203,10 +203,6 @@
         $ghost-shadow: elevation($ghost-elevation);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         selector: $selector,

--- a/projects/igniteui-angular/src/lib/core/styles/components/dialog/_dialog-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/dialog/_dialog-theme.scss
@@ -65,10 +65,6 @@
         $shadow: elevation($elevation);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         selector: $selector,

--- a/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/drop-down/_drop-down-theme.scss
@@ -152,14 +152,6 @@
         $shadow: elevation($elevation);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
-    @if not($item-border-radius) {
-        $item-border-radius: border-radius(map.get($theme, 'item-border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         selector: $selector,

--- a/projects/igniteui-angular/src/lib/core/styles/components/expansion-panel/_expansion-panel-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/expansion-panel/_expansion-panel-theme.scss
@@ -71,10 +71,6 @@
         $body-color: text-contrast($body-background);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         header-background: $header-background,

--- a/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/grid/_grid-theme.scss
@@ -455,7 +455,7 @@
     }
 
     @if not($drop-area-border-radius) {
-        $drop-area-border-radius: border-radius(map.get($theme, 'drop-area-border-radius')...);
+        $drop-area-border-radius: map.get($theme, 'drop-area-border-radius');
     }
 
     @return extend($theme, (

--- a/projects/igniteui-angular/src/lib/core/styles/components/input/_input-group-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/input/_input-group-theme.scss
@@ -206,15 +206,15 @@
     }
 
     @if not($box-border-radius) {
-        $box-border-radius: border-radius(map.get($theme, 'box-border-radius')...);
+        $box-border-radius: map.get($theme, 'box-border-radius');
     }
 
     @if not($border-border-radius) {
-        $border-border-radius: border-radius(map.get($theme, 'border-border-radius')...);
+        $border-border-radius: map.get($theme, 'border-border-radius');
     }
 
     @if not($search-border-radius) {
-        $search-border-radius: border-radius(map.get($theme, 'search-border-radius')...);
+        $search-border-radius: map.get($theme, 'search-border-radius');
     }
 
     @return extend($theme, (

--- a/projects/igniteui-angular/src/lib/core/styles/components/list/_list-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/list/_list-theme.scss
@@ -202,14 +202,6 @@
         $item-subtitle-color-active: $item-text-color-active;
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
-    @if not($item-border-radius) {
-        $item-border-radius: border-radius(map.get($theme, 'item-border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         border-radius: $border-radius,

--- a/projects/igniteui-angular/src/lib/core/styles/components/navdrawer/_navdrawer-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/navdrawer/_navdrawer-theme.scss
@@ -113,14 +113,6 @@
         $shadow: elevation($elevation);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
-    @if not($item-border-radius) {
-        $item-border-radius: border-radius(map.get($theme, 'item-border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         border-radius: $border-radius,

--- a/projects/igniteui-angular/src/lib/core/styles/components/progress/_progress-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/progress/_progress-theme.scss
@@ -55,7 +55,7 @@
     $meta: map.get($theme, '_meta');
 
     @if not($track-border-radius) {
-        $track-border-radius: border-radius(map.get($theme, 'track-border-radius')...);
+        $track-border-radius: map.get($theme, 'track-border-radius');
     }
 
     @return extend($theme, (

--- a/projects/igniteui-angular/src/lib/core/styles/components/snackbar/_snackbar-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/snackbar/_snackbar-theme.scss
@@ -59,10 +59,6 @@
         $shadow: elevation($elevation);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         border-radius: $border-radius,

--- a/projects/igniteui-angular/src/lib/core/styles/components/splitter/_splitter-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/splitter/_splitter-theme.scss
@@ -53,10 +53,6 @@
         $expander-color: text-contrast($bar-color);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         bar-color: $bar-color,

--- a/projects/igniteui-angular/src/lib/core/styles/components/stepper/_stepper-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/stepper/_stepper-theme.scss
@@ -230,11 +230,11 @@
     }
 
     @if not($border-radius-indicator) {
-        $border-radius-indicator: border-radius(map.get($theme, 'border-radius-indicator')...);
+        $border-radius-indicator: map.get($theme, 'border-radius-indicator');
     }
 
     @if not($border-radius-step-header) {
-        $border-radius-step-header: border-radius(map.get($theme, 'border-radius-step-header')...);
+        $border-radius-step-header: map.get($theme, 'border-radius-step-header');
     }
 
     @return extend($theme, (

--- a/projects/igniteui-angular/src/lib/core/styles/components/switch/_switch-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/switch/_switch-theme.scss
@@ -117,15 +117,15 @@
     }
 
     @if not($border-radius-track) {
-        $border-radius-track: border-radius(map.get($theme, 'border-radius-track')...);
+        $border-radius-track: map.get($theme, 'border-radius-track');
     }
 
     @if not($border-radius-thumb) {
-        $border-radius-thumb: border-radius(map.get($theme, 'border-radius-thumb')...);
+        $border-radius-thumb: map.get($theme, 'border-radius-thumb');
     }
 
     @if not($border-radius-ripple) {
-        $border-radius-ripple: border-radius(map.get($theme, 'border-radius-ripple')...);
+        $border-radius-ripple: map.get($theme, 'border-radius-ripple');
     }
 
     @return extend($theme, (

--- a/projects/igniteui-angular/src/lib/core/styles/components/tabs/_tabs-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/tabs/_tabs-theme.scss
@@ -164,10 +164,6 @@
         $tab-ripple-color: text-contrast($item-background);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         item-text-color: $item-text-color,

--- a/projects/igniteui-angular/src/lib/core/styles/components/time-picker/_time-picker-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/time-picker/_time-picker-theme.scss
@@ -109,14 +109,6 @@
         $dropdown-shadow: elevation($elevation);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
-    @if not($active-item-border-radius) {
-        $active-item-border-radius: border-radius(map.get($theme, 'active-item-border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         selector: $selector,

--- a/projects/igniteui-angular/src/lib/core/styles/components/toast/_toast-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/toast/_toast-theme.scss
@@ -55,10 +55,6 @@
         $text-color: text-contrast($background);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         background: $background,

--- a/projects/igniteui-angular/src/lib/core/styles/components/tooltip/_tooltip-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/tooltip/_tooltip-theme.scss
@@ -46,10 +46,6 @@
         $text-color: text-contrast($background);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         selector: $selector,

--- a/projects/igniteui-angular/src/lib/core/styles/components/watermark/_watermark-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/watermark/_watermark-theme.scss
@@ -48,10 +48,6 @@
         $color: text-contrast($link-background);
     }
 
-    @if not($border-radius) {
-        $border-radius: border-radius(map.get($theme, 'border-radius')...);
-    }
-
     @return extend($theme, (
         name: $name,
         selector: 'igc-trial-watermark',


### PR DESCRIPTION
Related https://github.com/IgniteUI/igniteui-theming/pull/113

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 