### PR TITLE
refactor(row-island): disable getters of no use and hide from api docs

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/row-island.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/row-island.component.ts
@@ -36,8 +36,10 @@ import { IgxGridSelectionService } from '../selection/selection.service';
 import { IgxOverlayService } from '../../services/public_api';
 import { first, filter, takeUntil, pluck } from 'rxjs/operators';
 import { IgxColumnComponent } from '../columns/column.component';
+import { ISearchInfo } from '../common/events';
 import { IgxRowIslandAPIService } from './row-island-api.service';
 import { PlatformUtil } from '../../core/utils';
+import { IForOfState } from '../../directives/for-of/for_of.directive';
 import { IgxColumnResizingService } from '../resizing/resizing.service';
 import { GridType, IGX_GRID_SERVICE_BASE, IgxGridPaginatorTemplateContext } from '../common/grid.interface';
 import { IgxGridToolbarDirective, IgxGridToolbarTemplateContext } from '../toolbar/common';
@@ -168,7 +170,59 @@ export class IgxRowIslandComponent extends IgxHierarchicalGridBaseDirective
      * @hidden
      */
     public rootGrid: GridType = null;
+
+    /** @hidden */
     public readonly data: any[] | null;
+
+    /** @hidden */
+    public override get hiddenColumnsCount(): number {
+        return 0;
+    }
+
+    /** @hidden */
+    public override get pinnedColumnsCount(): number {
+        return 0;
+    }
+
+    /** @hidden */
+    public override get lastSearchInfo(): ISearchInfo {
+        return null;
+    }
+
+    /** @hidden */
+    public override get filteredData(): any {
+        return [];
+    }
+
+    /** @hidden */
+    public override get filteredSortedData(): any[] {
+        return [];
+    }
+
+    /** @hidden */
+    public override get virtualizationState(): IForOfState {
+        return null;
+    }
+
+    /** @hidden */
+    public override get pinnedColumns(): IgxColumnComponent[] {
+        return [];
+    }
+
+    /** @hidden */
+    public override get unpinnedColumns(): IgxColumnComponent[] {
+        return [];
+    }
+
+    /** @hidden */
+    public override get visibleColumns(): IgxColumnComponent[] {
+        return [];
+    }
+
+    /** @hidden */
+    public override get dataView(): any[] {
+        return [];
+    }
 
     private ri_columnListDiffer;
     private layout_id = `igx-row-island-`;


### PR DESCRIPTION
There are probably more API members that make no sense for the Row Island (likely shouldn't inherit the grid base directly).
For now (due to Elements), cleaning up the state getters that can't meaningfully work since the island doesn't have data, view children (thus no data views or virtualization state) and it's not a single grid to report column pinned states and the like.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [x] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 