### PR TITLE
refactor(icon): remove ariaHidden member

### DIFF
--- a/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.html
+++ b/projects/igniteui-angular/src/lib/date-range-picker/date-range-picker.component.html
@@ -16,7 +16,7 @@
 </ng-template>
 
 <ng-template #defIcon>
-    <igx-icon family="default" name="date_range"></igx-icon>
+    <igx-icon family="default" name="date_range" [attr.aria-hidden]="true"></igx-icon>
 </ng-template>
 
 <ng-template #defDateSeparatorTemplate>{{ dateSeparator }}</ng-template>

--- a/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel-header.component.html
+++ b/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel-header.component.html
@@ -10,7 +10,8 @@
         <igx-icon
             *ngIf="!iconTemplate"
             family="default"
-            [name]="panel.collapsed ? 'expand' : 'collapse'">
+            [name]="panel.collapsed ? 'expand' : 'collapse'"
+            [attr.aria-hidden]="true">
         </igx-icon>
     </div>
 </div>

--- a/projects/igniteui-angular/src/lib/icon/icon.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/icon/icon.component.spec.ts
@@ -36,7 +36,6 @@ describe("Icon", () => {
             fixture.detectChanges();
 
             expect(instance.getFamily).toBe("material");
-            expect(instance.ariaHidden).toBe(true);
             expect(instance.getActive).toBe(true);
         });
 

--- a/projects/igniteui-angular/src/lib/icon/icon.component.ts
+++ b/projects/igniteui-angular/src/lib/icon/icon.component.ts
@@ -66,22 +66,6 @@ export class IgxIconComponent implements OnInit, OnChanges, OnDestroy {
     }
 
     /**
-     *  This allows you to disable the `aria-hidden` attribute. By default it's applied.
-     *
-     * @example
-     * ```typescript
-     * @ViewChild("MyIcon") public icon: IgxIconComponent;
-     * constructor(private cdRef:ChangeDetectorRef) {}
-     * ngAfterViewInit() {
-     *     this.icon.ariaHidden = false;
-     *     this.cdRef.detectChanges();
-     * }
-     * ```
-     */
-    @HostBinding("attr.aria-hidden")
-    public ariaHidden = true;
-
-    /**
      *  An accessor that returns inactive property.
      *
      * @example

--- a/projects/igniteui-angular/src/lib/query-builder/query-builder.component.html
+++ b/projects/igniteui-angular/src/lib/query-builder/query-builder.component.html
@@ -153,7 +153,7 @@
                     (keydown)="invokeClick($event)"
                     (click)="enterExpressionEdit(expressionItem)"
                 >
-                    <igx-icon id="edit-expression">edit</igx-icon>
+                    <igx-icon id="edit-expression" [attr.aria-hidden]="true">edit</igx-icon>
                 </button>
 
                 <button

--- a/projects/igniteui-angular/src/lib/select/select.component.html
+++ b/projects/igniteui-angular/src/lib/select/select.component.html
@@ -26,7 +26,7 @@
         <ng-container *ngIf="toggleIconTemplate">
             <ng-container *ngTemplateOutlet="toggleIconTemplate; context: {$implicit: this.collapsed}"></ng-container>
         </ng-container>
-        <igx-icon *ngIf="!toggleIconTemplate" family="default" [name]="toggleIcon"></igx-icon>
+        <igx-icon *ngIf="!toggleIconTemplate" family="default" [name]="toggleIcon" [attr.aria-hidden]="true"></igx-icon>
     </igx-suffix>
     <ng-container ngProjectAs="igx-hint, [igxHint]" >
         <ng-content select="igx-hint, [igxHint]"></ng-content>


### PR DESCRIPTION
Closes #15159

Removing the explicit ariaHidden binding set to true on component instantiation. Users should use `[attr.aria-hidden]="true"` to control the `aria-hidden` attribute of the Icon component and achieve the same result.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 