### PR TITLE
fix(combos): change valid property type to exposed IgxInputState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ All notable changes for each version of this project will be documented in this 
     - `ISimpleComboSelectionChangingEventArgs` exposes two new properties `newSelection` and `oldSelection` in place of the old ones that are no longer affected by `valueKey` and consistently emit items from Combo's `data`.
 
       Note: In remote data scenarios with `valueKey` set, selected items that are not currently part of the loaded data chunk will be emitted a partial item data object with the `valueKey` property.
+- `IgxCombo`,`IgxSimpleCombo`
+    - **Breaking Change** The `valid` property now accepts and returns the same `IgxInputState` enumeration as `IgxInput`.
+
 ## 16.1.4
 ### New Features
 - `Themes`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,6 @@ All notable changes for each version of this project will be documented in this 
     - `ISimpleComboSelectionChangingEventArgs` exposes two new properties `newSelection` and `oldSelection` in place of the old ones that are no longer affected by `valueKey` and consistently emit items from Combo's `data`.
 
       Note: In remote data scenarios with `valueKey` set, selected items that are not currently part of the loaded data chunk will be emitted a partial item data object with the `valueKey` property.
-- `IgxCombo`,`IgxSimpleCombo`
-    - **Breaking Change** The `valid` property now accepts and returns the same `IgxInputState` enumeration as `IgxInput`.
-
 ## 16.1.4
 ### New Features
 - `Themes`:

--- a/projects/igniteui-angular/src/lib/combo/combo.common.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.common.ts
@@ -103,21 +103,6 @@ export enum DataTypes {
     PRIMARYKEY = 'valueKey'
 }
 
