### PR TITLE
refactor(grids): check if primaryKey exists as a field in the data instead of in the columns

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -446,7 +446,7 @@ export abstract class IgxGridBaseDirective implements GridType,
 
     public set primaryKey(value: string) {
         this._primaryKey = value;
-        this.checkPrimaryKeyColumn();
+        this.checkPrimaryKeyField();
     }
 
     /* blazorSuppress */
@@ -6655,7 +6655,6 @@ export abstract class IgxGridBaseDirective implements GridType,
 
         this.initColumns(this._columns, (col: IgxColumnComponent) => this.columnInit.emit(col));
         this.columnListDiffer.diff(this.columnList);
-        this.checkPrimaryKeyColumn();
 
         this.columnList.changes
             .pipe(takeUntil(this.destroy$))
@@ -6767,15 +6766,14 @@ export abstract class IgxGridBaseDirective implements GridType,
             if (added || removed) {
                 this.onColumnsAddedOrRemoved();
             }
-            this.checkPrimaryKeyColumn();
         }
     }
 
     /**
      * @hidden @internal
      */
-    protected checkPrimaryKeyColumn() {
-        if (this.primaryKey && this.columns.length > 0 && !this.columns.find(c => c.field === this.primaryKey)) {
+    protected checkPrimaryKeyField() {
+        if (this.primaryKey && this.data?.length && !(this.primaryKey in this.data[0])) {
             console.warn(`Primary key column "${this.primaryKey}" is not defined. Set \`primaryKey\` to a valid column.`);
         }
     }
@@ -7788,7 +7786,7 @@ export abstract class IgxGridBaseDirective implements GridType,
             } else {
                 this._shouldRecalcRowHeight = true;
             }
-        } 
+        }
     }
 
     // TODO: About to Move to CRUD

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -6774,7 +6774,7 @@ export abstract class IgxGridBaseDirective implements GridType,
      */
     protected checkPrimaryKeyField() {
         if (this.primaryKey && this.data?.length && !(this.primaryKey in this.data[0])) {
-            console.warn(`Primary key column "${this.primaryKey}" is not defined. Set \`primaryKey\` to a valid column.`);
+            console.warn(`Field "${this.primaryKey}" is not defined in the data. Set \`primaryKey\` to a valid field.`);
         }
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -6769,9 +6769,6 @@ export abstract class IgxGridBaseDirective implements GridType,
         }
     }
 
