### PR TITLE
Dpetev/grid action strip tree shake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ All notable changes for each version of this project will be documented in this 
 
 
 - `IgxGrid`, `IgxTreeGrid`, `IgxHierarchicalGrid`
+    - Tree-shaking of the grids has been improved:
+        - The `igx-paginator`, `igx-grid-toolbar` and `igx-action-strip` components should now correctly tree-shake when not used in a grid.
     - **Breaking Changes**
         - `rowAdd` and `rowDelete` events now emit event argument of type `IRowDataCancelableEventArgs` instead of `IGridEditEventArgs`. The two interfaces are still compatible, however redundant for these events properties `cellID`, `newValue`, `oldValue`, `isAddRow` are deprecated in `IRowDataCancelableEventArgs` and will be removed in a future version. Switching to the correct new interfaces should reveal any deprecated use that can be safely removed.
     - **Deprecations**

--- a/projects/igniteui-angular/src/lib/action-strip/action-strip.component.ts
+++ b/projects/igniteui-angular/src/lib/action-strip/action-strip.component.ts
@@ -42,6 +42,16 @@ export class IgxActionStripMenuItemDirective {
     ) { }
 }
 
+/** @hidden @internal */
+export abstract class IgxActionStripToken {
+    public abstract context: any;
+    public abstract menuOverlaySettings: OverlaySettings;
+    public abstract get hideOnRowLeave(): boolean;
+
+    public abstract show(context?: any): void;
+    public abstract hide(): void;
+}
+
 /**
  * Action Strip provides templatable area for one or more actions.
  *
@@ -79,10 +89,10 @@ export class IgxActionStripMenuItemDirective {
         IgxIconComponent,
         IgxDropDownComponent,
         IgxDropDownItemComponent
-    ]
+    ],
+    providers: [{ provide: IgxActionStripToken, useExisting: IgxActionStripComponent }]
 })
-
-export class IgxActionStripComponent extends DisplayDensityBase implements AfterContentInit, AfterViewInit {
+export class IgxActionStripComponent extends DisplayDensityBase implements IgxActionStripToken, AfterContentInit, AfterViewInit {
     /**
      * Sets the context of an action strip.
      * The context should be an instance of a @Component, that has element property.

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -153,7 +153,7 @@ import { IgxColumnGroupComponent } from './columns/column-group.component';
 import { IgxRowDragGhostDirective, IgxDragIndicatorIconDirective } from './row-drag.directive';
 import { IgxSnackbarComponent } from '../snackbar/snackbar.component';
 import { v4 as uuidv4 } from 'uuid';
-import { IgxActionStripComponent } from '../action-strip/action-strip.component';
+import { IgxActionStripToken } from '../action-strip/action-strip.component';
 import { IgxGridRowComponent } from './grid/grid-row.component';
 import { IgxPaginatorToken, type IgxPaginatorComponent } from '../paginator/paginator.component';
 import { IgxGridHeaderRowComponent } from './headers/grid-header-row.component';
@@ -1117,8 +1117,8 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
     public columnList: QueryList<IgxColumnComponent> = new QueryList<IgxColumnComponent>();
 
     /** @hidden @internal */
-    @ContentChild(IgxActionStripComponent)
-    public actionStrip: IgxActionStripComponent;
+    @ContentChild(IgxActionStripToken)
+    public actionStrip: IgxActionStripToken;
 
     /**
      * @hidden @internal

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
@@ -65,7 +65,7 @@ import { IgxColumnMovingDropDirective } from '../moving/moving.drop.directive';
 import { IgxGridDragSelectDirective } from '../selection/drag-select.directive';
 import { IgxGridBodyDirective } from '../grid.common';
 import { IgxGridHeaderRowComponent } from '../headers/grid-header-row.component';
-import { IgxActionStripComponent } from '../../action-strip/action-strip.component';
+import { IgxActionStripToken } from '../../action-strip/action-strip.component';
 
 let NEXT_ID = 0;
 
@@ -405,8 +405,8 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
     public childRow: IgxChildGridRowComponent;
 
     /** @hidden @internal */
-    @ContentChild(IgxActionStripComponent, { read: IgxActionStripComponent, descendants: false } )
-    public override actionStrip: IgxActionStripComponent;
+    @ContentChild(IgxActionStripToken, { read: IgxActionStripToken, descendants: false } )
+    public override actionStrip: IgxActionStripToken;
 
     private _data;
     private h_id = `igx-hierarchical-grid-${NEXT_ID++}`;

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/row-island.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/row-island.component.ts
@@ -43,7 +43,7 @@ import { PlatformUtil } from '../../core/utils';
 import { IgxColumnResizingService } from '../resizing/resizing.service';
 import { GridType, IGX_GRID_SERVICE_BASE } from '../common/grid.interface';
 import { IgxGridToolbarDirective, IgxGridToolbarTemplateContext } from '../toolbar/common';
-import { IgxActionStripComponent } from '../../action-strip/action-strip.component';
+import { IgxActionStripToken } from '../../action-strip/action-strip.component';
 import { IgxPaginatorDirective } from '../../paginator/paginator-interfaces';
 import { IgxFlatTransactionFactory } from '../../services/transaction/transaction-factory.service';
 import { IGridCreatedEventArgs } from './events';
@@ -96,8 +96,8 @@ export class IgxRowIslandComponent extends IgxHierarchicalGridBaseDirective
     public islandPaginatorTemplate: TemplateRef<any>;
 
     /** @hidden @internal **/
-    @ContentChildren(IgxActionStripComponent, { read: IgxActionStripComponent, descendants: false })
-    public actionStrips: QueryList<IgxActionStripComponent>;
+    @ContentChildren(IgxActionStripToken, { read: IgxActionStripToken, descendants: false })
+    public actionStrips: QueryList<IgxActionStripToken>;
 
     /**
      * @hidden

--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.component.ts
@@ -70,7 +70,7 @@ import { GridBaseAPIService } from '../api.service';
 import { IgxGridForOfDirective } from '../../directives/for-of/for_of.directive';
 import { IgxPivotRowDimensionContentComponent } from './pivot-row-dimension-content.component';
 import { IgxPivotGridColumnResizerComponent } from '../resizing/pivot-grid/pivot-resizer.component';
-import { IgxActionStripComponent } from '../../action-strip/action-strip.component';
+import { IgxActionStripToken } from '../../action-strip/action-strip.component';
 import { ISortingExpression, SortingDirection } from '../../data-operations/sorting-strategy';
 import { PivotSortUtil } from './pivot-sort-util';
 import { IFilteringStrategy } from '../../data-operations/filtering-strategy';
@@ -686,7 +686,7 @@ export class IgxPivotGridComponent extends IgxGridBaseDirective implements OnIni
     /**
      * @hidden @internal
      */
-    public override actionStrip: IgxActionStripComponent;
+    public override actionStrip: IgxActionStripToken;
 
     /**
      * @hidden @internal


### PR DESCRIPTION
Added a DI alias for the action strip using a lightweight token and swapped the content queries in the grids to use it instead so the component can be tree-shaken when not in use.

Results:
Given the app imports just IgxGridComponent, IgxColumnComponent before and after:
![image](https://github.com/IgniteUI/igniteui-angular/assets/3198469/347d5bc8-521a-48c9-8f83-109df0cbeb4e)

Also changelog entry for the 3 recent changes

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 