### PR TITLE
Migrations test fixes

### DIFF
--- a/projects/igniteui-angular/migrations/common/UpdateChanges.spec.ts
+++ b/projects/igniteui-angular/migrations/common/UpdateChanges.spec.ts
@@ -34,8 +34,10 @@ describe('UpdateChanges', () => {
         appTree = setupTestTree({
             projects: {
                 testProj: {
+                    projectType: 'application',
                     root: '',
-                    sourceRoot: '/'
+                    sourceRoot: '/',
+                    architect: { build: { options: {} } }
                 }
             },
             schematics: {

--- a/projects/igniteui-angular/migrations/common/setup.spec.ts
+++ b/projects/igniteui-angular/migrations/common/setup.spec.ts
@@ -56,6 +56,8 @@ class IgxUnitTestTree extends UnitTestTree {
             if (!project.containsScriptInfo(scriptInfo)) {
                 // add the file to the configured project to prevent tss from creating an inferred project for floating files
                 scriptInfo.attachToProject(project);
+                // add root in advance for ng LS discovery if two files test.component.ts/html and html is analyzed first
+                project.addMissingFileRoot(scriptInfo.fileName);
             } else {
                 // if using same file, force-reload from host for new content
                 scriptInfo.reloadFromFile(tss.server.asNormalizedPath(entryPath));


### PR DESCRIPTION
This should resolve the migration test flickers:
1. Several of the base tests didn't run - due to unit test tree handling patching workspace `architect` options that weren't there and thus the 'build of undefined' errors. **NB** Something off here, these should've failed permanently instead of occasionally when running first in order, so there might be an issue w/ resetting the test tree still.
2. The single NG LS test would fail if it didn't run first in order or a prior test would properly add a `component.ts` file of the same path and load it correctly. Turns out the ng LS also needs `addMissingFileRoot` to consider/compile the new `component.ts` since we scan the html file first.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [x] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 