### PR TITLE
Allow nullables in date editor value

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/date-time-editor/date-time-editor.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/date-time-editor/date-time-editor.directive.ts
@@ -166,14 +166,14 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
      * ```
      */
     @Input()
-    public set value(value: Date | string) {
+    public set value(value: Date | string | undefined | null) {
         this._value = value;
         this.setDateValue(value);
         this.onChangeCallback(value);
         this.updateMask();
     }
 
-    public get value(): Date | string {
+    public get value(): Date | string | undefined | null {
         return this._value;
     }
 
@@ -218,7 +218,7 @@ export class IgxDateTimeEditorDirective extends IgxMaskDirective implements OnCh
     private document: Document;
     private _isFocused: boolean;
     private _defaultInputFormat: string;
-    private _value: Date | string;
+    private _value?: Date | string;
     private _minValue: Date | string;
     private _maxValue: Date | string;
     private _inputDateParts: DatePartInfo[];


### PR DESCRIPTION
Closes #14133

This issue was related to the `strictTemplates` option in the Angular compiler options. The editor works fine with `null` or `undefined` passed in as a value, only its type-definition had specified strict `Date | string` . This PR adds `undefined` or `null` as possible values for the `value` setter/getter. I was thinking of creating a `Nullable<T>` type that could set the provided type argument as nullable but this would change what can bee seen when peeking the `value` to `Nullable<Date | string>` which I can't decide if I like or not.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 