### PR TITLE
fix(month-picker): correct date format for year

### DIFF
--- a/projects/igniteui-angular/src/lib/calendar/calendar-base.ts
+++ b/projects/igniteui-angular/src/lib/calendar/calendar-base.ts
@@ -445,7 +445,7 @@ export class IgxCalendarBaseDirective implements ControlValueAccessor {
             case 'month':
                 return `${this.resourceStrings.igx_calendar_previous_month}, ${detail}`
             case 'year':
-                return this.resourceStrings.igx_calendar_previous_year.replace('{0}', '15');
+                return this.resourceStrings.igx_calendar_previous_year;
             case 'decade':
                 return this.resourceStrings.igx_calendar_previous_years.replace('{0}', '15');
         }
@@ -456,7 +456,7 @@ export class IgxCalendarBaseDirective implements ControlValueAccessor {
             case 'month':
                 return `${this.resourceStrings.igx_calendar_next_month}, ${detail}`
             case 'year':
-                return this.resourceStrings.igx_calendar_next_year.replace('{0}', '15');
+                return this.resourceStrings.igx_calendar_next_year;
             case 'decade':
                 return this.resourceStrings.igx_calendar_next_years.replace('{0}', '15');
         }

--- a/projects/igniteui-angular/src/lib/calendar/month-picker/month-picker.component.html
+++ b/projects/igniteui-angular/src/lib/calendar/month-picker/month-picker.component.html
@@ -15,7 +15,7 @@
         tabindex="0"
         class="igx-calendar-picker__prev"
         role="button"
-        [attr.aria-label]="prevNavLabel((getPrevYearDate(viewDate) | date: 'YYYY'))"
+        [attr.aria-label]="prevNavLabel((getPrevYearDate(viewDate) | date: 'yyyy'))"
         data-action="prev"
         igxCalendarScrollPage
         (mousedown)="previousPage()"
@@ -32,7 +32,7 @@
         tabindex="0"
         class="igx-calendar-picker__next"
         role="button"
-        [attr.aria-label]="nextNavLabel((getNextYearDate(viewDate) | date: 'YYYY'))"
+        [attr.aria-label]="nextNavLabel((getNextYearDate(viewDate) | date: 'yyyy'))"
         data-action="next"
         igxCalendarScrollPage
         (mousedown)="nextPage()"


### PR DESCRIPTION
With ng 20 this produces an error 
> NG02300: Suspicious use of week-based year "Y" in date pattern "YYYY". Did you mean to use calendar year "y" instead?

https://github.com/IgniteUI/igniteui-angular/actions/runs/15328149840/job/43168292297#step:11:544

Technically, on edge weeks the week year can return perv year value instead which isn't expected in this use indeed.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 