### PR TITLE
refactor(exporter): mark extra pivot methods private

### DIFF
--- a/projects/igniteui-angular/src/lib/services/exporter-common/base-export-service.ts
+++ b/projects/igniteui-angular/src/lib/services/exporter-common/base-export-service.ts
@@ -1275,7 +1275,7 @@ export abstract class IgxBaseExporter {
         return result;
     }
 
-    public addPivotRowHeaders(grid: any) {
+    private addPivotRowHeaders(grid: any) {
         if (grid?.pivotUI?.showRowHeaders) {
             const headersList = this._ownersMap.get(DEFAULT_OWNER);
             const enabledRows = grid.pivotConfiguration.rows.filter(r => r.enabled).map((r, index) => ({ name: r.displayName || r.memberName, level: index }));
@@ -1298,7 +1298,7 @@ export abstract class IgxBaseExporter {
         }
     }
 
-    public addPivotGridColumns(grid: any) {
+    private addPivotGridColumns(grid: any) {
         if (grid.nativeElement.tagName.toLowerCase() !== 'igx-pivot-grid') {
             return;
         }


### PR DESCRIPTION
Related to #14017
https://www.infragistics.com/products/ignite-ui-angular/docs/typescript/latest/classes/IgxExcelExporterService.html#addPivotRowHeaders is visible in the public API, when it shouldn't be. Guessing copied over from `addPivotGridColumns` which likely is in he same situation, so marking both `private`.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [x] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 