### PR TITLE
docs(h-grid): mark the internal child row class as such

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
@@ -1028,6 +1028,7 @@ export interface GridType extends IGridDataBindable {
     /** @hidden @internal */
     paginatorOutlet?: ViewContainerRef;
     flatData?: any[] | null;
+    /** @hidden @internal */
     childRow?: any;
     expansionDepth?: number;
     childDataKey?: any;

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
@@ -69,6 +69,9 @@ import { IgxActionStripToken } from '../../action-strip/token';
 
 let NEXT_ID = 0;
 
+/**
+ * @hidden @internal
+ */
 @Component({
     changeDetection: ChangeDetectionStrategy.OnPush,
     selector: 'igx-child-grid-row',
@@ -434,7 +437,7 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
     public parent: IgxHierarchicalGridComponent = null;
 
     /**
-     * @hidden
+     * @hidden @internal
      */
     public childRow: IgxChildGridRowComponent;
 


### PR DESCRIPTION
`IgxChildGridRowComponent` is [visible in the API docs](https://www.infragistics.com/products/ignite-ui-angular/docs/typescript/latest/classes/IgxChildGridRowComponent.html), yet it's used for two hidden properties of the HGrid and I see no reason for that. I see no usage outside internal service and tests for those.
_Also causes the API analyzer to produce a bogus model class from Elements and I want to get rid of it :)_

Actually, I see 0 usage for the actual `hierarchicalRows` query, even tho the child row**s** are looped, so something is not quite right and @dkamburov you guys might want to have a look at that at some point.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [x] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 