### PR TITLE
fix(grid): Correct shift-click selection in grouped IgxGrid #13757

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid/grid-row-selection.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-row-selection.spec.ts
@@ -2269,7 +2269,7 @@ describe('IgxGrid - Row Selection #grid', () => {
 
             expect(fix.componentInstance.onHeaderCheckboxClick).toHaveBeenCalledTimes(2);
             expect(fix.componentInstance.onHeaderCheckboxClick).
-                toHaveBeenCalledWith(fix.componentInstance.headerCheckboxClick, contextUnselect);
+                 toHaveBeenCalledWith(fix.componentInstance.headerCheckboxClick, contextUnselect);
         });
 
         it('Should have correct indices on all pages', () => {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-row-selection.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-row-selection.spec.ts
@@ -543,6 +543,53 @@ describe('IgxGrid - Row Selection #grid', () => {
             }
         });
 
+        it('Should select the correct rows with Shift + Click when grouping is activated', () => {
+            expect(grid.selectRowOnClick).toBe(true);
+            spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
+
+            grid.groupBy({
+                fieldName: 'ProductName', dir: SortingDirection.Desc, ignoreCase: false
+            });
+
+            fix.detectChanges();
+
+            const firstGroupRow = grid.gridAPI.get_row_by_index(1);
+            const lastGroupRow = grid.gridAPI.get_row_by_index(4);
+
+            // Clicking on the first row within a group
+            UIInteractions.simulateClickEvent(firstGroupRow.nativeElement);
+            fix.detectChanges();
+
+            GridSelectionFunctions.verifyRowSelected(firstGroupRow);
+
+            // Simulate Shift+Click on a row within another group
+            const mockEvent = new MouseEvent('click', { shiftKey: true });
+            lastGroupRow.nativeElement.dispatchEvent(mockEvent);
+            fix.detectChanges();
+
+            expect(grid.selectedRows).toEqual([5, 14, 8]); // ids
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledTimes(2);
+            expect(grid.rowSelectionChanging.emit).toHaveBeenCalledWith({
+                added: [grid.dataView[2], grid.dataView[4]],
+                cancel: false,
+                event: jasmine.anything(),
+                newSelection: [grid.dataView[1], grid.dataView[2], grid.dataView[4]],
+                oldSelection: [grid.dataView[1]],
+                removed: [],
+                allRowsSelected: false,
+                owner: grid
+            });
+
+            const expectedSelectedRowIds = [5, 14, 8];
+            grid.dataView.forEach((rowData, index) => {
+                if (expectedSelectedRowIds.includes(rowData.ProductID)) {
+                    const row = grid.gridAPI.get_row_by_index(index);
+                    GridSelectionFunctions.verifyRowSelected(row);
+                }
+            });
+
+        });
+
         it('Should NOT select multiple rows with Shift + Click when selectRowOnClick has false value', () => {
             grid.selectRowOnClick = false;
             spyOn(grid.rowSelectionChanging, 'emit').and.callThrough();
@@ -2222,7 +2269,7 @@ describe('IgxGrid - Row Selection #grid', () => {
 
             expect(fix.componentInstance.onHeaderCheckboxClick).toHaveBeenCalledTimes(2);
             expect(fix.componentInstance.onHeaderCheckboxClick).
-                 toHaveBeenCalledWith(fix.componentInstance.headerCheckboxClick, contextUnselect);
+                toHaveBeenCalledWith(fix.componentInstance.headerCheckboxClick, contextUnselect);
         });
 
         it('Should have correct indices on all pages', () => {

--- a/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
@@ -689,7 +689,7 @@ export class IgxGridSelectionService {
     /** Returns all data in the grid, with applied filtering and sorting and without deleted rows. */
     public get allData(): Array<any> {
         let allData;
-        if (this.isFilteringApplied() || this.grid.sortingExpressions.length) {
+        if (this.isFilteringApplied() || this.grid.sortingExpressions.length || this.grid.groupingExpressions?.length) {
             allData = this.grid.pinnedRecordsCount ? this.grid._filteredSortedUnpinnedData : this.grid.filteredSortedData;
         } else {
             allData = this.grid.gridAPI.get_all_data(true);


### PR DESCRIPTION
Closes #13757

This PR addresses the issue where shift-click was not functioning correctly in an IgxGrid with grouped rows. The selection logic has been updated to properly handle multi-level group comparisons, ensuring that the shift-click selection is consistent and intuitive in grouped grids.

Additional information:
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Demos
- [ ] CI/CD

Checklist:
- [x] All relevant tags have been applied to this PR
- [ ] This PR includes unit tests covering all the new code
- [ ] This PR includes API docs for newly added methods/properties
- [ ] This PR includes feature/README.MD updates for the feature docs
- [ ] This PR includes general feature table updates in the root README.MD
- [ ] This PR includes CHANGELOG.MD updates for newly added functionality
- [ ] This PR contains breaking changes
- [ ] This PR includes ng update migrations for the breaking changes
- [x] This PR includes behavioral changes and the feature specification has been updated with them
