### PR TITLE
refactor(paginator): deprecate isFirstPageDisabled and isLastPageDisabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ All notable changes for each version of this project will be documented in this 
 ### General
 - `ColumnType`, `IgxColumn`, `IgxColumnGroup`, `IgxColumnLayout`
     - The `children` query property has been deprecated and replaced by `childColumns` getter directly returning columns array.
+- `IgxPaginator`
+    - The `isFirstPageDisabled` and `isLastPageDisabled` have been deprecated in favor of the identical `isFirstPage` and `isLastPage` getter.
 
 
 ## 18.0.0

--- a/projects/igniteui-angular/migrations/update-18_1_0/changes/members.json
+++ b/projects/igniteui-angular/migrations/update-18_1_0/changes/members.json
@@ -10,6 +10,20 @@
                 "IgxColumnGroupComponent",
                 "IgxColumnLayoutComponent"
             ]
+        },
+        {
+            "member": "isFirstPageDisabled",
+            "replaceWith": "isFirstPage",
+            "definedIn": [
+                "IgxPaginatorComponent"
+            ]
+        },
+        {
+            "member": "isLastPageDisabled",
+            "replaceWith": "isLastPage",
+            "definedIn": [
+                "IgxPaginatorComponent"
+            ]
         }
     ]
 }

