### PR TITLE
fix(igxGrid): Fix timing issue between forof resetting and the grid h…

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
@@ -1324,18 +1324,19 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         const scrollable = containerSizeInfo ? this.scrollComponent.size > containerSizeInfo.prevSize : this.isScrollable();
         if (this.igxForScrollOrientation === 'horizontal') {
             const totalWidth = parseInt(this.igxForContainerSize, 10) > 0 ? this._calcSize() : 0;
-            this.scrollComponent.nativeElement.style.width = this.igxForContainerSize + 'px';
-            this.scrollComponent.size = totalWidth;
             if (totalWidth <= parseInt(this.igxForContainerSize, 10)) {
                 this.resetScrollPosition();
             }
+            this.scrollComponent.nativeElement.style.width = this.igxForContainerSize + 'px';
+            this.scrollComponent.size = totalWidth;
         }
         if (this.igxForScrollOrientation === 'vertical') {
-            this.scrollComponent.nativeElement.style.height = parseInt(this.igxForContainerSize, 10) + 'px';
-            this.scrollComponent.size = this._calcSize();
-            if (this.scrollComponent.size <= parseInt(this.igxForContainerSize, 10)) {
+            const totalHeight = this._calcSize();
+            if (totalHeight <= parseInt(this.igxForContainerSize, 10)) {
                 this.resetScrollPosition();
             }
+            this.scrollComponent.nativeElement.style.height = parseInt(this.igxForContainerSize, 10) + 'px';
+            this.scrollComponent.size = totalHeight;
         }
         if (scrollable !== this.isScrollable()) {
             // scrollbar visibility has changed

--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
@@ -546,7 +546,9 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         }
         const containerSize = 'igxForContainerSize';
         if (containerSize in changes && !changes[containerSize].firstChange && this.igxForOf) {
-            this._recalcOnContainerChange();
+            const prevSize = parseInt(changes[containerSize].previousValue, 10);
+            const newSize = parseInt(changes[containerSize].currentValue, 10);
+            this._recalcOnContainerChange({prevSize, newSize});
         }
     }
 
@@ -1316,10 +1318,10 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         return end;
     }
 
