### PR TITLE
test(migrations): fix leftover test workspace configs

### DIFF
--- a/projects/igniteui-angular/migrations/common/UpdateChanges.spec.ts
+++ b/projects/igniteui-angular/migrations/common/UpdateChanges.spec.ts
@@ -856,7 +856,9 @@ export class AppModule { }`);
             appTree.overwrite('/angular.json', JSON.stringify({
                 projects: {
                     testProj: {
-                        sourceRoot: '/src'
+                        projectType: 'application',
+                        sourceRoot: '/src',
+                        architect: { build: { options: {} } }
                     }
                 }
             }));
@@ -884,15 +886,18 @@ export class AppModule { }`);
                 projects: {
                     testProj: {
                         projectType: 'application',
-                        sourceRoot: 'src-one'
+                        sourceRoot: 'src-one',
+                        architect: { build: { options: {} } }
                     },
                     test2Proj: {
                         projectType: 'application',
-                        sourceRoot: '/src-two'
+                        sourceRoot: '/src-two',
+                        architect: { build: { options: {} } }
                     },
                     libProj: {
                         projectType: 'library',
-                        sourceRoot: 'src-lib'
+                        sourceRoot: 'src-lib',
+                        architect: { build: { options: {} } }
                     }
                 }
             };


### PR DESCRIPTION
Missed two more test workspace (`angular.json`) configs in #14919 that lacked build options and could still fail w/ current test setup depending on execution order 

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 