### PR TITLE
refactor(*): unused standalone imports cleanup

### DIFF
--- a/projects/igniteui-angular/src/lib/action-strip/action-strip.component.ts
+++ b/projects/igniteui-angular/src/lib/action-strip/action-strip.component.ts
@@ -24,7 +24,6 @@ import { IgxIconComponent } from '../icon/icon.component';
 import { IgxDropDownItemNavigationDirective } from '../drop-down/drop-down-navigation.directive';
 import { IgxToggleActionDirective } from '../directives/toggle/toggle.directive';
 import { IgxRippleDirective } from '../directives/ripple/ripple.directive';
-import { IgxButtonDirective } from '../directives/button/button.directive';
 import { NgIf, NgFor, NgTemplateOutlet } from '@angular/common';
 import { getCurrentResourceStrings } from '../core/i18n/resources';
 import { IgxIconButtonDirective } from '../directives/button/icon-button.directive';
@@ -78,7 +77,6 @@ export class IgxActionStripMenuItemDirective {
         NgIf,
         NgFor,
         NgTemplateOutlet,
-        IgxButtonDirective,
         IgxIconButtonDirective,
         IgxRippleDirective,
         IgxToggleActionDirective,

--- a/projects/igniteui-angular/src/lib/action-strip/grid-actions/grid-action-button.component.ts
+++ b/projects/igniteui-angular/src/lib/action-strip/grid-actions/grid-action-button.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, TemplateRef, ViewChild, Output, EventEmitter, ElementRef, booleanAttribute } from '@angular/core';
 import { IgxIconComponent } from '../../icon/icon.component';
 import { IgxRippleDirective } from '../../directives/ripple/ripple.directive';
-import { IgxButtonDirective } from '../../directives/button/button.directive';
 import { NgIf } from '@angular/common';
 import { IgxIconButtonDirective } from '../../directives/button/icon-button.directive';
 
@@ -12,7 +11,7 @@ import { IgxIconButtonDirective } from '../../directives/button/icon-button.dire
     selector: 'igx-grid-action-button',
     templateUrl: 'grid-action-button.component.html',
     standalone: true,
