### PR TITLE
fix(divider): correct inset input target

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/divider/divider.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/divider/divider.directive.ts
@@ -83,6 +83,7 @@ export class IgxDividerDirective {
      * ```
      */
     @HostBinding('style.--inset')
+    @Input()
     public set inset(value: string) {
         this._inset = value;
     }
@@ -105,7 +106,6 @@ export class IgxDividerDirective {
      * <igx-divider inset="16px"></igx-divider>
      * ```
      */
-    @Input('inset')
     private _inset = '0';
 
     /**


### PR DESCRIPTION
Related to #14550
The `@Input` sitting with rename on the private backing field causes strict templates to fail type checks:
![image](https://github.com/user-attachments/assets/18493536-e6fd-4180-82c6-643593b1d95c)
PS: Could also merge the doc comments

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 