### PR TITLE
ci(publish): NODE_OPTIONS emit to GITHUB_ENV is deprecated & not needed

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,7 +18,6 @@ jobs:
       - run: echo ${VERSION}
 
       - run: echo "NG_CLI_ANALYTICS=false" >> $GITHUB_ENV
-      - run: echo "NODE_OPTIONS='--max_old_space_size=4096'" >> $GITHUB_ENV
       - run: npm ci
 
       - name: Build igniteui-angular


### PR DESCRIPTION
Noticed our publish action is erroring on this step: https://github.com/IgniteUI/igniteui-angular/actions/runs/6814787834/job/18532444084#step:7:10

See https://github.blog/changelog/2023-10-05-github-actions-node_options-is-now-restricted-from-github_env/ - which means this has been 'inactive' for a while and is very much a step we can do without.
I checked and:
- based on the current [hosted runners for actions](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) `ubuntu-latest` should be running about 7 GB RAM and that puts Node since v12 at 2GB
- the heaviest process the publish does is build lib and that from what I see only goes a bit over 1GB, so we can skip this entirely. 

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [x] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 