### PR TITLE
chore(grid, pivot-grid): adjust deprecation notice to version 18.2.0 - master

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -2199,7 +2199,7 @@ export abstract class IgxGridBaseDirective implements GridType,
      * ```typescript
      *  this.grid.shouldGenerate = true;
      * ```
-     * @deprecated in version 18.1.0. Use the `autoGenerate` property instead.
+     * @deprecated in version 18.2.0. Use the `autoGenerate` property instead.
      */
     public shouldGenerate: boolean;
 

--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-grid.component.ts
@@ -745,7 +745,7 @@ export class IgxPivotGridComponent extends IgxGridBaseDirective implements OnIni
 
     /**
      * @hidden @internal
-     * @deprecated in version 18.1.0. Use the `autoGenerate` property instead.
+     * @deprecated in version 18.2.0. Use the `autoGenerate` property instead.
      */
     public override shouldGenerate: boolean;
 


### PR DESCRIPTION
Related to #14315 

This PR adjusts the deprecation notice for the autoGenerate property, updating the version number from 18.1.0 to 18.2.0 because the deprecation was intended for version 18.2.0.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [x] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 