### PR TITLE
refactor(tabs): remove unnecessary styles

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/tabs/_tabs-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/tabs/_tabs-theme.scss
@@ -252,20 +252,6 @@
         flex: 0 0 auto;
         background: var-get($theme, 'item-background');
         z-index: 1;
-
-        @if $indigo-theme {
-            [igxIconButton='flat'].igx-button--focused {
-                box-shadow: none;
-
-                &::after {
-                    border: rem(3px) solid var(--nav-btn-border-color);
-
-                    @if $theme-variant == 'dark' {
-                        border-color: contrast-color($color: 'gray', $variant: 50, $opacity: .2);
-                    }
-                }
-            }
-        }
     }
 
     %tabs-header-content {


### PR DESCRIPTION
Since the scroll buttons of the tabs component have been excluded from the keyboard navigation #14886, some styles regarding their focused state become redundant. 


### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 