### PR TITLE
Fix some errors in the grid samples

### DIFF
--- a/src/app/grid-row-edit/grid-row-edit-sample.component.ts
+++ b/src/app/grid-row-edit/grid-row-edit-sample.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, ViewChild } from '@angular/core';
 import { NgFor, NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -23,7 +23,7 @@ import { IgxColumnGroupComponent } from '../../../projects/igniteui-angular/src/
     standalone: true,
     imports: [IgxGridComponent, IgxColumnComponent, IgxCellTemplateDirective, IgxColumnRequiredValidatorDirective, IgxCellEditorTemplateDirective, FormsModule, IgxFocusDirective, IgxCheckboxComponent, NgFor, IgxButtonDirective, IgxSwitchComponent, IgxColumnGroupComponent, NgIf, IgxRowEditTabStopDirective, IgxRowEditTextDirective, IgxRowEditActionsDirective, IgxPaginatorComponent, IgxToggleDirective]
 })
-export class GridRowEditSampleComponent {
+export class GridRowEditSampleComponent implements AfterViewInit {
     @ViewChild(IgxToggleDirective, { static: true })
     public toggle: IgxToggleDirective;
     @ViewChild('gridRowEdit', { read: IgxGridComponent, static: true })
@@ -86,7 +86,9 @@ export class GridRowEditSampleComponent {
     private cssBig = `font-size: 16px; font-weight: 800;`;
     private addProductId: number;
 
-    constructor() {
+    constructor(private cdr: ChangeDetectorRef) { }
+
+    public ngAfterViewInit(): void {
         const enhancedData = data.map((e) => Object.assign(e, {
             UnitPrice2: this.getRandomInt(10, 1000),
             UnitsInStock2: this.getRandomInt(1, 100),
@@ -100,6 +102,7 @@ export class GridRowEditSampleComponent {
         this.addProductId = this.data.length + 1;
         this.generatePerformanceData(10000, 100);
         this.selectionMode = GridSelectionMode.multiple;
+        this.cdr.detectChanges();
     }
 
     public addRow(gridID) {

--- a/src/app/grid/grid.sample.html
+++ b/src/app/grid/grid.sample.html
@@ -151,7 +151,7 @@
                     <p style="color: crimson">{{column.field}}</p>
                 </ng-template>
                 <ng-template igxCell let-value let-cell="cell">
-                    <igx-checkbox [checked]="value" (change)="grid2.updateCell($event.checkbox.checked, cell.row.key, cell.column.field)"></igx-checkbox>
+                    <igx-checkbox [checked]="value" (change)="grid2.updateCell($event.checked, cell.row.key, cell.column.field)"></igx-checkbox>
                 </ng-template>
             </igx-column>
             <igx-paginator *ngIf="gridPaging" [(perPage)]="perPage"></igx-paginator>
@@ -194,7 +194,7 @@
                     <p>{{column.field}}</p>
                 </ng-template>
                 <ng-template igxCell let-item let-cell="cell">
-                    <igx-checkbox [checked]="item" (change)="grid3.updateCell($event.checkbox.checked, cell.row.key, cell.column.field)"></igx-checkbox>
+                    <igx-checkbox [checked]="item" (change)="grid3.updateCell($event.checked, cell.row.key, cell.column.field)"></igx-checkbox>
                 </ng-template>
             </igx-column>
             <igx-paginator [perPage]="10"></igx-paginator>

--- a/src/app/hierarchical-grid-remote-virtualization/hierarchical-remote.service.ts
+++ b/src/app/hierarchical-grid-remote-virtualization/hierarchical-remote.service.ts
@@ -5,7 +5,9 @@ import { HttpClient } from '@angular/common/http';
 import { IgxGridHierarchicalPipe } from 'projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.pipes';
 import { IgxHierarchicalGridComponent } from 'igniteui-angular';
 
-@Injectable()
+@Injectable({
+    providedIn: 'root'
+})
 export class HierarchicalRemoteService {
 
     public remotePagingData: BehaviorSubject<any[]>;

--- a/src/app/shared/local.service.ts
+++ b/src/app/shared/local.service.ts
@@ -3,7 +3,9 @@ import { HttpClient} from '@angular/common/http';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { FinancialData } from './financialData';
 
-@Injectable()
+@Injectable({ 
+    providedIn: 'root' 
+})
 export class LocalService {
     public records: Observable<any[]>;
     public url: string;

--- a/src/app/shared/remote.service.ts
+++ b/src/app/shared/remote.service.ts
@@ -3,7 +3,9 @@ import { Observable, BehaviorSubject } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { HttpClient } from '@angular/common/http';
 
-@Injectable()
+@Injectable({
+    providedIn: 'root'
+})
 export class RemoteService {
     public remotePagingData: BehaviorSubject<any[]>;
     public urlPaging = 'https://www.igniteui.com/api/products';


### PR DESCRIPTION
This PR fixes some errors that were thrown when opening some of the grids samples. We had services that were not provided anywhere and Angular was complaining because of that. Additionally, the grid row edit sample threw the expression changed exception and finally in the grid-base sample we were not using the new API of the `IChangeCheckboxEventArgs` so the sample did not load at all.

Not for testing - run a browser with CORS disabled otherwise there will be errors in the console since some samples do requests. No grid sample should be throwing any errors when routed to.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [x] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 