### PR TITLE
input-group - fix icons size inside prefix/suffix

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/input/_input-group-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/input/_input-group-theme.scss
@@ -378,9 +378,9 @@
         align-items: center;
 
         @if $indigo-theme {
-            height: calc(100% - #{rem(1px)}) !important;
+            min-height: calc(100% - #{rem(1px)}) !important;
         } @else {
-            height: 100% !important;
+            min-height: 100% !important;
         }
         transition: color $transition-timing, background $transition-timing;
 


### PR DESCRIPTION
Fix icon size when SVG icons are used inside the prefix/suffix of the input group combo and select

Closes https://github.com/IgniteUI/igniteui-angular/issues/14617

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 