### PR TITLE
Use provided in open method partial overlay settings - 19.0

### DIFF
--- a/projects/igniteui-angular/src/lib/dialog/dialog.component.ts
+++ b/projects/igniteui-angular/src/lib/dialog/dialog.component.ts
@@ -478,6 +478,7 @@ export class IgxDialogComponent implements IToggleView, OnInit, OnDestroy, After
         const eventArgs: IDialogCancellableEventArgs = { dialog: this, event: null, cancel: false };
         this.opening.emit(eventArgs);
         if (!eventArgs.cancel) {
+            overlaySettings = { ...{}, ... this._overlayDefaultSettings, ...overlaySettings };
             this.toggleRef.open(overlaySettings);
             this.isOpenChange.emit(true);
             if (!this.leftButtonLabel && !this.rightButtonLabel) {

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down.component.spec.ts
@@ -256,7 +256,6 @@ describe('IgxDropDown ', () => {
                 expect(positionStrategy.settings.horizontalDirection).toBe(HorizontalAlignment.Right);
                 expect(positionStrategy.settings.verticalDirection).toBe(VerticalAlignment.Bottom);
             });
-
             it('should apply custom overlay settings if provided', () => {
                 const toggle: IgxToggleDirective = (dropdown as any).toggleDirective;
                 const customOverlaySettings: OverlaySettings = {
@@ -1266,6 +1265,31 @@ describe('IgxDropDown ', () => {
                 expect(dropdown.closing.emit).toHaveBeenCalledTimes(3);
                 expect(dropdown.closed.emit).toHaveBeenCalledTimes(3);
             }));
+            fit('#15137 - should bind to custom target if provided', fakeAsync(() => {
+                const input = fixture.debugElement.query(By.css('input'));
+                dropdown.open({ target: input.nativeElement });
+                tick();
+                fixture.detectChanges();
+
+                const dropdownItems = fixture.debugElement.queryAll(By.css(`.${CSS_CLASS_ITEM}`));
+                expect(dropdownItems).not.toBeUndefined();
+
+                const inputRect = input.nativeElement.getBoundingClientRect();
+                let dropdownRect = dropdownItems[0].nativeElement.getBoundingClientRect();
+                expect(dropdownRect.left).toBe(inputRect.left);
+                expect(dropdownRect.top).toBe(inputRect.bottom);
+
+                dropdown.close();
+                tick();
+                fixture.detectChanges();
+                dropdown.open();
+                tick();
+                fixture.detectChanges();
+
+                dropdownRect = dropdownItems[0].nativeElement.getBoundingClientRect();
+                expect(dropdownRect.left).toBe(0);
+                expect(dropdownRect.top).toBe(0);
+            }));
         });
     });
 });
@@ -1341,7 +1365,6 @@ class DoubleIgxDropDownComponent implements OnInit {
         }
     }
 }
-
 @Component({
     template: `
     <input (click)="toggleDropDown()">

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down.component.spec.ts
@@ -1265,7 +1265,7 @@ describe('IgxDropDown ', () => {
                 expect(dropdown.closing.emit).toHaveBeenCalledTimes(3);
                 expect(dropdown.closed.emit).toHaveBeenCalledTimes(3);
             }));
-            fit('#15137 - should bind to custom target if provided', fakeAsync(() => {
+            it('#15137 - should bind to custom target if provided', fakeAsync(() => {
                 const input = fixture.debugElement.query(By.css('input'));
                 dropdown.open({ target: input.nativeElement });
                 tick();

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down.component.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down.component.ts
@@ -243,7 +243,7 @@ export class IgxDropDownComponent extends IgxDropDownBaseDirective implements ID
      * ```
      */
     public open(overlaySettings?: OverlaySettings) {
-        const settings = overlaySettings || this.getDefaultOverlaySettings();
+        const settings = { ... {}, ...this.getDefaultOverlaySettings(), ...overlaySettings };
         this.toggleDirective.open(settings);
         this.updateScrollPosition();
     }


### PR DESCRIPTION
Closes #15137
Correctly merge passed in `toggle` and `open` methods partial overlay settings in `dropdown` and `dialog` components.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 