### PR TITLE
(query-builder) Disabled search value input for unary operator

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid/grid-filtering-advanced.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-filtering-advanced.spec.ts
@@ -611,8 +611,11 @@ describe('IgxGrid - Advanced Filtering #grid - ', () => {
 
             selectColumnInEditModeExpression(fix, 4); // Select 'ReleaseDate' column.
             selectOperatorInEditModeExpression(fix, 9); // Select 'This Year' operator.
+            tick(100);
+            fix.detectChanges();
+
             verifyEditModeExpressionInputStates(fix, true, true, false, true); // Third input should be disabled for unary operators.
-            const input = GridFunctions.getAdvancedFilteringValueInput(fix, true);
+            const input = GridFunctions.getAdvancedFilteringValueInput(fix);
             input.click();
             fix.detectChanges();
 

--- a/projects/igniteui-angular/src/lib/query-builder/query-builder.component.html
+++ b/projects/igniteui-angular/src/lib/query-builder/query-builder.component.html
@@ -244,24 +244,35 @@
             </igx-select>
 
             <igx-input-group
+                *ngIf="isSearchValueInputDisabled()"
+                type="box"
+            >
+                <input
+                    igxInput
+                    [disabled]="true"
+                    [type]="
+                        selectedField && selectedField.dataType === 'number'
+                            ? 'number'
+                            : 'text'
+                    "
+                    [placeholder]="
+                        this.resourceStrings.igx_query_builder_value_placeholder
+                    "
+                />
+            </igx-input-group>
+
+            <igx-input-group
                 *ngIf="
-                    !selectedField ||
-                    (selectedField.dataType !== 'date' &&
-                        selectedField.dataType !== 'time' &&
-                        selectedField.dataType !== 'dateTime')
+                    !isSearchValueInputDisabled() &&
+                    selectedField.dataType !== 'date' &&
+                    selectedField.dataType !== 'time' &&
+                    selectedField.dataType !== 'dateTime'
                 "
                 type="box"
             >
                 <input
                     #searchValueInput
                     igxInput
-                    [disabled]="
-                        !selectedField ||
-                        !selectedCondition ||
-                        (selectedField &&
-                            selectedField.filters.condition(selectedCondition)
-                                .isUnary)
-                    "
                     [type]="
                         selectedField && selectedField.dataType === 'number'
                             ? 'number'
@@ -276,7 +287,7 @@
 
             <igx-date-picker
                 #picker
-                *ngIf="selectedField && selectedField.dataType === 'date'"
+                *ngIf="!isSearchValueInputDisabled() && selectedField.dataType === 'date'"
                 [(value)]="searchValue"
                 (keydown)="openPicker($event)"
                 (click)="picker.open()"
@@ -284,13 +295,6 @@
                 [readOnly]="true"
                 [placeholder]="
                     this.resourceStrings.igx_query_builder_date_placeholder
-                "
-                [disabled]="
-                    !selectedField ||
-                    !selectedCondition ||
-                    (selectedField &&
-                        selectedField.filters.condition(selectedCondition)
-                            .isUnary)
                 "
                 [locale]="this.locale"
                 [outlet]="pickerOutlet"
@@ -305,7 +309,7 @@
 
             <igx-time-picker
                 #picker
-                *ngIf="selectedField && selectedField.dataType === 'time'"
+                *ngIf="!isSearchValueInputDisabled() && selectedField.dataType === 'time'"
                 [(value)]="searchValue"
                 (click)="picker.open()"
                 (keydown)="openPicker($event)"
@@ -314,13 +318,6 @@
                 "
                 type="box"
                 [readOnly]="true"
-                [disabled]="
-                    !selectedField ||
-                    !selectedCondition ||
-                    (selectedField &&
-                        selectedField.filters.condition(selectedCondition)
-                            .isUnary)
-                "
                 [locale]="this.locale"
                 [outlet]="pickerOutlet"
                 [formatter]="selectedField.formatter"
@@ -335,7 +332,7 @@
             <igx-input-group
                 #inputGroup
                 type="box"
-                *ngIf="selectedField && selectedField.dataType === 'dateTime'"
+                *ngIf="!isSearchValueInputDisabled() && selectedField.dataType === 'dateTime'"
                 type="box"
             >
                 <input
@@ -347,13 +344,6 @@
                         this.resourceStrings.igx_query_builder_date_placeholder
                     "
                     [(ngModel)]="searchValue"
-                    [disabled]="
-                        !selectedField ||
-                        !selectedCondition ||
-                        (selectedField &&
-                            selectedField.filters.condition(selectedCondition)
-                                .isUnary)
-                    "
                     [locale]="this.locale"
                     [igxDateTimeEditor]="selectedField.editorOptions?.dateTimeFormat"
                     [defaultFormatType]="selectedField.dataType"

--- a/projects/igniteui-angular/src/lib/query-builder/query-builder.component.ts
+++ b/projects/igniteui-angular/src/lib/query-builder/query-builder.component.ts
@@ -343,6 +343,13 @@ export class IgxQueryBuilderComponent implements AfterViewInit, OnDestroy {
      */
     public searchValue: any;
 
+    /** @hidden */
+    protected isSearchValueInputDisabled(): boolean {
+        return !this.selectedField ||
+                !this.selectedCondition ||
+                (this.selectedField && this.selectedField.filters.condition(this.selectedCondition).isUnary);
+    }
+    
     /**
      * @hidden @internal
      */
@@ -524,6 +531,11 @@ export class IgxQueryBuilderComponent implements AfterViewInit, OnDestroy {
                 : this.selectedField.header
                     ? this.selectedField.header
                     : this.selectedField.field;
+                    
+            if (this.selectedField.filters.condition(this.selectedCondition)?.isUnary) {
+                this._editedExpression.expression.searchVal = null;
+            }
+            
             this._editedExpression.inEditMode = false;
             this._editedExpression = null;
         }


### PR DESCRIPTION
Closes #14888  

This solution adds a dedicated empty disabled input field, which is displayed when there is a need to display a disabled input.
This way, when an unary operator is selected, an empty disabled input is displayed and the original input(containing the search value) is been hidden. 
Now if the user returns to a non-unary operator, in the context of the same condition editing session, the input appears enabled again still containing the value before the disabling.
If the user saves the unary condition, the search value is only now cleared and won't reappear if opened for edit again and operator changed to not-unary. 

P.S. Following the same approach, the input can be removed all together (rather than substituted with a disabled one)
or the placeholder of the disabled input can be changed to 'n/a', -Empty-, or something else. 

### Additional information (check all that apply):
 - [ ] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 