### PR TITLE
docs(pivot): mark gridSize override internal

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.component.ts
@@ -386,6 +386,7 @@ export class IgxPivotGridComponent extends IgxGridBaseDirective implements OnIni
         this._superCompactMode = value;
     }
 
+    /** @hidden @internal */
     public override get gridSize() {
         if (this.superCompactMode) {
             return Size.Small;


### PR DESCRIPTION
Currently visible in https://www.infragistics.com/products/ignite-ui-angular/docs/typescript/latest/classes/IgxPivotGridComponent.html when it shouldn't be.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [x] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 