### PR TITLE
fix(grid): Correct shift-click selection in grouped IgxGrid #13757

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/selection/selection.service.ts
@@ -689,7 +689,7 @@ export class IgxGridSelectionService {
     /** Returns all data in the grid, with applied filtering and sorting and without deleted rows. */
     public get allData(): Array<any> {
         let allData;
-        if (this.isFilteringApplied() || this.grid.sortingExpressions.length) {
+        if (this.isFilteringApplied() || this.grid.sortingExpressions.length || this.grid.groupingExpressions?.length) {
             allData = this.grid.pinnedRecordsCount ? this.grid._filteredSortedUnpinnedData : this.grid.filteredSortedData;
         } else {
             allData = this.grid.gridAPI.get_all_data(true);


### PR DESCRIPTION
Closes #13757

This PR addresses the issue where shift-click was not functioning correctly in an IgxGrid with grouped rows. The selection logic has been updated to properly handle multi-level group comparisons, ensuring that the shift-click selection is consistent and intuitive in grouped grids.

Additional information:
- [x] Bug fix
- [ ] New functionality
- [ ] Documentation
- [ ] Demos
- [ ] CI/CD

Checklist:
- [x] All relevant tags have been applied to this PR
- [ ] This PR includes unit tests covering all the new code
- [ ] This PR includes API docs for newly added methods/properties
- [ ] This PR includes feature/README.MD updates for the feature docs
- [ ] This PR includes general feature table updates in the root README.MD
- [ ] This PR includes CHANGELOG.MD updates for newly added functionality
- [ ] This PR contains breaking changes
- [ ] This PR includes ng update migrations for the breaking changes
- [x] This PR includes behavioral changes and the feature specification has been updated with them
