### PR TITLE
fix(grid,filtering): expression tree interface optional find methods

### DIFF
--- a/projects/igniteui-angular/src/lib/data-operations/filtering-expressions-tree.ts
+++ b/projects/igniteui-angular/src/lib/data-operations/filtering-expressions-tree.ts
@@ -23,12 +23,12 @@ export declare interface IFilteringExpressionsTree extends IBaseEventArgs, IExpr
     /**
      * @deprecated in version 18.2.0. Use `ExpressionsTreeUtil.find` instead.
      */
-    find(fieldName: string): IFilteringExpressionsTree | IFilteringExpression;
+    find?: (fieldName: string) => IFilteringExpressionsTree | IFilteringExpression;
 
     /**
      * @deprecated in version 18.2.0. Use `ExpressionsTreeUtil.findIndex` instead.
      */
-    findIndex(fieldName: string): number;
+    findIndex?: (fieldName: string) => number;
 }
 
 /* marshalByValue */

--- a/projects/igniteui-angular/src/lib/data-operations/filtering-expressions-tree.ts
+++ b/projects/igniteui-angular/src/lib/data-operations/filtering-expressions-tree.ts
@@ -20,11 +20,13 @@ export declare interface IFilteringExpressionsTree extends IBaseEventArgs, IExpr
     /* alternateName: treeType */
     type?: FilteringExpressionsTreeType;
 
+    /* blazorSuppress */
     /**
      * @deprecated in version 18.2.0. Use `ExpressionsTreeUtil.find` instead.
      */
     find?: (fieldName: string) => IFilteringExpressionsTree | IFilteringExpression;
 
+    /* blazorSuppress */
     /**
      * @deprecated in version 18.2.0. Use `ExpressionsTreeUtil.findIndex` instead.
      */
@@ -112,6 +114,7 @@ export class FilteringExpressionsTree implements IFilteringExpressionsTree {
         return !expressionTree || !expressionTree.filteringOperands || !expressionTree.filteringOperands.length;
     }
 
+    /* blazorSuppress */
     /**
      * Returns the filtering expression for a column with the provided fieldName.
      * ```typescript
@@ -125,6 +128,7 @@ export class FilteringExpressionsTree implements IFilteringExpressionsTree {
         return ExpressionsTreeUtil.find(this, fieldName);
     }
 
+    /* blazorSuppress */
     /**
      * Returns the index of the filtering expression for a column with the provided fieldName.
      * ```typescript


### PR DESCRIPTION
Addition to https://github.com/IgniteUI/igniteui-angular/pull/14815
Make the `IFilteringExpressionsTree` find methods optional as well, otherwise plain objects without those do not satisfy the interface type.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 