### PR TITLE
refactor(IgxGridSummaries): Refactor how summaries height is calculated.

### DIFF
--- a/projects/igniteui-angular/src/lib/core/styles/components/grid-summary/_grid-summary-theme.scss
+++ b/projects/igniteui-angular/src/lib/core/styles/components/grid-summary/_grid-summary-theme.scss
@@ -180,6 +180,8 @@
             min-height: sizable(rem(24px), rem(30px), rem(36px));
         }
 
+        flex-basis: sizable(rem(24px), rem(30px), rem(36px));
+
         position: relative;
     }
 

--- a/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/grid.interface.ts
@@ -947,7 +947,6 @@ export interface GridType extends IGridDataBindable {
     readonly transactions: TransactionService<Transaction, State>;
     /** Represents the validation service for the grid. The type contains properties and methods (logic) for validating records */
     readonly validation: IgxGridValidationService;
-    defaultSummaryHeight: number;
     summaryRowHeight: number;
     rowEditingOverlay: IgxToggleDirective;
     totalRowsCountAfterFilter: number;

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -298,9 +298,9 @@ export abstract class IgxGridBaseDirective implements GridType,
 
     public get summaryRowHeight(): number {
         if (this.hasSummarizedColumns && this.rootSummariesEnabled) {
-            return this._summaryRowHeight || this.summaryService.calcMaxSummaryHeight();
+            return this._summaryRowHeight || undefined;
         }
-        return 0;
+        return undefined;
     }
 
     /** @hidden @internal */
@@ -4303,20 +4303,6 @@ export abstract class IgxGridBaseDirective implements GridType,
      */
     public get defaultRowHeight(): number {
         return this._defaultRowHeight;
-    }
-
-    /**
-     * @hidden @internal
-     */
-    public get defaultSummaryHeight(): number {
-        switch (this.gridSize) {
-            case Size.Medium:
-                return 30;
-            case Size.Small:
-                return 24;
-            default:
-                return 36;
-        }
     }
 
     /**

--- a/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid-summary.spec.ts
@@ -31,6 +31,7 @@ describe('IgxGrid - Summaries #grid', () => {
     const SUMMARY_CELL = 'igx-grid-summary-cell';
     const EMPTY_SUMMARY_CLASS = 'igx-grid-summary--empty';
     const DEBOUNCETIME = 30;
+    const DEFAULT_SUMMARY_HEIGHT = 36;
 
     configureTestSuite((() => {
         return TestBed.configureTestingModule({
@@ -63,7 +64,7 @@ describe('IgxGrid - Summaries #grid', () => {
             it('should enableSummaries through grid API ', () => {
                 expect(grid.hasSummarizedColumns).toBe(false);
                 let tFoot = GridFunctions.getGridFooterWrapper(fixture).nativeElement.getBoundingClientRect().height;
-                expect(tFoot < grid.defaultSummaryHeight).toBe(true);
+                expect(tFoot < DEFAULT_SUMMARY_HEIGHT).toBe(true);
 
                 grid.enableSummaries([{ fieldName: 'ProductName' }, { fieldName: 'ProductID' }]);
                 fixture.detectChanges();
@@ -83,7 +84,7 @@ describe('IgxGrid - Summaries #grid', () => {
                 fixture.detectChanges();
 
                 tFoot = GridFunctions.getGridFooterWrapper(fixture).nativeElement.getBoundingClientRect().height;
-                expect(tFoot).toEqual(grid.defaultSummaryHeight);
+                expect(tFoot).toEqual(DEFAULT_SUMMARY_HEIGHT);
             });
 
             it(`should recalculate grid sizes correctly when the column is outside of the viewport`, () => {
@@ -95,7 +96,7 @@ describe('IgxGrid - Summaries #grid', () => {
                 fixture.detectChanges();
 
                 const tFoot = GridFunctions.getGridFooterWrapper(fixture).nativeElement.getBoundingClientRect().height;
-                expect(tFoot).toEqual(5 * grid.defaultSummaryHeight);
+                expect(tFoot).toEqual(5 * DEFAULT_SUMMARY_HEIGHT);
                 expect(GridSummaryFunctions.getRootSummaryRow(fixture)).toBeDefined();
             });
 
@@ -241,28 +242,28 @@ describe('IgxGrid - Summaries #grid', () => {
                 fixture.detectChanges();
 
                 const tFootHeight = GridFunctions.getGridFooterWrapper(fixture).nativeElement.getBoundingClientRect().height;
-                expect(tFootHeight).toBeGreaterThanOrEqual(3 * grid.defaultSummaryHeight);
+                expect(tFootHeight).toBeGreaterThanOrEqual(3 * DEFAULT_SUMMARY_HEIGHT);
             });
 
             it('should change custom summaries at runtime', () => {
                 const summaryRow = GridSummaryFunctions.getRootSummaryRow(fixture);
                 GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3, ['Count', 'Sum', 'Avg'], ['10', '39,004', '3,900.4']);
                 GridSummaryFunctions.verifyColumnSummaries(summaryRow, 4, ['Earliest', 'Items InStock'], ['May 17, 1990', '1337']);
-                GridSummaryFunctions.verifyVisibleSummariesHeight(fixture, 3, grid.defaultSummaryHeight);
+                GridSummaryFunctions.verifyVisibleSummariesHeight(fixture, 3, DEFAULT_SUMMARY_HEIGHT);
                 grid.getColumnByName('UnitsInStock').summaries = fixture.componentInstance.dealsSummaryMinMax;
                 grid.summaryRowHeight = 0;
                 fixture.detectChanges();
                 const tFootHeight = GridFunctions.getGridFooterWrapper(fixture).nativeElement.getBoundingClientRect().height;
-                expect(tFootHeight).toBe(2 * grid.defaultSummaryHeight);
+                expect(tFootHeight).toBe(2 * DEFAULT_SUMMARY_HEIGHT);
                 GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3, ['Min', 'Max'], ['0', '20,000']);
-                GridSummaryFunctions.verifyVisibleSummariesHeight(fixture, 2, grid.defaultSummaryHeight);
+                GridSummaryFunctions.verifyVisibleSummariesHeight(fixture, 2, DEFAULT_SUMMARY_HEIGHT);
             });
 
             it('should be able to access alldata from each summary', () => {
                 const summaryRow = GridSummaryFunctions.getRootSummaryRow(fixture);
                 GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3, ['Count', 'Sum', 'Avg'], ['10', '39,004', '3,900.4']);
                 GridSummaryFunctions.verifyColumnSummaries(summaryRow, 4, ['Earliest', 'Items InStock'], ['May 17, 1990', '1337']);
-                GridSummaryFunctions.verifyVisibleSummariesHeight(fixture, 3, grid.defaultSummaryHeight);
+                GridSummaryFunctions.verifyVisibleSummariesHeight(fixture, 3, DEFAULT_SUMMARY_HEIGHT);
                 grid.getColumnByName('UnitsInStock').summaries = fixture.componentInstance.inStockSummary;
                 fixture.detectChanges();
 
@@ -395,8 +396,8 @@ describe('IgxGrid - Summaries #grid', () => {
                 const summaryRow = GridSummaryFunctions.getRootSummaryRow(fix);
                 const tFootHeight = GridFunctions.getGridFooterWrapper(fix).nativeElement.getBoundingClientRect().height;
                 GridSummaryFunctions.verifyColumnSummaries(summaryRow, 3, ['Min', 'Max'], ['0', '20,000']);
-                GridSummaryFunctions.verifyVisibleSummariesHeight(fix, 3, grid.defaultSummaryHeight);
-                expect(tFootHeight).toBe(3 * grid.defaultSummaryHeight);
+                GridSummaryFunctions.verifyVisibleSummariesHeight(fix, 3, DEFAULT_SUMMARY_HEIGHT);
+                expect(tFootHeight).toBe(3 * DEFAULT_SUMMARY_HEIGHT);
             });
 
             it('should have summary per each column that \'hasSummary\'= true', () => {
@@ -523,7 +524,7 @@ describe('IgxGrid - Summaries #grid', () => {
                 grid.summaryRowHeight = null;
                 fix.detectChanges();
 
-                const expectedHeight = GridSummaryFunctions.calcMaxSummaryHeight(grid.columnList, summaries, grid.defaultSummaryHeight);
+                const expectedHeight = GridSummaryFunctions.calcMaxSummaryHeight(grid.columnList, summaries, DEFAULT_SUMMARY_HEIGHT);
 
                 expect(tfootSize).toBe(expectedHeight);
             });
@@ -544,7 +545,7 @@ describe('IgxGrid - Summaries #grid', () => {
                 const summaries = fix.debugElement.queryAll(By.css(SUMMARY_CELL)).filter((el) =>
                     el.nativeElement.classList.contains(EMPTY_SUMMARY_CLASS) === false);
                 const tfootSize = GridSummaryFunctions.getRootSummaryRow(fix).nativeElement.getBoundingClientRect().height;
-                const expectedHeight = GridSummaryFunctions.calcMaxSummaryHeight(grid.columnList, summaries, grid.defaultSummaryHeight);
+                const expectedHeight = GridSummaryFunctions.calcMaxSummaryHeight(grid.columnList, summaries, DEFAULT_SUMMARY_HEIGHT);
                 expect(tfootSize).toBe(expectedHeight);
 
                 grid.getColumnByName('ProductName').hasSummary = false;
@@ -796,14 +797,14 @@ describe('IgxGrid - Summaries #grid', () => {
             it('Hiding: should recalculate summary area after column with enabled summary is hidden', fakeAsync(() => {
                 grid.summaryRowHeight = undefined;
                 let tFoot = GridFunctions.getGridFooterWrapper(fix).nativeElement.getBoundingClientRect().height;
-                expect(tFoot).toEqual(5 * grid.defaultSummaryHeight);
+                expect(tFoot).toEqual(5 * DEFAULT_SUMMARY_HEIGHT);
 
                 grid.getColumnByName('UnitsInStock').hidden = true;
                 tick();
                 fix.detectChanges();
 
                 tFoot = GridFunctions.getGridFooterWrapper(fix).nativeElement.getBoundingClientRect().height;
-                expect(tFoot).toEqual(3 * grid.defaultSummaryHeight);
+                expect(tFoot).toEqual(3 * DEFAULT_SUMMARY_HEIGHT);
                 expect(grid.hasSummarizedColumns).toBe(true);
 
                 let summaryRow = fix.debugElement.query(By.css(SUMMARY_ROW));
@@ -820,7 +821,7 @@ describe('IgxGrid - Summaries #grid', () => {
 
                 expect(grid.hasSummarizedColumns).toBe(true);
                 tFoot = GridFunctions.getGridFooterWrapper(fix).nativeElement.getBoundingClientRect().height;
-                expect(tFoot).toEqual(5 * grid.defaultSummaryHeight);
+                expect(tFoot).toEqual(5 * DEFAULT_SUMMARY_HEIGHT);
                 summaryRow = fix.debugElement.query(By.css(SUMMARY_ROW));
                 GridSummaryFunctions.verifyColumnSummaries(summaryRow, 0, [], []);
                 GridSummaryFunctions.verifyColumnSummaries(summaryRow, 1, ['Count'], ['10']);
@@ -1904,7 +1905,7 @@ describe('IgxGrid - Summaries #grid', () => {
             grid.getColumnByName('ParentID').hasSummary = false;
             fix.detectChanges();
 
-            GridSummaryFunctions.verifyVisibleSummariesHeight(fix, 3, grid.defaultSummaryHeight);
+            GridSummaryFunctions.verifyVisibleSummariesHeight(fix, 3, DEFAULT_SUMMARY_HEIGHT);
 
             let summaries = GridSummaryFunctions.getAllVisibleSummaries(fix);
             summaries.forEach(summary => {
@@ -1927,7 +1928,7 @@ describe('IgxGrid - Summaries #grid', () => {
             fix.detectChanges();
 
             expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(5);
-            GridSummaryFunctions.verifyVisibleSummariesHeight(fix, 1, grid.defaultSummaryHeight);
+            GridSummaryFunctions.verifyVisibleSummariesHeight(fix, 1, DEFAULT_SUMMARY_HEIGHT);
             summaries = GridSummaryFunctions.getAllVisibleSummaries(fix);
             summaries.forEach(summary => {
                 GridSummaryFunctions.verifyColumnSummaries(summary, 0, [], []);
@@ -2110,7 +2111,7 @@ describe('IgxGrid - Summaries #grid', () => {
             grid.summaryRowHeight = 0;
             fix.detectChanges();
 
-            GridSummaryFunctions.verifyVisibleSummariesHeight(fix, 3, grid.defaultSummaryHeight);
+            GridSummaryFunctions.verifyVisibleSummariesHeight(fix, 3, DEFAULT_SUMMARY_HEIGHT);
 
             let summaries = GridSummaryFunctions.getAllVisibleSummaries(fix);
 
@@ -2134,7 +2135,7 @@ describe('IgxGrid - Summaries #grid', () => {
             fix.detectChanges();
 
             expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(5);
-            GridSummaryFunctions.verifyVisibleSummariesHeight(fix, 1, grid.defaultSummaryHeight);
+            GridSummaryFunctions.verifyVisibleSummariesHeight(fix, 1, DEFAULT_SUMMARY_HEIGHT);
             summaries = GridSummaryFunctions.getAllVisibleSummaries(fix);
             summaries.forEach(summary => {
                 GridSummaryFunctions.verifyColumnSummaries(summary, 0, [], []);

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.component.spec.ts
@@ -36,6 +36,7 @@ describe('IgxGrid Component Tests #grid', () => {
 
     const TBODY_CLASS = '.igx-grid__tbody-content';
     const THEAD_CLASS = '.igx-grid-thead';
+    const DEFAULT_SUMMARY_HEIGHT = 36;
 
     configureTestSuite();
 
@@ -290,8 +291,8 @@ describe('IgxGrid Component Tests #grid', () => {
             expect(grid.defaultRowHeight).toBe(50);
             expect(headerHight.offsetHeight).toBe(grid.defaultRowHeight);
             expect(rowHeight.offsetHeight).toBe(51);
-            expect(summaryItemHeight.offsetHeight).toBe(grid.defaultSummaryHeight - 1);
-            expect(summaryRowHeight.offsetHeight).toBe(grid.defaultSummaryHeight);
+            expect(summaryItemHeight.offsetHeight).toBe(DEFAULT_SUMMARY_HEIGHT - 1);
+            expect(summaryRowHeight.offsetHeight).toBe(DEFAULT_SUMMARY_HEIGHT);
             setElementSize(grid.nativeElement, Size.Medium)
             grid.summaryRowHeight = null;
             fixture.detectChanges();
@@ -302,8 +303,8 @@ describe('IgxGrid Component Tests #grid', () => {
             expect(grid.defaultRowHeight).toBe(40);
             expect(headerHight.offsetHeight).toBe(grid.defaultRowHeight);
             expect(rowHeight.offsetHeight).toBe(41);
-            expect(summaryItemHeight.offsetHeight).toBe(grid.defaultSummaryHeight - 1);
-            expect(summaryRowHeight.offsetHeight).toBe(grid.defaultSummaryHeight);
+            expect(summaryItemHeight.offsetHeight).toBe(DEFAULT_SUMMARY_HEIGHT - 1);
+            expect(summaryRowHeight.offsetHeight).toBe(DEFAULT_SUMMARY_HEIGHT);
             setElementSize(grid.nativeElement, Size.Small)
             grid.summaryRowHeight = undefined;
             fixture.detectChanges();
@@ -314,8 +315,8 @@ describe('IgxGrid Component Tests #grid', () => {
             expect(grid.defaultRowHeight).toBe(32);
             expect(headerHight.offsetHeight).toBe(grid.defaultRowHeight);
             expect(rowHeight.offsetHeight).toBe(33);
-            expect(summaryItemHeight.offsetHeight).toBe(grid.defaultSummaryHeight - 1);
-            expect(summaryRowHeight.offsetHeight).toBe(grid.defaultSummaryHeight);
+            expect(summaryItemHeight.offsetHeight).toBe(DEFAULT_SUMMARY_HEIGHT - 1);
+            expect(summaryRowHeight.offsetHeight).toBe(DEFAULT_SUMMARY_HEIGHT);
         });
 
         it ('checks if attributes are correctly assigned when grid has or does not have data', fakeAsync( () => {

--- a/projects/igniteui-angular/src/lib/grids/grid/grid.summary.pipe.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid/grid.summary.pipe.ts
@@ -33,7 +33,6 @@ export class IgxGridSummaryPipe implements PipeTransform {
     private addSummaryRows(gridId: string, collection: IGroupByResult, summaryPosition: GridSummaryPosition, showSummary): any[] {
         const recordsWithSummary = [];
         const lastChildMap = new Map<any, IGroupByRecord[]>();
-        const maxSummaryHeight = this.grid.summaryService.calcMaxSummaryHeight();
 
         if (collection.metadata.length && !this.grid.isGroupByRecord(collection.data[0]) &&
             this.grid.isGroupByRecord(collection.metadata[0]) && summaryPosition === GridSummaryPosition.bottom) {
@@ -67,8 +66,7 @@ export class IgxGridSummaryPipe implements PipeTransform {
                 const records = this.removeDeletedRecord(this.grid, groupByRecord.records.slice());
                 const summaries = this.grid.summaryService.calculateSummaries(recordId, records);
                 const summaryRecord: ISummaryRecord = {
-                    summaries,
-                    max: maxSummaryHeight
+                    summaries
                 };
                 recordsWithSummary.push(summaryRecord);
             }
@@ -80,8 +78,7 @@ export class IgxGridSummaryPipe implements PipeTransform {
                     const records = this.removeDeletedRecord(this.grid, groupRecord.records.slice());
                     const summaries = this.grid.summaryService.calculateSummaries(groupRecordId, records, groupRecord);
                     const summaryRecord: ISummaryRecord = {
-                        summaries,
-                        max: maxSummaryHeight
+                        summaries
                     };
                     recordsWithSummary.push(summaryRecord);
                 }
@@ -96,8 +93,7 @@ export class IgxGridSummaryPipe implements PipeTransform {
                 const records = this.removeDeletedRecord(this.grid, groupByRecord.records.slice());
                 const summaries = this.grid.summaryService.calculateSummaries(recordId, records, groupByRecord);
                 const summaryRecord: ISummaryRecord = {
-                    summaries,
-                    max: maxSummaryHeight
+                    summaries
                 };
                 recordsWithSummary.push(summaryRecord);
             } else if (summaryPosition === GridSummaryPosition.bottom) {

--- a/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.integration.spec.ts
+++ b/projects/igniteui-angular/src/lib/grids/hierarchical-grid/hierarchical-grid.integration.spec.ts
@@ -32,6 +32,7 @@ describe('IgxHierarchicalGrid Integration #hGrid', () => {
 
     const FILTERING_ROW_CLASS = 'igx-grid-filtering-row';
     const FILTERING_CELL_CLASS = 'igx-grid-filtering-cell';
+    const DEFAULT_SUMMARY_HEIGHT = 36;
 
     configureTestSuite();
 
@@ -497,8 +498,8 @@ describe('IgxHierarchicalGrid Integration #hGrid', () => {
             let tFoot = hierarchicalGrid.nativeElement.querySelector('.igx-grid__tfoot');
             let childTFoot = childGrid.nativeElement.querySelector('.igx-grid__tfoot');
 
-            expect(tFoot.getBoundingClientRect().height).toBe(hierarchicalGrid.defaultSummaryHeight);
-            expect(childTFoot.getBoundingClientRect().height).toBe(hierarchicalGrid.defaultSummaryHeight);
+            expect(tFoot.getBoundingClientRect().height).toBe(DEFAULT_SUMMARY_HEIGHT);
+            expect(childTFoot.getBoundingClientRect().height).toBe(DEFAULT_SUMMARY_HEIGHT);
 
 
             setElementSize(hierarchicalGrid.nativeElement, Size.Medium)
@@ -510,8 +511,8 @@ describe('IgxHierarchicalGrid Integration #hGrid', () => {
             tFoot = hierarchicalGrid.nativeElement.querySelectorAll('.igx-grid__tfoot')[1];
             childTFoot = childGrid.nativeElement.querySelector('.igx-grid__tfoot');
 
-            expect(tFoot.getBoundingClientRect().height).toBe(hierarchicalGrid.defaultSummaryHeight);
-            expect(childTFoot.getBoundingClientRect().height).toBe(hierarchicalGrid.defaultSummaryHeight);
+            expect(tFoot.getBoundingClientRect().height).toBe(DEFAULT_SUMMARY_HEIGHT);
+            expect(childTFoot.getBoundingClientRect().height).toBe(DEFAULT_SUMMARY_HEIGHT);
 
             setElementSize(hierarchicalGrid.nativeElement, Size.Small)
             hierarchicalGrid.summaryRowHeight = 0;
@@ -522,8 +523,8 @@ describe('IgxHierarchicalGrid Integration #hGrid', () => {
             tFoot = hierarchicalGrid.nativeElement.querySelectorAll('.igx-grid__tfoot')[1];
             childTFoot = childGrid.nativeElement.querySelector('.igx-grid__tfoot');
 
-            expect(tFoot.getBoundingClientRect().height).toBe(hierarchicalGrid.defaultSummaryHeight);
-            expect(childTFoot.getBoundingClientRect().height).toBe(hierarchicalGrid.defaultSummaryHeight);
+            expect(tFoot.getBoundingClientRect().height).toBe(DEFAULT_SUMMARY_HEIGHT);
+            expect(childTFoot.getBoundingClientRect().height).toBe(DEFAULT_SUMMARY_HEIGHT);
         })
 
         it('should render summaries for column inside a column group.', fakeAsync(() => {

--- a/projects/igniteui-angular/src/lib/grids/summaries/grid-summary.ts
+++ b/projects/igniteui-angular/src/lib/grids/summaries/grid-summary.ts
@@ -32,7 +32,6 @@ export interface IgxSummaryResult {
 
 export interface ISummaryRecord {
     summaries: Map<string, IgxSummaryResult[]>;
-    max?: number;
     cellIndentation?: number;
 }
 

--- a/projects/igniteui-angular/src/lib/grids/summaries/summary-cell.component.html
+++ b/projects/igniteui-angular/src/lib/grids/summaries/summary-cell.component.html
@@ -1,14 +1,14 @@
-@if (hasSummary) {
-    <ng-container *ngTemplateOutlet="summaryTemplate ? summaryTemplate : defaultSummary; context: { $implicit: summaryResults }">
-    </ng-container>
-}
+<ng-container *ngTemplateOutlet="(summaryTemplate && hasSummary) ? summaryTemplate : defaultSummary; context: { $implicit: summaryResults }">
+</ng-container>
 <ng-template #defaultSummary>
     @for (summary of summaryResults; track trackSummaryResult(summary)) {
-        <div class="igx-grid-summary__item" [style.height.px]="itemHeight">
-            <span class="igx-grid-summary__label" [title]="summary.label">{{ translateSummary(summary) }}</span>
-            <span class="igx-grid-summary__result" [title]="formatSummaryResult(summary)">
-                {{ formatSummaryResult(summary) }}
-            </span>
+        <div class="igx-grid-summary__item">
+            @if (hasSummary) {
+                <span class="igx-grid-summary__label" [title]="summary.label">{{ translateSummary(summary) }}</span>
+                <span class="igx-grid-summary__result" [title]="formatSummaryResult(summary)">
+                    {{ formatSummaryResult(summary) }}
+                </span>
+            }
         </div>
     }
 </ng-template>

--- a/projects/igniteui-angular/src/lib/grids/summaries/summary-cell.component.ts
+++ b/projects/igniteui-angular/src/lib/grids/summaries/summary-cell.component.ts
@@ -88,10 +88,6 @@ export class IgxSummaryCellComponent {
         return this.column.dataType;
     }
 
-    public get itemHeight() {
-        return this.column.grid.defaultSummaryHeight;
-    }
-
     /**
      * @hidden
      */

--- a/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.summary.pipe.ts
+++ b/projects/igniteui-angular/src/lib/grids/tree-grid/tree-grid.summary.pipe.ts
@@ -40,7 +40,6 @@ export class IgxTreeGridSummaryPipe implements PipeTransform {
                 const summaries = grid.summaryService.calculateSummaries(record.key, childData);
                 const summaryRecord: ISummaryRecord = {
                     summaries,
-                    max: maxSummaryHeight,
                     cellIndentation: record.level + 1
                 };
                 recordsWithSummary.push(summaryRecord);
@@ -59,7 +58,6 @@ export class IgxTreeGridSummaryPipe implements PipeTransform {
                         const summaries = grid.summaryService.calculateSummaries(parent.key, childData);
                         const summaryRecord: ISummaryRecord = {
                             summaries,
-                            max: maxSummaryHeight,
                             cellIndentation: parent.level + 1
                         };
                         recordsWithSummary.push(summaryRecord);
@@ -76,7 +74,6 @@ export class IgxTreeGridSummaryPipe implements PipeTransform {
                 const summaries = grid.summaryService.calculateSummaries(record.key, childData);
                 const summaryRecord: ISummaryRecord = {
                     summaries,
-                    max: maxSummaryHeight,
                     cellIndentation: record.level + 1
                 };
                 recordsWithSummary.push(summaryRecord);


### PR DESCRIPTION
Related to #15603 

This is related to the purging of  hardcoded sizes as part of part 1. from https://github.com/IgniteUI/igniteui-angular/issues/14048#issuecomment-2736581106. Specifically `defaultSummaryHeight`.

This is more of a proposal (hence why it's a draft), since it introduces some breaking changes and will probably break a lot of tests. So it would be best to evaluate it before putting in the effort. 

In general, the reason for the `defaultSummaryHeight`'s hardcoded values is due to the fact that horizontal virtualization renders only the visible part of the summary row and summaries can have different size depending on the number of summaries per column. To have consistent size between chunks it currently sets a fixed summary height = `defaultSummaryHeight` * the max summary length for all columns in the grid.

So to remove the hardcoded sizes and just have the dom flex and size itself I've changed the structure in the summary cell so it renders and item (empty if there's no summary there) for all summaries up to the total summaries count in the grid and have them use css with `flex-basis` based on the density. For example:

![image](https://github.com/user-attachments/assets/da6795b6-3dc9-4700-ab5e-8c1d91bc8ec1)

That way everything should flex with the content correctly without hardcoded sizes. 


### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [x] Refactor

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 