### PR TITLE
chore(migrations): update using standalone schematics

### DIFF
--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -86,7 +86,7 @@
         "@angular/forms": "^17.0.0"
     },
     "igxDevDependencies": {
-        "@igniteui/angular-schematics": "~17.0.1300"
+        "@igniteui/angular-schematics": "~17.1.1310-beta.0"
     },
     "ng-update": {
         "migrations": "./migrations/migration-collection.json",

--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -86,7 +86,7 @@
         "@angular/forms": "^17.0.0"
     },
     "igxDevDependencies": {
-        "@igniteui/angular-schematics": "~17.1.1310-beta.0"
+        "@igniteui/angular-schematics": "~17.1.1310"
     },
     "ng-update": {
         "migrations": "./migrations/migration-collection.json",


### PR DESCRIPTION
Update @igniteui/angular-schematics with version 17.1.1310, which is standalone.