### PR TITLE
fix(pivotGrid): row dimension kb nav

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid-navigation.service.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid-navigation.service.ts
@@ -71,15 +71,19 @@ export class IgxPivotGridNavigationService extends IgxGridNavigationService {
                 }
 
                 verticalContainer = this.grid.verticalRowDimScrollContainers.toArray()[newActiveNode.column];
-                if (key.includes('up') && this.activeNode.row > 0) {
-                    newActiveNode.row = ctrl ? 0 : this.activeNode.row - 1;
-                } else if (key.includes('up')) {
-                    newActiveNode.row = 0;
-                    newActiveNode.column = newActiveNode.layout.colStart - 1;
-                    newActiveNode.layout = null;
-                    this.isRowDimensionHeaderActive = true;
-                    this.isRowHeaderActive = false;
-                    this.grid.theadRow.nativeElement.focus();
+                if (key.includes('up')) {
+                    if (ctrl) {
+                        newActiveNode.row = 0;
+                    } else if (this.activeNode.row > 0) {
+                        newActiveNode.row = this.activeNode.row - 1;
+                    } else {
+                        newActiveNode.row = -1;
+                        newActiveNode.column = newActiveNode.layout ? newActiveNode.layout.colStart - 1 : 0;
+                        newActiveNode.layout = null;
+                        this.isRowDimensionHeaderActive = true;
+                        this.isRowHeaderActive = false;
+                        this.grid.theadRow.nativeElement.focus();
+                    }
                 }
 
                 if (key.includes('down') && this.activeNode.row < this.findLastDataRowIndex()) {


### PR DESCRIPTION
Fixes issue when navigating from pivot row dimension header group to the pivot row header group in the header row when horizontal layout is disabled  

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 