### PR TITLE
Use mask's CVA callbacks

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/date-time-editor/date-time-editor.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/date-time-editor/date-time-editor.directive.ts
@@ -90,7 +90,7 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
     @Input()
     public set minValue(value: string | Date) {
         this._minValue = value;
-        this.onValidatorChange();
+        this._onValidatorChange();
     }
 
     /**
@@ -111,7 +111,7 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
     @Input()
     public set maxValue(value: string | Date) {
         this._maxValue = value;
-        this.onValidatorChange();
+        this._onValidatorChange();
     }
 
     /**
@@ -216,7 +216,6 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
     private _dateValue: Date;
     private _onClear: boolean;
     private document: Document;
-    private _isFocused: boolean;
     private _defaultInputFormat: string;
     private _value: Date | string;
     private _minValue: Date | string;
@@ -230,9 +229,9 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
         minutes: 1,
         seconds: 1
     };
-    private onTouchCallback: (...args: any[]) => void = noop;
+
     private onChangeCallback: (...args: any[]) => void = noop;
-    private onValidatorChange: (...args: any[]) => void = noop;
+    private _onValidatorChange: (...args: any[]) => void = noop;
 
     private get datePartDeltas(): DatePartDeltas {
         return Object.assign({}, this._datePartDeltas, this.spinDelta);
@@ -289,7 +288,7 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
 
     @HostListener('wheel', ['$event'])
     public onWheel(event: WheelEvent): void {
-        if (!this._isFocused) {
+        if (!this._focused) {
             return;
         }
         event.preventDefault();
@@ -392,7 +391,7 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
 
     /** @hidden @internal */
     public registerOnValidatorChange?(fn: () => void): void {
-        this.onValidatorChange = fn;
+        this._onValidatorChange = fn;
     }
 
     /** @hidden @internal */
@@ -402,7 +401,7 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
 
     /** @hidden @internal */
     public override registerOnTouched(fn: any): void {
-        this.onTouchCallback = fn;
+        this._onTouchedCallback = fn;
     }
 
     /** @hidden @internal */
@@ -471,8 +470,8 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
         if (this.nativeElement.readOnly) {
             return;
         }
-        this._isFocused = true;
-        this.onTouchCallback();
+        this._focused = true;
+        this._onTouchedCallback();
         this.updateMask();
         super.onFocus();
         this.nativeElement.select();
@@ -480,7 +479,7 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
 
     /** @hidden @internal */
     public override onBlur(value: string): void {
-        this._isFocused = false;
+        this._focused = false;
         if (!this.inputIsComplete() && this.inputValue !== this.emptyMask) {
             this.updateValue(this.parseDate(this.inputValue));
         } else {
@@ -504,7 +503,7 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
     }
 
     private updateMask(): void {
-        if (this._isFocused) {
+        if (this._focused) {
             // store the cursor position as it will be moved during masking
             const cursor = this.selectionEnd;
             this.inputValue = this.getMaskedValue();

--- a/projects/igniteui-angular/src/lib/directives/mask/mask.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/mask/mask.directive.ts
@@ -130,6 +130,7 @@ export class IgxMaskDirective implements OnInit, AfterViewChecked, ControlValueA
 
     protected _composing: boolean;
     protected _compositionStartIndex: number;
+    protected _focused = false;
     private _compositionValue: string;
     private _end = 0;
     private _start = 0;
@@ -137,14 +138,13 @@ export class IgxMaskDirective implements OnInit, AfterViewChecked, ControlValueA
     private _mask: string;
     private _oldText = '';
     private _dataValue = '';
-    private _focused = false;
     private _droppedData: string;
     private _hasDropAction: boolean;
 
     private readonly defaultMask = 'CCCCCCCCCC';
 
-    private _onTouchedCallback: () => void = noop;
-    private _onChangeCallback: (_: any) => void = noop;
+    protected _onTouchedCallback: () => void = noop;
+    protected _onChangeCallback: (_: any) => void = noop;
 
     constructor(
         protected elementRef: ElementRef<HTMLInputElement>,


### PR DESCRIPTION
Closes #14110

This was related to the blur handler where the editor specified its own touched callback. This was contradicting with the mask's touched callback and prevented the proper update.

This PR extends the already exting cva callbacks of the mask directive in the date editor.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 