--- a/projects/igniteui-angular/migrations/update-18_1_0/index.spec.ts
+++ b/projects/igniteui-angular/migrations/update-18_1_0/index.spec.ts
@@ -123,7 +123,7 @@ describe(`Update to ${version}`, () => {
     it('Should replace deprecated `children` property of Columns', async () => {
         pending('set up tests for migrations through lang service');
         appTree.create(
-            '/testSrc/appPrefix/component/expansion-test.component.ts',
+            '/testSrc/appPrefix/component/column-test.component.ts',
             `import { Component } from '@angular/core';
 import { IgxColumnGroupComponent, ColumnType } from 'igniteui-angular';
 
@@ -143,7 +143,7 @@ export class ColumnsTestComponent {
         );
         const tree = await schematicRunner.runSchematic(migrationName, { shouldInvokeLS: false }, appTree);
         const expectedContent =  `import { Component } from '@angular/core';
-import { IgxColumnGroupComponent } from 'igniteui-angular';
+import { IgxColumnGroupComponent, ColumnType } from 'igniteui-angular';
 
 @Component({
     selector: 'app-columns-test',
@@ -159,7 +159,47 @@ export class ColumnsTestComponent {
     }
 }`;
         expect(
-                tree.readContent('/testSrc/appPrefix/component/expansion-test.component.ts')
-            ).toEqual(expectedContent);
+            tree.readContent('/testSrc/appPrefix/component/column-test.component.ts')
+        ).toEqual(expectedContent);
+    });
+
+
+    it('Should replace deprecated `isFirstPageDisabled`/`isLastPageDisabled` on paginator', async () => {
+        pending('set up tests for migrations through lang service');
+        appTree.create(
+            '/testSrc/appPrefix/component/paginator-test.component.ts',
+            `import { Component } from '@angular/core';
+import { IgxPaginatorComponent } from 'igniteui-angular';
+
+@Component({
+    selector: 'app-paginator-test',
+    templateUrl: './paginator-test.component.html',
+    styleUrls: ['./paginator-test.component.scss']
+})
+export class PaginatorTestComponent {
+    public paginator: IgxPaginatorComponent;
+    public testMethod() {
+        return this.paginator.isFirstPageDisabled || this.paginator.isLastPageDisabled;
+    }
+}`
+        );
+        const tree = await schematicRunner.runSchematic(migrationName, { shouldInvokeLS: false }, appTree);
+        const expectedContent =  `import { Component } from '@angular/core';
+import { IgxPaginatorComponent } from 'igniteui-angular';
+
+@Component({
+    selector: 'app-paginator-test',
+    templateUrl: './paginator-test.component.html',
+    styleUrls: ['./paginator-test.component.scss']
+})
+export class PaginatorTestComponent {
+    public paginator: IgxPaginatorComponent;
+    public testMethod() {
+        return this.paginator.isFirstPage || this.paginator.isLastPage;
+    }
+}`;
+        expect(
+            tree.readContent('/testSrc/appPrefix/component/paginator-test.component.ts')
+        ).toEqual(expectedContent);
     });
 });

--- a/projects/igniteui-angular/src/lib/paginator/pager.component.html
+++ b/projects/igniteui-angular/src/lib/paginator/pager.component.html
@@ -1,7 +1,7 @@
 <button
     [title]="paginator.resourceStrings.igx_paginator_first_page_button_text"
-    [disabled]="paginator.isFirstPageDisabled"
-    [attr.aria-disabled]="paginator.isFirstPageDisabled"
+    [disabled]="paginator.isFirstPage"
+    [attr.aria-disabled]="paginator.isFirstPage"
     (click)="paginator.paginate(0)"
     igxIconButton="flat"
     igxRipple
@@ -12,8 +12,8 @@
 </button>
 <button
     [title]="paginator.resourceStrings.igx_paginator_previous_page_button_text"
-    [disabled]="paginator.isFirstPageDisabled"
-    [attr.aria-disabled]="paginator.isFirstPageDisabled"
+    [disabled]="paginator.isFirstPage"
+    [attr.aria-disabled]="paginator.isFirstPage"
     (click)="paginator.previousPage()"
     igxIconButton="flat"
     igxRipple
@@ -33,8 +33,8 @@
 </div>
 <button
     [title]="paginator.resourceStrings.igx_paginator_next_page_button_text"
-    [disabled]="paginator.isLastPageDisabled"
-    [attr.aria-disabled]="paginator.isLastPageDisabled"
+    [disabled]="paginator.isLastPage"
+    [attr.aria-disabled]="paginator.isLastPage"
     (click)="paginator.nextPage()"
     igxRipple
     [igxRippleCentered]="true"
@@ -45,8 +45,8 @@
 </button>
 <button
     [title]="paginator.resourceStrings.igx_paginator_last_page_button_text"
-    [disabled]="paginator.isLastPageDisabled"
-    [attr.aria-disabled]="paginator.isLastPageDisabled"
+    [disabled]="paginator.isLastPage"
+    [attr.aria-disabled]="paginator.isLastPage"
     (click)="paginator.paginate(paginator.totalPages - 1)"
     igxIconButton="flat"
     igxRipple

--- a/projects/igniteui-angular/src/lib/paginator/paginator.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/paginator/paginator.component.spec.ts
@@ -287,11 +287,11 @@ describe('IgxPaginator with custom settings', () => {
         <igx-paginator #pg [totalRecords]="42">
             <igx-paginator-content *ngIf="customContent">
                 <div id="numberPager" class="igx-paginator" style="justify-content: center;">
-                    <button type="button" class="customPrev" [disabled]="pg.isFirstPageDisabled" (click)="pg.previousPage()" igxButton="flat">
+                    <button type="button" class="customPrev" [disabled]="pg.isFirstPage" (click)="pg.previousPage()" igxButton="flat">
                         PREV
                     </button>
                     <span class="currPage" style="margin-left:10px; margin-right: 10px"> {{pg.page}} </span>
-                    <button type="button" class="customNext" [disabled]="pg.isLastPageDisabled" (click)="pg.nextPage()" igxButton="flat">
+                    <button type="button" class="customNext" [disabled]="pg.isLastPage" (click)="pg.nextPage()" igxButton="flat">
                         NEXT
                     </button>
                 </div>

--- a/projects/igniteui-angular/src/lib/paginator/paginator.component.ts
+++ b/projects/igniteui-angular/src/lib/paginator/paginator.component.ts
@@ -275,6 +275,8 @@ export class IgxPaginatorComponent implements IgxPaginatorToken {
 
     /**
      * Returns if the first pager buttons should be disabled
+     * @hidden
+     * @deprecated in version 18.1.0. Use the `isFirstPage` property instead.
      */
     public get isFirstPageDisabled(): boolean {
         return this.isFirstPage;
@@ -282,6 +284,8 @@ export class IgxPaginatorComponent implements IgxPaginatorToken {
 
     /**
      * Returns if the last pager buttons should be disabled
+     * @hidden
+     * @deprecated in version 18.1.0. Use the `isLastPage` property instead.
      */
     public get isLastPageDisabled(): boolean {
         return this.isLastPage;

--- a/src/app/pagination/pagination.template.html
+++ b/src/app/pagination/pagination.template.html
@@ -20,16 +20,16 @@
     <igx-paginator-content>
         <igx-page-size></igx-page-size>
         <span style="margin: 0 20px 0 20px;">{{ (pag.page * pag.perPage) + 1}}-{{(pag.page * pag.perPage) + pag.perPage}} of {{ pag.totalRecords}}</span>
-        <button [disabled]="pag.isFirstPageDisabled" (click)="pag.paginate(0)" igxIconButton="flat">
+        <button [disabled]="pag.isFirstPage" (click)="pag.paginate(0)" igxIconButton="flat">
             <igx-icon>first_page</igx-icon>
         </button>
-        <button [disabled]="pag.isFirstPageDisabled" (click)="pag.previousPage()" igxIconButton="flat">
+        <button [disabled]="pag.isFirstPage" (click)="pag.previousPage()" igxIconButton="flat">
             <igx-icon>chevron_left</igx-icon>
         </button>
-        <button [disabled]="pag.isLastPageDisabled" (click)="pag.nextPage()" igxIconButton="flat">
+        <button [disabled]="pag.isLastPage" (click)="pag.nextPage()" igxIconButton="flat">
             <igx-icon>chevron_right</igx-icon>
         </button>
-        <button [disabled]="paginator.isLastPageDisabled" (click)="paginator.paginate(paginator.totalPages - 1)" igxIconButton="flat">
+        <button [disabled]="paginator.isLastPage" (click)="paginator.paginate(paginator.totalPages - 1)" igxIconButton="flat">
             <igx-icon>last_page</igx-icon>
         </button>
     </igx-paginator-content>


### PR DESCRIPTION
The `isFirstPageDisabled` and `isLastPageDisabled` are just proxies of `isFirstPage` and `isLastPage` already - no reason for them.
The only use I can find outside internal was in a dev demo and the docs actually already instruct to use the latter - see Example under https://www.infragistics.com/products/ignite-ui-angular/angular/components/grid/paging#angular-pagination-example

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 