### PR TITLE
fix(igxForOf): do not reset state.startIndex with scroll position - 17.0.x

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.spec.ts
@@ -189,6 +189,38 @@ describe('IgxForOf directive -', () => {
             expect(state.startIndex).toBe(1);
         });
 
+        it('should display the correct chunk items on resizing the container', () => {
+            // initially the container's width is narrow enough to be scrollable
+            fix.componentInstance.width = '200px';
+            fix.componentInstance.cols = [
+                { field: '1', width: 100 },
+                { field: '2', width: 100 },
+                { field: '3', width: 100 },
+                { field: '4', width: 100 },
+                { field: '5', width: 100 }
+            ];
+            fix.detectChanges();
+
+            expect(displayContainer).not.toBeNull();
+
+            // scroll the container so that at least the first col is out of view
+            fix.componentInstance.scrollLeft(displayContainer.clientWidth);
+            fix.detectChanges();
+
+            fix.componentInstance.childVirtDirs.toArray().forEach(element => {
+                expect(element.state.startIndex).not.toBe(0);
+            });
+
+            // the container's width is assigned as wide as to display all cols
+            fix.componentInstance.width = '600px';
+            fix.detectChanges();
+
+            const secondRecChildren = fix.nativeElement.querySelectorAll(DISPLAY_CONTAINER)[1].children;
+            for (let i = 0; i < secondRecChildren.length; i++) {
+                expect(secondRecChildren[i].textContent)
+                    .toBe(fix.componentInstance.data[1][i + 1].toString());
+            }
+        });
     });
 
     describe('vertical virtual component', () => {

--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
@@ -888,7 +888,6 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
     public resetScrollPosition() {
         this.scrollPosition = 0;
         this.scrollComponent.scrollAmount = 0;
-        this.state.startIndex = 0;
     }
 
     /**


### PR DESCRIPTION
Closes #13688 

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 