### PR TITLE
fix(grid,state): restore directive w/o options, drop duplicate prop

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/state-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/state-base.directive.ts
@@ -113,7 +113,6 @@ interface Feature {
 /* blazorIndirectRender */
 @Directive()
 export class IgxGridStateBaseDirective {
-    private static ngAcceptInputType_options: IGridStateOptions | '';
 
     private featureKeys: GridFeatures[] = [];
     private state: IGridState;

--- a/projects/igniteui-angular/src/lib/grids/state.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/state.directive.ts
@@ -6,7 +6,7 @@ import { GridFeatures, IGridState, IGridStateOptions, IgxGridStateBaseDirective 
     standalone: true
 })
 export class IgxGridStateDirective extends IgxGridStateBaseDirective {
-
+    private static ngAcceptInputType_options: IGridStateOptions | '';
 
     /**
      *  An object with options determining if a certain feature state should be saved.
@@ -17,14 +17,14 @@ export class IgxGridStateDirective extends IgxGridStateBaseDirective {
      * public options = {selection: false, advancedFiltering: false};
      * ```
      */
-        @Input('igxGridState')
-        public get stateOptions(): IGridStateOptions {
-           return super.options;
-        }
+    @Input('igxGridState')
+    public override get options(): IGridStateOptions {
+        return super.options;
+    }
 
-        public set stateOptions(value: IGridStateOptions) {
-            super.options = value;
-        }
+    public override set options(value: IGridStateOptions) {
+        super.options = value;
+    }
 
     /**
      * Gets the state of a feature or states of all grid features, unless a certain feature is disabled through the `options` property.


### PR DESCRIPTION
Related to refactor in #14421
Restore the functionality to assign the `igxGridState` directive without setting options, remove would-be public duplicate `stateOptions` property.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 