-    protected _recalcScrollBarSize() {
+    protected _recalcScrollBarSize(containerSizeInfo = null) {
         const count = this.isRemote ? this.totalItemCount : (this.igxForOf ? this.igxForOf.length : 0);
         this.dc.instance.notVirtual = !(this.igxForContainerSize && this.dc && this.state.chunkSize < count);
-        const scrollable = this.isScrollable();
+        const scrollable = containerSizeInfo ? this.scrollComponent.size > containerSizeInfo.prevSize : this.isScrollable();
         if (this.igxForScrollOrientation === 'horizontal') {
             const totalWidth = parseInt(this.igxForContainerSize, 10) > 0 ? this._calcSize() : 0;
             this.scrollComponent.nativeElement.style.width = this.igxForContainerSize + 'px';
@@ -1356,10 +1358,10 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         return size;
     }
 
-    protected _recalcOnContainerChange() {
+    protected _recalcOnContainerChange(containerSizeInfo = null) {
         const prevChunkSize = this.state.chunkSize;
         this.applyChunkSizeChange();
-        this._recalcScrollBarSize();
+        this._recalcScrollBarSize(containerSizeInfo);
         if (prevChunkSize !== this.state.chunkSize) {
             this.chunkLoad.emit(this.state);
         }
@@ -1616,7 +1618,9 @@ export class IgxGridForOfDirective<T, U extends T[] = T[]> extends IgxForOfDirec
         }
         const containerSize = 'igxForContainerSize';
         if (containerSize in changes && !changes[containerSize].firstChange && this.igxForOf) {
-            this._recalcOnContainerChange();
+            const prevSize = parseInt(changes[containerSize].previousValue, 10);
+            const newSize = parseInt(changes[containerSize].currentValue, 10);
+            this._recalcOnContainerChange({prevSize, newSize});
         }
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -3605,6 +3605,14 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
             this.cdr.detectChanges();
         });
 
+
+        this.headerContainer.scrollbarVisibilityChanged.pipe(filter(() => !this._init), destructor).subscribe(() => {
+            // the horizontal scrollbar showing/hiding
+            // update scrollbar visibility and recalc heights
+            this.notifyChanges(true);
+            this.cdr.detectChanges();
+        });
+
         this.verticalScrollContainer.contentSizeChange.pipe(filter(() => !this._init), throttleTime(30), destructor).subscribe(() => {
             this.notifyChanges(true);
         });
@@ -6056,7 +6064,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
      * @hidden @internal
      */
     public hasHorizontalScroll() {
-        return this.totalWidth - this.unpinnedWidth > 0;
+        return this.totalWidth - this.unpinnedWidth > 0 && this.width !== null;
     }
 
     /**
@@ -6636,7 +6644,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
         this.resetCaches(recalcFeatureWidth);
 
         const hasScroll = this.hasVerticalScroll();
-        const hasHScroll = this.hasHorizontalScroll();
+        const hasHScroll = !this.isHorizontalScrollHidden;
         this.calculateGridWidth();
         this.resetCaches(recalcFeatureWidth);
         this.cdr.detectChanges();
@@ -6657,8 +6665,12 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
             this.cdr.detectChanges();
         }
 
+        // in case horizontal scrollbar has appeared recalc to size correctly.
         if (hasHScroll !== this.hasHorizontalScroll()) {
             this.isHorizontalScrollHidden = !this.hasHorizontalScroll();
+            this.cdr.detectChanges();
+            this.calculateGridHeight();
+            this.cdr.detectChanges();
         }
         if (this.zone.isStable) {
             this.zone.run(() => {

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -3606,7 +3606,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
         });
 
 
-        this.headerContainer.scrollbarVisibilityChanged.pipe(filter(() => !this._init), destructor).subscribe(() => {
+        this.headerContainer?.scrollbarVisibilityChanged.pipe(filter(() => !this._init), destructor).subscribe(() => {
             // the horizontal scrollbar showing/hiding
             // update scrollbar visibility and recalc heights
             this.notifyChanges(true);

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -4213,10 +4213,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
     /**
      * @hidden @internal
      */
-    public get isHorizontalScrollHidden() {
-        const diff = this.unpinnedWidth - this.totalWidth;
-        return this.width === null || diff >= 0;
-    }
+    public isHorizontalScrollHidden = false;
 
     /**
      * @hidden @internal
@@ -6639,6 +6636,7 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
         this.resetCaches(recalcFeatureWidth);
 
         const hasScroll = this.hasVerticalScroll();
+        const hasHScroll = this.hasHorizontalScroll();
         this.calculateGridWidth();
         this.resetCaches(recalcFeatureWidth);
         this.cdr.detectChanges();
@@ -6657,6 +6655,10 @@ export abstract class IgxGridBaseDirective extends DisplayDensityBase implements
         if (hasScroll !== this.hasVerticalScroll()) {
             this.calculateGridWidth();
             this.cdr.detectChanges();
+        }
+
+        if (hasHScroll !== this.hasHorizontalScroll()) {
+            this.isHorizontalScrollHidden = !this.hasHorizontalScroll();
         }
         if (this.zone.isStable) {
             this.zone.run(() => {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-keyBoardNav.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-keyBoardNav.spec.ts
@@ -514,6 +514,8 @@ describe('IgxGrid - Keyboard navigation #grid', () => {
             fix.detectChanges();
 
             fix.componentInstance.columns = fix.componentInstance.generateCols(100);
+            await wait(DEBOUNCETIME);
+            fix.detectChanges();
             fix.componentInstance.data = fix.componentInstance.generateData(1000);
             fix.detectChanges();
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -1451,6 +1451,7 @@ describe('IgxGrid Component Tests #grid', () => {
                 fix.componentInstance.initColumnsRows(5, 5);
                 fix.detectChanges();
                 await wait(16);
+                fix.detectChanges();
                 expect(fix.componentInstance.isHorizonatScrollbarVisible()).toBe(true);
                 const scrollbar = grid.headerContainer.getScroll();
                 scrollbar.scrollLeft = 10000;

--- a/projects/igniteui-angular/src/lib/grids/grid/row-drag.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/row-drag.directive.spec.ts
@@ -260,6 +260,7 @@ describe('Row Drag Tests', () => {
                     fixture.detectChanges();
 
                     // selectable rows disabled
+                    fixture.detectChanges();
                     let horizontalScrollbarElement: DebugElement = fixture.debugElement.query(By.css(CSS_CLASS_VIRTUAL_HSCROLLBAR));
                     let horizontalScrollbarRect = horizontalScrollbarElement.nativeElement.getBoundingClientRect();
                     let pinnedColumnHeaderElement: DebugElement = fixture.debugElement.query(By.css('.' + CSS_CLASS_LAST_PINNED_HEADER));

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.integration.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.integration.spec.ts
@@ -302,6 +302,7 @@ describe('IgxHierarchicalGrid Integration #hGrid', () => {
             const childGrid = hierarchicalGrid.gridAPI.getChildGrids(false)[0];
             childGrid.columns[0].sortable = true;
             fixture.detectChanges();
+            childGrid.cdr.detectChanges();
 
             const childHeader = GridFunctions.getColumnHeader('ID', fixture, childGrid);
             GridFunctions.clickHeaderSortIcon(childHeader);

--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-header-row.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-header-row.component.ts
@@ -112,7 +112,7 @@ export class IgxPivotHeaderRowComponent extends IgxGridHeaderRowComponent implem
     public headerContainers: QueryList<IgxGridForOfDirective<ColumnType, ColumnType[]>>;
 
     public override get headerForOf() {
-        return this.headerContainers.last;
+        return this.headerContainers?.last;
     }
 
     constructor(


### PR DESCRIPTION
…iding its scrollbar on resize.

Note: Issue is that the grid's `isHorizontalScrollHidden` getter got resolved first, hence the scrollbar gets hidden before the forof's resize observer is called, so at that point the for-of cannot reset the scrollbar because it is already hidden from the grid. After that once it is resized again to have a scrollbar, the scrollbar resets to its last known scroll position, hence the desync.  

Closes #https://github.com/IgniteUI/igniteui-webcomponents/issues/1116  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 