-    imports: [NgIf, IgxButtonDirective, IgxRippleDirective, IgxIconComponent, IgxIconButtonDirective]
+    imports: [NgIf, IgxRippleDirective, IgxIconComponent, IgxIconButtonDirective]
 })
 export class IgxGridActionButtonComponent {
 

--- a/projects/igniteui-angular/src/lib/calendar/calendar.component.ts
+++ b/projects/igniteui-angular/src/lib/calendar/calendar.component.ts
@@ -13,7 +13,7 @@ import {
 	booleanAttribute,
     HostListener,
 } from '@angular/core';
-import { NgIf, NgTemplateOutlet, NgStyle, NgFor, DatePipe } from '@angular/common';
+import { NgIf, NgTemplateOutlet, NgFor, DatePipe } from '@angular/common';
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import {
@@ -72,7 +72,7 @@ let NEXT_ID = 0;
 	selector: 'igx-calendar',
 	templateUrl: 'calendar.component.html',
 	standalone: true,
-	imports: [NgIf, NgTemplateOutlet, IgxCalendarScrollPageDirective, NgStyle, IgxIconComponent, NgFor, IgxDaysViewComponent, IgxMonthsViewComponent, IgxYearsViewComponent, DatePipe, IgxMonthViewSlotsCalendar, IgxGetViewDateCalendar],
+	imports: [NgIf, NgTemplateOutlet, IgxCalendarScrollPageDirective, IgxIconComponent, NgFor, IgxDaysViewComponent, IgxMonthsViewComponent, IgxYearsViewComponent, DatePipe, IgxMonthViewSlotsCalendar, IgxGetViewDateCalendar],
 })
 export class IgxCalendarComponent extends IgxCalendarBaseDirective implements AfterViewInit, OnDestroy {
     /**

--- a/projects/igniteui-angular/src/lib/calendar/month-picker/month-picker.component.ts
+++ b/projects/igniteui-angular/src/lib/calendar/month-picker/month-picker.component.ts
@@ -9,7 +9,7 @@ import {
     OnDestroy,
     OnInit,
 } from "@angular/core";
-import { NgIf, NgStyle, NgTemplateOutlet, DatePipe } from "@angular/common";
+import { NgIf, NgTemplateOutlet, DatePipe } from "@angular/common";
 import { NG_VALUE_ACCESSOR } from "@angular/forms";
 
 import { IgxMonthsViewComponent } from "../months-view/months-view.component";
@@ -40,7 +40,6 @@ let NEXT_ID = 0;
     standalone: true,
     imports: [
         NgIf,
-        NgStyle,
         NgTemplateOutlet,
         DatePipe,
         IgxIconComponent,

--- a/projects/igniteui-angular/src/lib/calendar/months-view/months-view.component.ts
+++ b/projects/igniteui-angular/src/lib/calendar/months-view/months-view.component.ts
@@ -7,7 +7,7 @@ import {
     Inject,
 } from "@angular/core";
 import { IgxCalendarMonthDirective } from "../calendar.directives";
-import { NgFor, TitleCasePipe, DatePipe } from "@angular/common";
+import { NgFor, TitleCasePipe } from "@angular/common";
 import {
     IgxCalendarViewDirective,
     DAY_INTERVAL_TOKEN,
@@ -34,7 +34,7 @@ let NEXT_ID = 0;
     selector: "igx-months-view",
     templateUrl: "months-view.component.html",
     standalone: true,
-    imports: [NgFor, IgxCalendarMonthDirective, TitleCasePipe, DatePipe],
+    imports: [NgFor, IgxCalendarMonthDirective, TitleCasePipe],
 })
 export class IgxMonthsViewComponent extends IgxCalendarViewDirective implements ControlValueAccessor {
     #standalone = true;

--- a/projects/igniteui-angular/src/lib/grids/filtering/excel-style/excel-style-header.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/filtering/excel-style/excel-style-header.component.ts
@@ -1,7 +1,6 @@
 import { Component, Input, booleanAttribute } from '@angular/core';
 import { BaseFilteringComponent } from './base-filtering.component';
 import { IgxIconComponent } from '../../../icon/icon.component';
-import { IgxButtonDirective } from '../../../directives/button/button.directive';
 import { NgIf, NgClass } from '@angular/common';
 import { IgxIconButtonDirective } from '../../../directives/button/icon-button.directive';
 
@@ -12,7 +11,7 @@ import { IgxIconButtonDirective } from '../../../directives/button/icon-button.d
     selector: 'igx-excel-style-header',
     templateUrl: './excel-style-header.component.html',
     standalone: true,
-    imports: [NgIf, IgxButtonDirective, NgClass, IgxIconComponent, IgxIconButtonDirective]
+    imports: [NgIf, NgClass, IgxIconComponent, IgxIconButtonDirective]
 })
 export class IgxExcelStyleHeaderComponent {
     /**

--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-row-dimension-header-group.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-row-dimension-header-group.component.ts
@@ -9,7 +9,6 @@ import { IPivotDimension, PivotRowHeaderGroupType } from './pivot-grid.interface
 import { IgxPivotRowDimensionHeaderComponent } from './pivot-row-dimension-header.component';
 import { IgxHeaderGroupStylePipe } from '../headers/pipes';
 import { IgxPivotResizeHandleDirective } from '../resizing/pivot-grid/pivot-resize-handle.directive';
-import { IgxGridFilteringCellComponent } from '../filtering/base/grid-filtering-cell.component';
 import { IgxColumnMovingDropDirective } from '../moving/moving.drop.directive';
 import { IgxColumnMovingDragDirective } from '../moving/moving.drag.directive';
 import { NgIf, NgClass, NgStyle } from '@angular/common';
@@ -24,7 +23,7 @@ import { IMultiRowLayoutNode } from '../common/types';
     selector: 'igx-pivot-row-dimension-header-group',
     templateUrl: './pivot-row-dimension-header-group.component.html',
     standalone: true,
-    imports: [IgxIconComponent, NgIf, IgxPivotRowDimensionHeaderComponent, NgClass, NgStyle, IgxColumnMovingDragDirective, IgxColumnMovingDropDirective, IgxGridFilteringCellComponent, IgxPivotResizeHandleDirective, IgxHeaderGroupStylePipe]
+    imports: [IgxIconComponent, NgIf, IgxPivotRowDimensionHeaderComponent, NgClass, NgStyle, IgxColumnMovingDragDirective, IgxColumnMovingDropDirective, IgxPivotResizeHandleDirective, IgxHeaderGroupStylePipe]
 })
 export class IgxPivotRowDimensionHeaderGroupComponent extends IgxGridHeaderGroupComponent implements PivotRowHeaderGroupType {
 

--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-row-dimension-mrl-row.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-row-dimension-mrl-row.component.ts
@@ -15,9 +15,7 @@ import {
 import { IGX_GRID_BASE, PivotGridType } from '../common/grid.interface';
 import { IgxGridHeaderRowComponent } from '../headers/grid-header-row.component';
 import { IPivotDimension, IPivotDimensionData, IPivotGridRecord } from './pivot-grid.interface';
-import { IgxHeaderGroupWidthPipe, IgxHeaderGroupStylePipe } from '../headers/pipes';
-import { IgxIconComponent } from '../../icon/icon.component';
-import { NgClass, NgFor, NgStyle } from '@angular/common';
+import { NgFor } from '@angular/common';
 import { IgxPivotRowDimensionContentComponent } from './pivot-row-dimension-content.component';
 import { IgxPivotGridHorizontalRowCellMerging } from './pivot-grid.pipes';
 
@@ -34,8 +32,7 @@ import { IgxPivotGridHorizontalRowCellMerging } from './pivot-grid.pipes';
     selector: 'igx-pivot-row-dimension-mrl-row',
     templateUrl: './pivot-row-dimension-mrl-row.component.html',
     standalone: true,
-    imports: [NgClass, NgStyle, NgFor, IgxIconComponent, IgxHeaderGroupWidthPipe, IgxHeaderGroupStylePipe,
-        IgxPivotRowDimensionContentComponent, IgxPivotGridHorizontalRowCellMerging]
+    imports: [NgFor, IgxPivotRowDimensionContentComponent, IgxPivotGridHorizontalRowCellMerging]
 })
 export class IgxPivotRowDimensionMrlRowComponent extends IgxGridHeaderRowComponent {
 

--- a/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-row-header-group.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/pivot-grid/pivot-row-header-group.component.ts
@@ -8,7 +8,6 @@ import { IPivotDimension, PivotRowHeaderGroupType } from './pivot-grid.interface
 import { IgxPivotRowDimensionHeaderComponent } from './pivot-row-dimension-header.component';
 import { IgxHeaderGroupStylePipe } from '../headers/pipes';
 import { IgxPivotResizeHandleDirective } from '../resizing/pivot-grid/pivot-resize-handle.directive';
-import { IgxGridFilteringCellComponent } from '../filtering/base/grid-filtering-cell.component';
 import { IgxColumnMovingDropDirective } from '../moving/moving.drop.directive';
 import { IgxColumnMovingDragDirective } from '../moving/moving.drag.directive';
 import { NgIf, NgClass, NgStyle } from '@angular/common';
@@ -23,7 +22,7 @@ import { SortingDirection } from '../../data-operations/sorting-strategy';
     selector: 'igx-pivot-row-header-group',
     templateUrl: './pivot-row-dimension-header-group.component.html',
     standalone: true,
-    imports: [IgxIconComponent, NgIf, IgxPivotRowDimensionHeaderComponent, NgClass, NgStyle, IgxColumnMovingDragDirective, IgxColumnMovingDropDirective, IgxGridFilteringCellComponent, IgxPivotResizeHandleDirective, IgxHeaderGroupStylePipe]
+    imports: [IgxIconComponent, NgIf, IgxPivotRowDimensionHeaderComponent, NgClass, NgStyle, IgxColumnMovingDragDirective, IgxColumnMovingDropDirective, IgxPivotResizeHandleDirective, IgxHeaderGroupStylePipe]
 })
 export class IgxPivotRowHeaderGroupComponent extends IgxGridHeaderGroupComponent implements PivotRowHeaderGroupType {
 

--- a/projects/igniteui-angular/src/lib/grids/toolbar/grid-toolbar-advanced-filtering.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/toolbar/grid-toolbar-advanced-filtering.component.ts
@@ -2,7 +2,7 @@ import { AfterViewInit, Component, Inject, Input } from '@angular/core';
 import { IgxToolbarToken } from './token';
 import { OverlaySettings } from '../../services/overlay/utilities';
 import { IgxIconComponent } from '../../icon/icon.component';
-import { NgClass, NgIf } from '@angular/common';
+import { NgIf } from '@angular/common';
 import { IgxRippleDirective } from '../../directives/ripple/ripple.directive';
 import { IgxButtonDirective } from '../../directives/button/button.directive';
 import { FilteringExpressionsTree, IFilteringExpressionsTree } from '../../data-operations/filtering-expressions-tree';
@@ -31,7 +31,7 @@ import { IFilteringExpression } from '../../data-operations/filtering-expression
     selector: 'igx-grid-toolbar-advanced-filtering',
     templateUrl: './grid-toolbar-advanced-filtering.component.html',
     standalone: true,
-    imports: [IgxButtonDirective, IgxRippleDirective, NgClass, IgxIconComponent, NgIf]
+    imports: [IgxButtonDirective, IgxRippleDirective, IgxIconComponent, NgIf]
 })
 export class IgxGridToolbarAdvancedFilteringComponent implements AfterViewInit {
     protected numberOfColumns: number;

--- a/projects/igniteui-angular/src/lib/grids/toolbar/grid-toolbar-exporter.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/toolbar/grid-toolbar-exporter.component.ts
@@ -13,7 +13,7 @@ import {
 import { IgxToggleDirective } from '../../directives/toggle/toggle.directive';
 import { GridType } from '../common/grid.interface';
 import { IgxToolbarToken } from './token';
-import { NgIf, NgTemplateOutlet } from '@angular/common';
+import { NgIf } from '@angular/common';
 import { IgxIconComponent } from '../../icon/icon.component';
 import { IgxRippleDirective } from '../../directives/ripple/ripple.directive';
 import { IgxButtonDirective } from '../../directives/button/button.directive';
@@ -52,7 +52,7 @@ export interface IgxExporterEvent {
     selector: 'igx-grid-toolbar-exporter',
     templateUrl: './grid-toolbar-exporter.component.html',
     standalone: true,
-    imports: [IgxButtonDirective, IgxRippleDirective, IgxIconComponent, NgIf, IgxToggleDirective, IgxExcelTextDirective, NgTemplateOutlet, IgxCSVTextDirective]
+    imports: [IgxButtonDirective, IgxRippleDirective, IgxIconComponent, NgIf, IgxToggleDirective, IgxExcelTextDirective, IgxCSVTextDirective]
 })
 export class IgxGridToolbarExporterComponent extends BaseToolbarDirective {
 

--- a/projects/igniteui-angular/src/lib/icon/icon.component.ts
+++ b/projects/igniteui-angular/src/lib/icon/icon.component.ts
@@ -14,7 +14,6 @@ import type { IconReference } from "./types";
 import { filter, takeUntil } from "rxjs/operators";
 import { Subject } from "rxjs";
 import { SafeHtml } from "@angular/platform-browser";
-import { NgIf, NgTemplateOutlet } from "@angular/common";
 
 /**
  * Icon provides a way to include material icons to markup
@@ -42,7 +41,6 @@ import { NgIf, NgTemplateOutlet } from "@angular/common";
     selector: "igx-icon",
     templateUrl: "icon.component.html",
     standalone: true,
-    imports: [NgTemplateOutlet, NgIf],
 })
 export class IgxIconComponent implements OnInit, OnChanges, OnDestroy {
     private _iconRef: IconReference;

--- a/projects/igniteui-angular/src/lib/paginator/paginator.component.ts
+++ b/projects/igniteui-angular/src/lib/paginator/paginator.component.ts
@@ -3,12 +3,10 @@ import { IPageCancellableEventArgs, IPageEventArgs } from './paginator-interface
 import { IPaginatorResourceStrings, PaginatorResourceStringsEN } from '../core/i18n/paginator-resources';
 import { OverlaySettings } from '../services/overlay/utilities';
 import { IgxSelectItemComponent } from '../select/select-item.component';
-import { IgxLabelDirective } from '../directives/label/label.directive';
 import { FormsModule } from '@angular/forms';
 import { IgxSelectComponent } from '../select/select.component';
 import { IgxIconComponent } from '../icon/icon.component';
 import { IgxRippleDirective } from '../directives/ripple/ripple.directive';
-import { IgxButtonDirective } from '../directives/button/button.directive';
 import { NgIf, NgFor } from '@angular/common';
 import { getCurrentResourceStrings } from '../core/i18n/resources';
 import { IgxIconButtonDirective } from '../directives/button/icon-button.directive';
@@ -361,7 +359,7 @@ export class IgxPaginatorComponent implements IgxPaginatorToken {
     selector: 'igx-page-size',
     templateUrl: 'page-size-selector.component.html',
     standalone: true,
-    imports: [IgxSelectComponent, FormsModule, IgxLabelDirective, NgFor, IgxSelectItemComponent]
+    imports: [IgxSelectComponent, FormsModule, NgFor, IgxSelectItemComponent]
 })
 export class IgxPageSizeSelectorComponent {
     /**
@@ -379,7 +377,7 @@ export class IgxPageSizeSelectorComponent {
     selector: 'igx-page-nav',
     templateUrl: 'pager.component.html',
     standalone: true,
-    imports: [IgxButtonDirective, IgxRippleDirective, IgxIconComponent, IgxIconButtonDirective]
+    imports: [IgxRippleDirective, IgxIconComponent, IgxIconButtonDirective]
 })
 export class IgxPageNavigationComponent {
     /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,6 +46,9 @@
     "angularCompilerOptions": {
         "generateDeepReexports": true,
         "strictTemplates": true,
+        "extendedDiagnostics": {
+            "defaultCategory": "error"
+        },
         "fullTemplateTypeCheck": true,
         "strictInjectionParameters": true,
         "strictInputAccessModifiers": true,


### PR DESCRIPTION
Picked from #15212
Cleaning up unused standalone imports and setting those those fail compilation if found.
Note: The specific unused imports being removed don't have a diagnostics in 18, but leaving the setting regardless for everything else.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [x] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 