-export enum IgxComboState {
-    /**
-     * Combo with initial state.
-     */
-    INITIAL = IgxInputState.INITIAL,
-    /**
-     * Combo with valid state.
-     */
-    VALID = IgxInputState.VALID,
-    /**
-     * Combo with invalid state.
-     */
-    INVALID = IgxInputState.INVALID
-}
-
 /** The filtering criteria to be applied on data search */
 export interface IComboFilteringOptions {
     /** Defines filtering case-sensitivity */
@@ -792,7 +777,7 @@ export abstract class IgxComboBaseDirective extends DisplayDensityBase implement
      * let valid = this.combo.valid;
      * ```
      */
-    public get valid(): IgxComboState {
+    public get valid(): IgxInputState {
         return this._valid;
     }
 
@@ -801,12 +786,12 @@ export abstract class IgxComboBaseDirective extends DisplayDensityBase implement
      *
      * ```typescript
      * // set
-     * this.combo.valid = IgxComboState.INVALID;
+     * this.combo.valid = IgxInputState.INVALID;
      * ```
      */
-    public set valid(valid: IgxComboState) {
+    public set valid(valid: IgxInputState) {
         this._valid = valid;
-        this.comboInput.valid = IgxInputState[IgxComboState[valid]];
+        this.comboInput.valid = valid;
     }
 
     /**
@@ -941,7 +926,7 @@ export abstract class IgxComboBaseDirective extends DisplayDensityBase implement
     protected _displayKey: string;
     protected _remoteSelection = {};
     protected _resourceStrings = getCurrentResourceStrings(ComboResourceStringsEN);
-    protected _valid = IgxComboState.INITIAL;
+    protected _valid = IgxInputState.INITIAL;
     protected ngControl: NgControl = null;
     protected destroy$ = new Subject<any>();
     protected _onTouchedCallback: () => void = noop;
@@ -1250,9 +1235,9 @@ export abstract class IgxComboBaseDirective extends DisplayDensityBase implement
         if (this.collapsed) {
             this._onTouchedCallback();
             if (this.ngControl && this.ngControl.invalid) {
-                this.valid = IgxComboState.INVALID;
+                this.valid = IgxInputState.INVALID;
             } else {
-                this.valid = IgxComboState.INITIAL;
+                this.valid = IgxInputState.INITIAL;
             }
         }
     }
@@ -1270,13 +1255,13 @@ export abstract class IgxComboBaseDirective extends DisplayDensityBase implement
     protected onStatusChanged = () => {
         if (this.ngControl && this.isTouchedOrDirty && !this.disabled) {
             if (this.hasValidators && (!this.collapsed || this.inputGroup.isFocused)) {
-                this.valid = this.ngControl.valid ? IgxComboState.VALID : IgxComboState.INVALID;
+                this.valid = this.ngControl.valid ? IgxInputState.VALID : IgxInputState.INVALID;
             } else {
-                this.valid = this.ngControl.valid ? IgxComboState.INITIAL : IgxComboState.INVALID;
+                this.valid = this.ngControl.valid ? IgxInputState.INITIAL : IgxInputState.INVALID;
             }
         } else {
             // B.P. 18 May 2021: IgxDatePicker does not reset its state upon resetForm #9526
-            this.valid = IgxComboState.INITIAL;
+            this.valid = IgxInputState.INITIAL;
         }
         this.manageRequiredAsterisk();
     };

--- a/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/combo/combo.component.spec.ts
@@ -22,7 +22,7 @@ import { UIInteractions, wait } from '../test-utils/ui-interactions.spec';
 import { IgxComboAddItemComponent } from './combo-add-item.component';
 import { IgxComboDropDownComponent } from './combo-dropdown.component';
 import { IgxComboItemComponent } from './combo-item.component';
-import { IComboFilteringOptions, IgxComboState } from './combo.common';
+import { IComboFilteringOptions } from './combo.common';
 import {
     IComboItemAdditionEvent, IComboSearchInputEventArgs, IComboSelectionChangingEventArgs, IgxComboComponent
 } from './combo.component';
@@ -3019,26 +3019,26 @@ describe('igxCombo', () => {
                     expect(combo.value).toEqual(comboFormReference.value);
                     expect(combo.selection.length).toEqual(1);
                     expect(combo.selection[0].field).toEqual('Connecticut');
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                     const clearButton = fixture.debugElement.query(By.css(`.${CSS_CLASS_CLEARBUTTON}`));
                     clearButton.triggerEventHandler('click', UIInteractions.getMouseEvent('click'));
                     fixture.detectChanges();
-                    expect(combo.valid).toEqual(IgxComboState.INVALID);
+                    expect(combo.valid).toEqual(IgxInputState.INVALID);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                     combo.onBlur();
                     fixture.detectChanges();
-                    expect(combo.valid).toEqual(IgxComboState.INVALID);
+                    expect(combo.valid).toEqual(IgxInputState.INVALID);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                     combo.select([combo.dropdown.items[0], combo.dropdown.items[1]]);
-                    expect(combo.valid).toEqual(IgxComboState.VALID);
+                    expect(combo.valid).toEqual(IgxInputState.VALID);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.VALID);
 
                     combo.onBlur();
                     fixture.detectChanges();
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                 });
                 it('should properly initialize when used as a form control - without validators', () => {
@@ -3051,26 +3051,26 @@ describe('igxCombo', () => {
                     expect(combo.value).toEqual(comboFormReference.value);
                     expect(combo.selection.length).toEqual(1);
                     expect(combo.selection[0].field).toEqual('Connecticut');
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                     const clearButton = fixture.debugElement.query(By.css(`.${CSS_CLASS_CLEARBUTTON}`));
                     clearButton.triggerEventHandler('click', UIInteractions.getMouseEvent('click'));
                     fixture.detectChanges();
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
 
                     combo.onBlur();
                     fixture.detectChanges();
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
 
                     combo.select([combo.dropdown.items[0], combo.dropdown.items[1]]);
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
 
                     combo.onBlur();
                     fixture.detectChanges();
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                 });
                 it('should be possible to be enabled/disabled when used as a form control', () => {
@@ -3198,24 +3198,24 @@ describe('igxCombo', () => {
                     inputGroupRequired = fixture.debugElement.query(By.css(`.${CSS_CLASS_INPUTGROUP_REQUIRED}`));
                 }));
                 it('should properly initialize when used in a template form control', () => {
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                     expect(inputGroupRequired).toBeDefined();
                     combo.onBlur();
                     fixture.detectChanges();
-                    expect(combo.valid).toEqual(IgxComboState.INVALID);
+                    expect(combo.valid).toEqual(IgxInputState.INVALID);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                     input.triggerEventHandler('focus', {});
                     combo.selectAllItems();
                     fixture.detectChanges();
-                    expect(combo.valid).toEqual(IgxComboState.VALID);
+                    expect(combo.valid).toEqual(IgxInputState.VALID);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.VALID);
 
                     const clearButton = fixture.debugElement.query(By.css(`.${CSS_CLASS_CLEARBUTTON}`));
                     clearButton.triggerEventHandler('click', UIInteractions.getMouseEvent('click'));
                     fixture.detectChanges();
-                    expect(combo.valid).toEqual(IgxComboState.INVALID);
+                    expect(combo.valid).toEqual(IgxInputState.INVALID);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                 });
                 it('should properly init with empty array and handle consecutive model changes', fakeAsync(() => {
@@ -3223,7 +3223,7 @@ describe('igxCombo', () => {
                     fixture.componentInstance.values = [];
                     fixture.detectChanges();
                     tick();
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                     expect(model.valid).toBeFalse();
                     expect(model.dirty).toBeFalse();
@@ -3232,7 +3232,7 @@ describe('igxCombo', () => {
                     fixture.componentInstance.values = ['Missouri'];
                     fixture.detectChanges();
                     tick();
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.selection).toEqual([{ field: 'Missouri', region: 'West North Central' }]);
                     expect(combo.value).toEqual(['Missouri']);
@@ -3242,7 +3242,7 @@ describe('igxCombo', () => {
 
                     fixture.componentInstance.values = ['Missouri', 'Missouri'];
                     fixture.detectChanges();
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.selection).toEqual([{ field: 'Missouri', region: 'West North Central' }]);
                     expect(combo.value).toEqual(['Missouri']);
@@ -3253,7 +3253,7 @@ describe('igxCombo', () => {
                     fixture.componentInstance.values = null;
                     fixture.detectChanges();
                     tick();
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.selection).toEqual([]);
                     expect(combo.value).toEqual([]);
@@ -3264,7 +3264,7 @@ describe('igxCombo', () => {
 
                     combo.onBlur();
                     fixture.detectChanges();
-                    expect(combo.valid).toEqual(IgxComboState.INVALID);
+                    expect(combo.valid).toEqual(IgxInputState.INVALID);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                     expect(model.valid).toBeFalse();
                     expect(model.touched).toBeTrue();
@@ -3273,7 +3273,7 @@ describe('igxCombo', () => {
                     fixture.componentInstance.values = ['New Jersey'];
                     fixture.detectChanges();
                     tick();
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.selection).toEqual([{ field: 'New Jersey', region: 'Mid-Atlan' }]);
                     expect(combo.value).toEqual(['New Jersey']);
@@ -3292,12 +3292,12 @@ describe('igxCombo', () => {
                 it('should set validity to initial when the form is reset', fakeAsync(() => {
                     combo.onBlur();
                     fixture.detectChanges();
-                    expect(combo.valid).toEqual(IgxComboState.INVALID);
+                    expect(combo.valid).toEqual(IgxInputState.INVALID);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                     fixture.componentInstance.form.resetForm();
                     tick();
-                    expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                    expect(combo.valid).toEqual(IgxInputState.INITIAL);
                     expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                 }));
             });

--- a/projects/igniteui-angular/src/lib/simple-combo/simple-combo.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/simple-combo/simple-combo.component.spec.ts
@@ -5,7 +5,6 @@ import { FormsModule, NgForm, ReactiveFormsModule, UntypedFormBuilder, UntypedFo
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IgxComboDropDownComponent } from '../combo/combo-dropdown.component';
-import { IgxComboState } from '../combo/combo.common';
 import { RemoteDataService } from '../combo/combo.component.spec';
 import { IComboSelectionChangingEventArgs, IgxComboFooterDirective, IgxComboHeaderDirective, IgxComboItemDirective, IgxComboToggleIconDirective } from '../combo/public_api';
 import { DisplayDensity } from '../core/density';
@@ -1579,35 +1578,35 @@ describe('IgxSimpleCombo', () => {
                 inputGroupRequired = fixture.debugElement.query(By.css(`.${CSS_CLASS_INPUTGROUP_REQUIRED}`));
             }));
             it('should properly initialize when used in a template form control', () => {
-                expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                expect(combo.valid).toEqual(IgxInputState.INITIAL);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                 expect(inputGroupRequired).toBeDefined();
                 combo.onBlur();
                 fixture.detectChanges();
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                 input.triggerEventHandler('focus', {});
                 combo.select('Wisconsin');
                 fixture.detectChanges();
-                expect(combo.valid).toEqual(IgxComboState.VALID);
+                expect(combo.valid).toEqual(IgxInputState.VALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.VALID);
 
                 const clearButton = fixture.debugElement.query(By.css(`.${CSS_CLASS_CLEARBUTTON}`));
                 clearButton.triggerEventHandler('click', UIInteractions.getMouseEvent('click'));
                 fixture.detectChanges();
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
             });
             it('should set validity to initial when the form is reset', fakeAsync(() => {
                 combo.onBlur();
                 fixture.detectChanges();
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                 fixture.componentInstance.form.resetForm();
                 tick();
-                expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                expect(combo.valid).toEqual(IgxInputState.INITIAL);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
             }));
             it('should not select null, undefined and empty string in a template form with required', () => {
@@ -1624,7 +1623,7 @@ describe('IgxSimpleCombo', () => {
                     { field: 'undefined', value: undefined },
                 ];
 
-                expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                expect(combo.valid).toEqual(IgxInputState.INITIAL);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
 
                 // empty string
@@ -1637,7 +1636,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                 // null
@@ -1650,7 +1649,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                 // undefined
@@ -1663,7 +1662,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                 // primitive data - undefined is not displayed in the dropdown
@@ -1674,7 +1673,7 @@ describe('IgxSimpleCombo', () => {
 
                 fixture.componentInstance.form.resetForm();
                 fixture.detectChanges();
-                expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                expect(combo.valid).toEqual(IgxInputState.INITIAL);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
 
                 // empty string
@@ -1687,7 +1686,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                 // null
@@ -1700,7 +1699,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
             });
             it('should not select null, undefined and empty string with "writeValue" method in a template form with required', () => {
@@ -1717,7 +1716,7 @@ describe('IgxSimpleCombo', () => {
                     { field: 'undefined', value: undefined },
                 ];
 
-                expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                expect(combo.valid).toEqual(IgxInputState.INITIAL);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
 
                 combo.onBlur();
@@ -1727,21 +1726,21 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                 combo.writeValue('');
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                 combo.writeValue(undefined);
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                 // primitive data - undefined is not displayed in the dropdown
@@ -1752,7 +1751,7 @@ describe('IgxSimpleCombo', () => {
 
                 fixture.componentInstance.form.resetForm();
                 fixture.detectChanges();
-                expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                expect(combo.valid).toEqual(IgxInputState.INITIAL);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
 
                 combo.onBlur();
@@ -1762,21 +1761,21 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                 combo.writeValue('');
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
 
                 combo.writeValue(undefined);
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
             });
         });
@@ -1815,7 +1814,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                expect(combo.valid).toEqual(IgxInputState.INITIAL);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1830,7 +1829,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1845,7 +1844,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1860,7 +1859,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1875,7 +1874,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                expect(combo.valid).toEqual(IgxInputState.INITIAL);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1890,7 +1889,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1905,7 +1904,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1927,7 +1926,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                expect(combo.valid).toEqual(IgxInputState.INITIAL);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1939,7 +1938,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1948,7 +1947,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1957,7 +1956,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1973,7 +1972,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INITIAL);
+                expect(combo.valid).toEqual(IgxInputState.INITIAL);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INITIAL);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1985,7 +1984,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -1994,7 +1993,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');
@@ -2003,7 +2002,7 @@ describe('IgxSimpleCombo', () => {
                 expect(combo.displayValue).toEqual([]);
                 expect(combo.selection).toEqual([]);
                 expect(combo.value).toEqual([]);
-                expect(combo.valid).toEqual(IgxComboState.INVALID);
+                expect(combo.valid).toEqual(IgxInputState.INVALID);
                 expect(combo.comboInput.valid).toEqual(IgxInputState.INVALID);
                 expect(reactiveForm.status).toEqual('INVALID');
                 expect(reactiveControl.status).toEqual('INVALID');


### PR DESCRIPTION
The previous type was `IgxComboState` but that was not exported from the public API
![image](https://github.com/IgniteUI/igniteui-angular/assets/3198469/a4cbfe2b-469c-411c-aa4a-e43285a870a9)
and was also identical in values and somewhat redundant, so just switched over to the existing `IgxInputState` it was using underneath anyway.

Closes #  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [x] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 