### PR TITLE
Use provided in show method overlay settings - 19.0

### DIFF
--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -1379,7 +1379,7 @@ describe('igxOverlay', () => {
             overlayInstance.detach(firstCallId);
         }));
 
-        fit('#15228 - Should use provided in show overlay settings ', fakeAsync(() => {
+        it('#15228 - Should use provided in show overlay settings ', fakeAsync(() => {
             const fixture = TestBed.createComponent(SimpleRefComponent);
             fixture.detectChanges();
             const overlayInstance = fixture.componentInstance.overlay;

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -1378,6 +1378,37 @@ describe('igxOverlay', () => {
             expect(overlayContent.style.getPropertyValue('--ig-size')).toEqual('1');
             overlayInstance.detach(firstCallId);
         }));
+
+        fit('#15228 - Should use provided in show overlay settings ', fakeAsync(() => {
+            const fixture = TestBed.createComponent(SimpleRefComponent);
+            fixture.detectChanges();
+            const overlayInstance = fixture.componentInstance.overlay;
+            const id = overlayInstance.attach(SimpleDynamicComponent);
+            const info = overlayInstance.getOverlayById(id);
+            const initialPositionSpy = spyOn(info.settings.positionStrategy, 'position').and.callThrough();
+
+            overlayInstance.show(id);
+            tick();
+
+            expect(initialPositionSpy).toHaveBeenCalledTimes(1);
+            overlayInstance.hide(id);
+            tick();
+
+            const os: OverlaySettings = {
+                excludeFromOutsideClick: [],
+                positionStrategy: new GlobalPositionStrategy(),
+                scrollStrategy: new CloseScrollStrategy(),
+                modal: false,
+                closeOnOutsideClick: false,
+                closeOnEscape: true
+            };
+            const lastPositionSpy = spyOn(os.positionStrategy, 'position').and.callThrough();
+            overlayInstance.show(id, os);
+            tick();
+
+            expect(lastPositionSpy).toHaveBeenCalledTimes(1);
+            expect(info.settings).toBe(os);
+        }));
     });
 
     describe('Unit Tests - Scroll Strategies: ', () => {

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.spec.ts
@@ -1407,7 +1407,8 @@ describe('igxOverlay', () => {
             tick();
 
             expect(lastPositionSpy).toHaveBeenCalledTimes(1);
-            expect(info.settings).toBe(os);
+            expect(info.settings.scrollStrategy).toBe(os.scrollStrategy);
+            expect(info.settings.positionStrategy).toBe(os.positionStrategy);
         }));
     });
 

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
@@ -411,7 +411,7 @@ export class IgxOverlayService implements OnDestroy {
             return;
         }
         if (settings) {
-            // TODO: update attach
+            info.settings = settings;
         }
         this.updateSize(info);
         info.settings.positionStrategy.position(

--- a/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
+++ b/projects/igniteui-angular/src/lib/services/overlay/overlay.ts
@@ -411,7 +411,9 @@ export class IgxOverlayService implements OnDestroy {
             return;
         }
         if (settings) {
-            info.settings = settings;
+            settings.positionStrategy ??= info.settings.positionStrategy;
+            settings.scrollStrategy ??= info.settings.scrollStrategy;
+            info.settings = { ...info.settings, ...settings };
         }
         this.updateSize(info);
         info.settings.positionStrategy.position(
@@ -592,7 +594,7 @@ export class IgxOverlayService implements OnDestroy {
                 const createSettings = viewContainerRefOrSettings as OverlayCreateSettings | undefined;
                 let elementInjector: Injector;
                 if (createSettings) {
-                    ({ injector: elementInjector, ...overlaySettings} = createSettings);
+                    ({ injector: elementInjector, ...overlaySettings } = createSettings);
                 }
                 dynamicComponent = createComponent(component, { environmentInjector, elementInjector });
                 this._appRef.attachView(dynamicComponent.hostView);
@@ -610,7 +612,7 @@ export class IgxOverlayService implements OnDestroy {
             info.elementRef = { nativeElement: element };
             info.componentRef = dynamicComponent;
         }
-        info.settings = Object.assign({}, this._defaultSettings, overlaySettings); 
+        info.settings = Object.assign({}, this._defaultSettings, overlaySettings);
         return info;
     }
 

--- a/src/app/overlay/overlay-animation.sample.html
+++ b/src/app/overlay/overlay-animation.sample.html
@@ -1,5 +1,6 @@
 <div #container>
-    <section class="sample-content">
+    <h5 style="text-align: center;">Move mouse over the avatars to start animations</h5>
+    <section class="sample-content padding">
         <igx-avatar id="audi" initials="BS" size="large" (mouseenter)="mouseenter($event)"
             (mouseleave)="mouseleave($event)">
         </igx-avatar>
@@ -8,6 +9,18 @@
         </igx-avatar>
         <igx-avatar id="mercedes" initials="DZ" size="large" (mouseenter)="mouseenter($event)"
             (mouseleave)="mouseleave($event)">
+        </igx-avatar>
+    </section>
+    <h5 style="text-align: center;">Move mouse over the avatars to reuse overlay settings</h5>
+    <section class="sample-content padding">
+        <igx-avatar id="audi" initials="BS" size="large" (mouseenter)="mouseenterReuse($event)"
+            (mouseleave)="mouseleaveReuse($event)">
+        </igx-avatar>
+        <igx-avatar id="bmw" initials="HK" size="large" (mouseenter)="mouseenterReuse($event)"
+            (mouseleave)="mouseleaveReuse($event)">
+        </igx-avatar>
+        <igx-avatar id="mercedes" initials="DZ" size="large" (mouseenter)="mouseenterReuse($event)"
+            (mouseleave)="mouseleaveReuse($event)">
         </igx-avatar>
     </section>
     <div igxToggle #audiToggle="toggle" style="max-width: 400px; min-width:250px;">
@@ -45,6 +58,17 @@
                 <p class="igx-card-content__text">Harald Krüger (born 13 October 1965 in Freiburg im Breisgau, West
                     Germany)
                     is the current chairman of the board of management (CEO) for BMW.</p>
+            </igx-card-content>
+        </igx-card>
+    </div>
+    <div igxToggle #commonToggle="toggle" style="max-width: 400px; min-width:250px;">
+        <igx-card>
+            <igx-card-header>
+                <h3 class="igx-card-header__title">No Name</h3>
+                <h5 class="igx-card-header__subtitle">No Company</h5>
+            </igx-card-header>
+            <igx-card-content>
+                <p class="igx-card-content__text">This is a common toggle with no specific information.</p>
             </igx-card-content>
         </igx-card>
     </div>

--- a/src/app/overlay/overlay-animation.sample.scss
+++ b/src/app/overlay/overlay-animation.sample.scss
@@ -8,3 +8,7 @@ $new-card-theme: card-theme(
 ::ng-deep {
     @include card($new-card-theme);
 }
+
+.padding {
+    gap: 2rem;
+}

--- a/src/app/overlay/overlay-animation.sample.ts
+++ b/src/app/overlay/overlay-animation.sample.ts
@@ -7,7 +7,9 @@ import {
     IgxToggleDirective,
     HorizontalAlignment,
     IgxAvatarComponent,
-    IGX_CARD_DIRECTIVES
+    IGX_CARD_DIRECTIVES,
+    ConnectedPositioningStrategy,
+    VerticalAlignment
 } from 'igniteui-angular';
 
 @Component({
@@ -20,6 +22,7 @@ export class OverlayAnimationSampleComponent {
     @ViewChild('audiToggle', { static: true }) public audiToggle: IgxToggleDirective;
     @ViewChild('bmwToggle', { static: true }) public bmwToggle: IgxToggleDirective;
     @ViewChild('mercedesToggle', { static: true }) public mercedesToggle: IgxToggleDirective;
+    @ViewChild('commonToggle', { static: true }) public commonToggle: IgxToggleDirective;
 
     private _overlaySettings: OverlaySettings = {
         positionStrategy: new GlobalPositionStrategy(),
@@ -58,7 +61,6 @@ export class OverlayAnimationSampleComponent {
                 break;
         }
     }
-
     public mouseleave(ev) {
         switch (ev.target.id) {
             case 'audi':
@@ -69,6 +71,51 @@ export class OverlayAnimationSampleComponent {
                 break;
             case 'mercedes':
                 this.mercedesToggle.close();
+                break;
+        }
+    }
+    public mouseenterReuse(ev) {
+        const os: OverlaySettings = {
+            positionStrategy: new ConnectedPositioningStrategy(),
+            scrollStrategy: new NoOpScrollStrategy(),
+            modal: false,
+            closeOnOutsideClick: false,
+        };
+    
+        os.positionStrategy.settings.horizontalDirection = HorizontalAlignment.Center;
+        os.positionStrategy.settings.horizontalStartPoint = HorizontalAlignment.Center;
+        os.positionStrategy.settings.verticalDirection = VerticalAlignment.Bottom;
+        os.positionStrategy.settings.verticalStartPoint = VerticalAlignment.Bottom;
+        os.target = ev.target;
+
+        const closeAnimationMetaData: AnimationMetadata[] = [
+            style({ opacity: `1`, transform: `scale(1)`, transformOrigin: `50% 50%` }),
+            animate(`6000ms`, style({ opacity: `0`, transform: `scale(0.5)`, transformOrigin: `50% 50%` }))
+        ];
+        const closeAnimation: AnimationReferenceMetadata = animation(closeAnimationMetaData);
+        this._overlaySettings.positionStrategy.settings.closeAnimation = closeAnimation;
+        switch (ev.target.id) {
+            case 'audi':
+                this.commonToggle.open(os);
+                break;
+            case 'bmw':
+                this.commonToggle.open(os);
+                break;
+            case 'mercedes':
+                this.commonToggle.open(os);
+                break;
+        }
+    }
+    public mouseleaveReuse(ev) {
+        switch (ev.target.id) {
+            case 'audi':
+                this.commonToggle.close();
+                break;
+            case 'bmw':
+                this.commonToggle.close();
+                break;
+            case 'mercedes':
+                this.commonToggle.close();
                 break;
         }
     }


### PR DESCRIPTION
Closes #15228
Use passed in `show` method `overlay settings`. We were skipping this and with this PR this should be fixed.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 