### PR TITLE
refactor(grids): replace uuid dep with native crypto method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "lodash-es": "^4.17.21",
         "rxjs": "^7.8.0",
         "tslib": "^2.3.0",
-        "uuid": "^9.0.0",
         "zone.js": "~0.14.10"
       },
       "devDependencies": {
@@ -22639,18 +22638,6 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "lodash-es": "^4.17.21",
     "rxjs": "^7.8.0",
     "tslib": "^2.3.0",
-    "uuid": "^9.0.0",
     "zone.js": "~0.14.10"
   },
   "devDependencies": {

--- a/projects/igniteui-angular-elements/src/app/wrapper/template-ref-wrapper.ts
+++ b/projects/igniteui-angular-elements/src/app/wrapper/template-ref-wrapper.ts
@@ -1,5 +1,4 @@
-import { ElementRef, EmbeddedViewRef, Injector, TemplateRef, ViewChild } from '@angular/core';
-import { v4 as uuidv4 } from 'uuid';
+import { ElementRef, EmbeddedViewRef, Injector, TemplateRef } from '@angular/core';
 
 const CONTEXT_PROP = 'context';
 const IMPLICIT_PROP = 'implicit';
@@ -71,7 +70,7 @@ export class TemplateRefWrapper<C extends object> extends TemplateRef<C> {
             root = viewRef.rootNodes[0];
 
             contentContext = new TemplateRefWrapperContentContext();
-            contentId = uuidv4() as string;
+            contentId = crypto.randomUUID();
             contentContext._id = contentId;
             root._id = contentId;
             contentContext.root = root;

--- a/projects/igniteui-angular/ng-package.json
+++ b/projects/igniteui-angular/ng-package.json
@@ -11,7 +11,6 @@
     "fflate",
     "igniteui-trial-watermark",
     "lodash-es",
-    "uuid",
     "@igniteui/material-icons-extended",
     "igniteui-theming"
   ]

--- a/projects/igniteui-angular/ng-package.prod.json
+++ b/projects/igniteui-angular/ng-package.prod.json
@@ -10,7 +10,6 @@
     "fflate",
     "igniteui-trial-watermark",
     "lodash-es",
-    "uuid",
     "@igniteui/material-icons-extended",
     "igniteui-theming"
   ]

--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -73,7 +73,6 @@
         "tslib": "^2.3.0",
         "igniteui-trial-watermark": "^3.0.2",
         "lodash-es": "^4.17.21",
-        "uuid": "^9.0.0",
         "igniteui-theming": "^14.2.0",
         "@igniteui/material-icons-extended": "^3.0.0"
     },

--- a/projects/igniteui-angular/schematics/utils/dependency-handler.ts
+++ b/projects/igniteui-angular/schematics/utils/dependency-handler.ts
@@ -24,7 +24,6 @@ export const DEPENDENCIES_MAP: PackageEntry[] = [
     { name: 'tslib', target: PackageTarget.NONE },
     { name: 'igniteui-trial-watermark', target: PackageTarget.NONE },
     { name: 'lodash-es', target: PackageTarget.NONE },
-    { name: 'uuid', target: PackageTarget.NONE },
     { name: '@igniteui/material-icons-extended', target: PackageTarget.REGULAR },
     { name: 'igniteui-theming', target: PackageTarget.NONE },
     // peerDependencies

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -154,7 +154,6 @@ import { IgxColumnComponent } from './columns/column.component';
 import { IgxColumnGroupComponent } from './columns/column-group.component';
 import { IgxRowDragGhostDirective, IgxDragIndicatorIconDirective } from './row-drag.directive';
 import { IgxSnackbarComponent } from '../snackbar/snackbar.component';
-import { v4 as uuidv4 } from 'uuid';
 import { IgxActionStripToken } from '../action-strip/token';
 import { IgxGridRowComponent } from './grid/grid-row.component';
 import type { IgxPaginatorComponent } from '../paginator/paginator.component';
@@ -3771,7 +3770,7 @@ export abstract class IgxGridBaseDirective implements GridType,
         const primaryColumn = this._columns.find(col => col.field === this.primaryKey);
         const idType = this.data.length ?
             this.resolveDataTypes(this.data[0][this.primaryKey]) : primaryColumn ? primaryColumn.dataType : 'string';
-        return idType === 'string' ? uuidv4() : FAKE_ROW_ID--;
+        return idType === 'string' ? crypto.randomUUID() : FAKE_ROW_ID--;
     }
 
     /**
@@ -7788,7 +7787,7 @@ export abstract class IgxGridBaseDirective implements GridType,
             } else {
                 this._shouldRecalcRowHeight = true;
             }
-        } 
+        }
     }
 
     // TODO: About to Move to CRUD


### PR DESCRIPTION
Related to #8191
Replace the `uuid` package with native [`crypto.randomUUID()` method that's widely available](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) and being [used by the package if possible](https://github.com/uuidjs/uuid/blob/1370497eecb5c4a570da3d76aa1b47b86448470f/src/v4.ts#L9-L10) anyway.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 