### PR TITLE
fix(column): Update row island summaries when disabledSummaries changes - 19.1.x

### DIFF
--- a/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/columns/column.component.ts
@@ -1,4 +1,5 @@
 import { Subject } from 'rxjs';
+import { isEqual } from 'lodash-es';
 import {
     AfterContentInit,
     ChangeDetectorRef,
@@ -1090,12 +1091,16 @@ export class IgxColumnComponent implements AfterContentInit, OnDestroy, ColumnTy
      *
      * @memberof IgxColumnComponent
      */
+    @WatchColumnChanges()
     @Input()
     public get disabledSummaries(): string[] {
         return this._disabledSummaries;
     }
 
     public set disabledSummaries(value: string[]) {
+        if (isEqual(this._disabledSummaries, value)) {
+            return;
+        }
         this._disabledSummaries = value;
         if (this.grid) {
             this.grid.summaryService.removeSummariesCachePerColumn(this.field);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
@@ -160,9 +160,6 @@ describe('IgxGrid - Summaries #grid', () => {
 
                 const column = grid.getColumnByName('UnitsInStock');
 
-                column.disabledSummaries = [];
-                fixture.detectChanges();
-                tick();
                 GridSummaryFunctions.verifyColumnSummaries(
                     GridSummaryFunctions.getRootSummaryRow(fixture), 3,
                     ['Count', 'Min', 'Max', 'Sum', 'Avg'],

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.spec.ts
@@ -1085,6 +1085,40 @@ describe('Basic IgxHierarchicalGrid #hGrid', () => {
             expect(childGrid1.columns[0].editable).toBeTrue();
             expect(childGrid1.columns[1].editable).toBeTrue();
         });
+
+        it('should update the row island summary UI when disabledSummaries is changed at runtime', fakeAsync(() => {
+            const masterRow = hierarchicalGrid.gridAPI.get_row_by_index(0) as IgxHierarchicalRowComponent;
+            UIInteractions.simulateClickAndSelectEvent(masterRow.expander);
+            fixture.detectChanges();
+
+            const childGrid = hierarchicalGrid.gridAPI.getChildGrids(false)[0] as IgxHierarchicalGridComponent;
+            fixture.detectChanges();
+
+            childGrid.columns.forEach(c => c.hasSummary = true);
+            fixture.detectChanges();
+            tick();
+
+            const column = childGrid.columns.find(c => c.field === 'ProductName');
+            expect(column).toBeDefined();
+            fixture.detectChanges();
+            tick();
+
+            const summaryCells = childGrid.nativeElement.querySelectorAll('igx-grid-summary-cell');
+            const summaryCell = summaryCells[1];
+
+            expect(summaryCell).toBeDefined();
+            expect(summaryCell.textContent.trim().length).toBeGreaterThan(0);
+
+            const getterSpy = spyOnProperty(column, 'disabledSummaries', 'get').and.callThrough();
+
+            column.disabledSummaries = ['count'];
+            fixture.detectChanges();
+            tick();
+            fixture.detectChanges();
+
+            expect(getterSpy).toHaveBeenCalledTimes(7);
+            expect(summaryCell.textContent.trim()).toEqual('');
+        }));
     });
 
     describe('IgxHierarchicalGrid Children Sizing #hGrid', () => {


### PR DESCRIPTION
Closes #15424  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 