### PR TITLE
chore(action-strip): drop action button analyzer meta

### DIFF
--- a/projects/igniteui-angular/src/lib/action-strip/grid-actions/grid-action-button.component.ts
+++ b/projects/igniteui-angular/src/lib/action-strip/grid-actions/grid-action-button.component.ts
@@ -4,9 +4,6 @@ import { IgxRippleDirective } from '../../directives/ripple/ripple.directive';
 import { NgIf } from '@angular/common';
 import { IgxIconButtonDirective } from '../../directives/button/icon-button.directive';
 
-/* blazorElement */
-/* wcElementTag: igc-grid-action-button */
-/* blazorIndirectRender */
 @Component({
     selector: 'igx-grid-action-button',
     templateUrl: 'grid-action-button.component.html',


### PR DESCRIPTION
The grid action strip appears to be internal and isn't exposed from Elements, so dropping the analyzer meta

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 