### PR TITLE
refactor(grids): move watermark register

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -180,8 +180,6 @@ import { IgxGridCellComponent } from './cell.component';
 import { IgxGridValidationService } from './grid/grid-validation.service';
 import { getCurrentResourceStrings } from '../core/i18n/resources';
 
-/*@__PURE__*/IgcTrialWatermark.register();
-
 interface IMatchInfoCache {
     row: any;
     index: number;
@@ -3402,6 +3400,7 @@ export abstract class IgxGridBaseDirective implements GridType,
         this._transactions = this.transactionFactory.create(TRANSACTION_TYPE.None);
         this._transactions.cloneStrategy = this.dataCloneStrategy;
         this.cdr.detach();
+        IgcTrialWatermark.register();
     }
 
     /**


### PR DESCRIPTION
Related to #13562

While the use of the `@__PURE__` notation is valid on a stand-alone expression call (I imagined it wouldn't be, but see https://github.com/javascript-compiler-hints/compiler-notations-spec/blob/main/pure-notation-spec.md, also https://esbuild.github.io/api/#pure) in this scenario it doesn't quite work.
The register is actually side-effectful to begin with and since this is a top level expression that doesn't have it's supposed return value used or exported the notation basically means permanent tree-shake and deletes the register.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 