-    /**
-     * @hidden @internal
-     */
     protected checkPrimaryKeyField() {
         if (this.primaryKey && this.data?.length && !(this.primaryKey in this.data[0])) {
             console.warn(`Field "${this.primaryKey}" is not defined in the data. Set \`primaryKey\` to a valid field.`);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -683,7 +683,7 @@ describe('IgxGrid Component Tests #grid', () => {
 
             expect(console.warn).toHaveBeenCalledTimes(1);
             expect(console.warn).toHaveBeenCalledWith(
-                `Primary key column "${grid.primaryKey}" is not defined. Set \`primaryKey\` to a valid column.`
+                `Field "${grid.primaryKey}" is not defined in the data. Set \`primaryKey\` to a valid field.`
             );
             warnSpy.calls.reset();
 
@@ -700,7 +700,7 @@ describe('IgxGrid Component Tests #grid', () => {
 
             expect(console.warn).toHaveBeenCalledTimes(1);
             expect(console.warn).toHaveBeenCalledWith(
-                `Primary key column "${grid.primaryKey}" is not defined. Set \`primaryKey\` to a valid column.`
+                `Field "${grid.primaryKey}" is not defined in the data. Set \`primaryKey\` to a valid field.`
             );
         });
     });

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -674,10 +674,10 @@ describe('IgxGrid Component Tests #grid', () => {
             expect(cell.offsetHeight).toEqual(expectedCellHeight);
         });
 
-        it('should throw a warning when primaryKey is set to a non-existing column field', () => {
+        it('should throw a warning when primaryKey is set to a non-existing data field', () => {
+            const warnSpy = spyOn(console, 'warn');
             const fixture = TestBed.createComponent(IgxGridTestComponent);
             const grid = fixture.componentInstance.grid;
-            const warnSpy = spyOn(console, 'warn');
             grid.primaryKey = 'testField';
             fixture.detectChanges();
 
@@ -687,18 +687,14 @@ describe('IgxGrid Component Tests #grid', () => {
             );
             warnSpy.calls.reset();
 
-            // update columns to include the 'testField'
-            fixture.componentInstance.columns = [
-                { field: 'index', header: 'index', dataType: 'number', width: null, hasSummary: false },
-                { field: 'value', header: 'value', dataType: 'number', width: null, hasSummary: false },
-                { field: 'testField', header: 'testField', dataType: 'number', width: null, hasSummary: false }
-            ];
+            // update data to include the 'testField'
+            fixture.componentInstance.data = [{ index: 1, value: 1, testField: 1 }];
             fixture.detectChanges();
 
             expect(console.warn).toHaveBeenCalledTimes(0);
 
             // remove the 'testField' runtime
-            fixture.componentInstance.columns.pop();
+            fixture.componentInstance.data = [{ index: 1, value: 1 }];
             fixture.componentInstance.columns = [...fixture.componentInstance.columns];
             fixture.detectChanges();
 

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.ts
@@ -417,6 +417,7 @@ export class IgxGridComponent extends IgxGridBaseDirective implements GridType, 
         if (dataLoaded && this._columns.some(x => (x as any)._width === 'auto')) {
             this.recalculateAutoSizes();
         }
+        this.checkPrimaryKeyField();
     }
 
     /**

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.component.ts
@@ -486,6 +486,7 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
     public set data(value: any[] | null) {
         this.setDataInternal(value);
         this.dataSetByUser = true;
+        this.checkPrimaryKeyField();
     }
 
     /**
@@ -1139,7 +1140,6 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
     protected override setupColumns() {
         if (this.parentIsland && this.parentIsland.childColumns.length > 0 && !this.autoGenerate) {
             this.createColumnsList(this.parentIsland.childColumns.toArray());
-            super.checkPrimaryKeyColumn();
         } else {
             super.setupColumns();
         }

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.spec.ts
@@ -647,15 +647,16 @@ describe('Basic IgxHierarchicalGrid #hGrid', () => {
             fixture.detectChanges();
 
             expect(console.warn).toHaveBeenCalledWith(
-                `Primary key column "${hierarchicalGrid.primaryKey}" is not defined. Set \`primaryKey\` to a valid column.`
+                `Field "${hierarchicalGrid.primaryKey}" is not defined in the data. Set \`primaryKey\` to a valid field.`
             );
 
             let row1 = hierarchicalGrid.gridAPI.get_row_by_index(0) as IgxHierarchicalRowComponent;
             UIInteractions.simulateClickAndSelectEvent(row1.expander);
             fixture.detectChanges();
 
+            let rowIsland = fixture.componentInstance.rowIsland;
             expect(console.warn).toHaveBeenCalledWith(
-                `Primary key column "${fixture.componentInstance.rowIsland.primaryKey}" is not defined. Set \`primaryKey\` to a valid column.`
+                `Field "${rowIsland.primaryKey}" is not defined in the data. Set \`primaryKey\` to a valid field.`
             );
 
             const secondLevelGrid = hierarchicalGrid.gridAPI.getChildGrids()[0];
@@ -663,8 +664,9 @@ describe('Basic IgxHierarchicalGrid #hGrid', () => {
             UIInteractions.simulateClickAndSelectEvent(row1.expander);
             fixture.detectChanges();
 
+            rowIsland = fixture.componentInstance.rowIsland2;
             expect(console.warn).toHaveBeenCalledWith(
-                `Primary key column "${fixture.componentInstance.rowIsland2.primaryKey}" is not defined. Set \`primaryKey\` to a valid column.`
+                `Field "${rowIsland.primaryKey}" is not defined in the data. Set \`primaryKey\` to a valid field.`
             );
         });
     });

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.spec.ts
@@ -639,7 +639,7 @@ describe('Basic IgxHierarchicalGrid #hGrid', () => {
             expect(hierarchicalGrid.columnInit.emit).toHaveBeenCalled();
         });
 
-        it('should throw a warning when primaryKey is set to a non-existing column field', () => {
+        it('should throw a warning when primaryKey is set to a non-existing data field', () => {
             spyOn(console, 'warn');
             hierarchicalGrid.primaryKey = 'testField';
             fixture.componentInstance.rowIsland.primaryKey = 'testField-rowIsland';

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.spec.ts
@@ -152,6 +152,33 @@ describe('IgxTreeGrid Component Tests #tGrid', () => {
 
             expect(grid.dataView.length).toBeGreaterThan(0);
         });
+
+        it('should throw a warning when primaryKey is set to a non-existing data field', () => {
+            const warnSpy = spyOn(console, 'warn');
+            grid.primaryKey = 'testField';
+            fix.detectChanges();
+
+            expect(console.warn).toHaveBeenCalledTimes(1);
+            expect(console.warn).toHaveBeenCalledWith(
+                `Primary key column "${grid.primaryKey}" is not defined. Set \`primaryKey\` to a valid column.`
+            );
+            warnSpy.calls.reset();
+
+            const oldData = fix.componentInstance.data;
+            const newData = fix.componentInstance.data.map(rec => Object.assign({}, rec, { testField: 0 }));
+            fix.componentInstance.data = newData;
+            fix.detectChanges();
+
+            expect(console.warn).toHaveBeenCalledTimes(0);
+
+            fix.componentInstance.data = oldData;
+            fix.detectChanges();
+
+            expect(console.warn).toHaveBeenCalledTimes(1);
+            expect(console.warn).toHaveBeenCalledWith(
+                `Primary key column "${grid.primaryKey}" is not defined. Set \`primaryKey\` to a valid column.`
+            );
+        });
     });
 
     describe('Auto-generated columns', () => {

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.spec.ts
@@ -160,7 +160,7 @@ describe('IgxTreeGrid Component Tests #tGrid', () => {
 
             expect(console.warn).toHaveBeenCalledTimes(1);
             expect(console.warn).toHaveBeenCalledWith(
-                `Primary key column "${grid.primaryKey}" is not defined. Set \`primaryKey\` to a valid column.`
+                `Field "${grid.primaryKey}" is not defined in the data. Set \`primaryKey\` to a valid field.`
             );
             warnSpy.calls.reset();
 
@@ -176,7 +176,7 @@ describe('IgxTreeGrid Component Tests #tGrid', () => {
 
             expect(console.warn).toHaveBeenCalledTimes(1);
             expect(console.warn).toHaveBeenCalledWith(
-                `Primary key column "${grid.primaryKey}" is not defined. Set \`primaryKey\` to a valid column.`
+                `Field "${grid.primaryKey}" is not defined in the data. Set \`primaryKey\` to a valid field.`
             );
         });
     });

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.component.ts
@@ -379,6 +379,7 @@ export class IgxTreeGridComponent extends IgxGridBaseDirective implements GridTy
         if (this.autoGenerate && this._data.length > 0 && this.shouldRecreateColumns(oldData, this._data)) {
             this.setupColumns();
         }
+        this.checkPrimaryKeyField();
         this.cdr.markForCheck();
     }
 


### PR DESCRIPTION
Refactor the approach in https://github.com/IgniteUI/igniteui-angular/pull/14945
Closes https://github.com/IgniteUI/igniteui-angular/issues/14928

### Additional information (check all that apply):
 - [ ] Bug fix
 - [x] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 