### PR TITLE
refactor(*): replace mkenum with const assertion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes for each version of this project will be documented in this file.
 
+## 20.0.0
+
+### General
+- `IgxChip`
+    - **Behavioral Change** The `variant` is now strictly typed with the union of supported options and no longer accepts invalid values for the default state, provide no value (nullish) instead is needed.
+
 ## 19.2.0
 
 ### General

--- a/projects/igniteui-angular/src/lib/avatar/avatar.component.ts
+++ b/projects/igniteui-angular/src/lib/avatar/avatar.component.ts
@@ -9,23 +9,23 @@ import {
     ViewChild
 } from '@angular/core';
 
-import { mkenum, normalizeURI } from '../core/utils';
+import { normalizeURI } from '../core/utils';
 import { IgxIconComponent } from '../icon/icon.component';
 
 let NEXT_ID = 0;
-export const IgxAvatarSize = /*@__PURE__*/mkenum({
+export const IgxAvatarSize = {
     SMALL: 'small',
     MEDIUM: 'medium',
     LARGE: 'large'
-});
+} as const;
 export type IgxAvatarSize = (typeof IgxAvatarSize)[keyof typeof IgxAvatarSize];
 
-export const IgxAvatarType = /*@__PURE__*/mkenum({
+export const IgxAvatarType = {
     INITIALS: 'initials',
     IMAGE: 'image',
     ICON: 'icon',
     CUSTOM: 'custom'
-});
+} as const;
 export type IgxAvatarType = (typeof IgxAvatarType)[keyof typeof IgxAvatarType];
 
 /**

--- a/projects/igniteui-angular/src/lib/badge/badge.component.ts
+++ b/projects/igniteui-angular/src/lib/badge/badge.component.ts
@@ -1,5 +1,4 @@
 import { booleanAttribute, Component, HostBinding, Input } from '@angular/core';
-import { mkenum } from '../core/utils';
 import { IgxIconComponent } from '../icon/icon.component';
 
 let NEXT_ID = 0;
@@ -7,13 +6,13 @@ let NEXT_ID = 0;
 /**
  * Determines the igxBadge type
  */
-export const IgxBadgeType = /*@__PURE__*/mkenum({
+export const IgxBadgeType = {
     PRIMARY: 'primary',
     INFO: 'info',
     SUCCESS: 'success',
     WARNING: 'warning',
     ERROR: 'error'
-});
+} as const;
 export type IgxBadgeType = (typeof IgxBadgeType)[keyof typeof IgxBadgeType];
 /**
  * Badge provides visual notifications used to decorate avatars, menus, etc.

--- a/projects/igniteui-angular/src/lib/buttonGroup/buttonGroup.component.ts
+++ b/projects/igniteui-angular/src/lib/buttonGroup/buttonGroup.component.ts
@@ -20,16 +20,15 @@ import { IgxRippleDirective } from '../directives/ripple/ripple.directive';
 
 import { takeUntil } from 'rxjs/operators';
 import { IBaseEventArgs } from '../core/utils';
-import { mkenum } from '../core/utils';
 import { IgxIconComponent } from '../icon/icon.component';
 
 /**
  * Determines the Button Group alignment
  */
-export const ButtonGroupAlignment = mkenum({
+export const ButtonGroupAlignment = {
     horizontal: 'horizontal',
     vertical: 'vertical'
-});
+} as const;
 export type ButtonGroupAlignment = typeof ButtonGroupAlignment[keyof typeof ButtonGroupAlignment];
 
 let NEXT_ID = 0;

--- a/projects/igniteui-angular/src/lib/calendar/calendar.ts
+++ b/projects/igniteui-angular/src/lib/calendar/calendar.ts
@@ -1,13 +1,12 @@
-import { mkenum } from '../core/utils';
 
 /**
  * Sets the selection type - single, multi or range.
  */
-export const CalendarSelection = /*@__PURE__*/mkenum({
+export const CalendarSelection = {
     SINGLE: 'single',
     MULTI: 'multi',
     RANGE: 'range'
-});
+} as const;
 export type CalendarSelection = (typeof CalendarSelection)[keyof typeof CalendarSelection];
 
 export const enum ScrollDirection {
@@ -21,11 +20,11 @@ export interface IViewDateChangeEventArgs {
     currentValue: Date;
 }
 
-export const IgxCalendarView = /*@__PURE__*/mkenum({
+export const IgxCalendarView = {
     Month: 'month',
     Year: 'year',
     Decade: 'decade'
-});
+} as const;
 
 /**
  * Determines the Calendar active view - days, months or years.

--- a/projects/igniteui-angular/src/lib/card/card.component.ts
+++ b/projects/igniteui-angular/src/lib/card/card.component.ts
@@ -11,8 +11,6 @@ import {
     booleanAttribute
 } from '@angular/core';
 
-import { mkenum } from '../core/utils';
-
 let NEXT_ID = 0;
 
 /**
@@ -269,10 +267,10 @@ export class IgxCardComponent {
     public horizontal = false;
 }
 
-export const IgxCardActionsLayout = /*@__PURE__*/mkenum({
+export const IgxCardActionsLayout = {
     START: 'start',
     JUSTIFY: 'justify'
-});
+} as const;
 export type IgxCardActionsLayout = (typeof IgxCardActionsLayout)[keyof typeof IgxCardActionsLayout];
 
 /**

--- a/projects/igniteui-angular/src/lib/carousel/enums.ts
+++ b/projects/igniteui-angular/src/lib/carousel/enums.ts
@@ -1,13 +1,12 @@
-import { mkenum } from '../core/utils';
 
-export const CarouselAnimationType = /*@__PURE__*/mkenum({
+export const CarouselAnimationType = {
     none: 'none',
     slide: 'slide',
     fade: 'fade'
-});
+} as const;
 export type CarouselAnimationType = (typeof CarouselAnimationType)[keyof typeof CarouselAnimationType];
 
-export const CarouselIndicatorsOrientation = /*@__PURE__*/mkenum({
+export const CarouselIndicatorsOrientation = {
     /**
      * @deprecated in version 19.1.0. Use `end` instead.
      */
@@ -18,5 +17,5 @@ export const CarouselIndicatorsOrientation = /*@__PURE__*/mkenum({
     top: 'top',
     start: 'start',
     end: 'end'
-});
+} as const;
 export type CarouselIndicatorsOrientation = (typeof CarouselIndicatorsOrientation)[keyof typeof CarouselIndicatorsOrientation];

--- a/projects/igniteui-angular/src/lib/checkbox/checkbox-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/checkbox/checkbox-base.directive.ts
@@ -17,7 +17,7 @@ import {
     AfterViewInit,
 } from '@angular/core';
 import { NgControl, Validators } from '@angular/forms';
-import { IBaseEventArgs, getComponentTheme, mkenum } from '../core/utils';
+import { IBaseEventArgs, getComponentTheme } from '../core/utils';
 import { noop, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import {
@@ -26,10 +26,10 @@ import {
     ThemeToken,
 } from '../services/theme/theme.token';
 
-export const LabelPosition = /*@__PURE__*/ mkenum({
+export const LabelPosition = {
     BEFORE: 'before',
     AFTER: 'after'
-});
+} as const;
 export type LabelPosition = typeof LabelPosition[keyof typeof LabelPosition];
 
 export interface IChangeCheckboxEventArgs extends IBaseEventArgs {

--- a/projects/igniteui-angular/src/lib/chips/chip.component.ts
+++ b/projects/igniteui-angular/src/lib/chips/chip.component.ts
@@ -17,7 +17,7 @@ import {
     DOCUMENT
 } from '@angular/core';
 import { IgxDragDirective, IDragBaseEventArgs, IDragStartEventArgs, IDropBaseEventArgs, IDropDroppedEventArgs, IgxDropDirective } from '../directives/drag-drop/drag-drop.directive';
-import { IBaseEventArgs, mkenum } from '../core/utils';
+import { IBaseEventArgs } from '../core/utils';
 import { ChipResourceStringsEN, IChipResourceStrings } from '../core/i18n/chip-resources';
 import { Subject } from 'rxjs';
 import { IgxIconComponent } from '../icon/icon.component';
@@ -25,13 +25,13 @@ import { NgClass, NgTemplateOutlet } from '@angular/common';
 import { getCurrentResourceStrings } from '../core/i18n/resources';
 import { Size } from '../grids/common/enums';
 
-export const IgxChipTypeVariant = /*@__PURE__*/mkenum({
+export const IgxChipTypeVariant = {
     PRIMARY: 'primary',
     INFO: 'info',
     SUCCESS: 'success',
     WARNING: 'warning',
     DANGER: 'danger'
-});
+} as const;
 
 export interface IBaseChipEventArgs extends IBaseEventArgs {
     originalEvent: IDragBaseEventArgs | IDropBaseEventArgs | KeyboardEvent | MouseEvent | TouchEvent;

--- a/projects/igniteui-angular/src/lib/chips/chip.component.ts
+++ b/projects/igniteui-angular/src/lib/chips/chip.component.ts
@@ -32,6 +32,7 @@ export const IgxChipTypeVariant = {
     WARNING: 'warning',
     DANGER: 'danger'
 } as const;
+export type IgxChipTypeVariant = (typeof IgxChipTypeVariant)[keyof typeof IgxChipTypeVariant];
 
 export interface IBaseChipEventArgs extends IBaseEventArgs {
     originalEvent: IDragBaseEventArgs | IDropBaseEventArgs | KeyboardEvent | MouseEvent | TouchEvent;
@@ -93,15 +94,15 @@ export class IgxChipComponent implements OnInit, OnDestroy {
      *
      * @remarks
      * Allowed values are `primary`, `info`, `success`, `warning`, `danger`.
-     * Providing an invalid value won't change the chip.
+     * Providing no/nullish value leaves the chip in its default state.
      *
      * @example
      * ```html
-     * <igx-chip [variant]="success"></igx-chip>
+     * <igx-chip variant="success"></igx-chip>
      * ```
      */
     @Input()
-    public variant: string | typeof IgxChipTypeVariant;
+    public variant?: IgxChipTypeVariant | null;
     /**
      * Sets the value of `id` attribute. If not provided it will be automatically generated.
      *

--- a/projects/igniteui-angular/src/lib/core/utils.ts
+++ b/projects/igniteui-angular/src/lib/core/utils.ts
@@ -20,8 +20,6 @@ export const showMessage = (message: string, isMessageShown: boolean): boolean =
     return true;
 };
 
-export const mkenum = <T extends { [index: string]: U }, U extends string>(x: T) => x;
-
 /**
  *
  * @hidden @internal
@@ -247,7 +245,7 @@ export class PlatformUtil {
     /** @hidden @internal */
     public isElements = inject(ELEMENTS_TOKEN, { optional: true });
 
-    public KEYMAP = mkenum({
+    public KEYMAP = {
         ENTER: 'Enter',
         SPACE: ' ',
         ESCAPE: 'Escape',
@@ -269,7 +267,7 @@ export class PlatformUtil {
         X: 'x',
         Y: 'y',
         Z: 'z'
-    });
+    } as const;
 
     constructor(@Inject(PLATFORM_ID) private platformId: any) { }
 

--- a/projects/igniteui-angular/src/lib/data-operations/data-util.ts
+++ b/projects/igniteui-angular/src/lib/data-operations/data-util.ts
@@ -5,7 +5,7 @@ import { IPagingState, PagingError } from './paging-state.interface';
 import { IGroupByKey } from './groupby-expand-state.interface';
 import { IGroupByRecord } from './groupby-record.interface';
 import { IGroupingState } from './groupby-state.interface';
-import { mergeObjects, mkenum } from '../core/utils';
+import { mergeObjects } from '../core/utils';
 import { Transaction, TransactionType, HierarchicalTransaction } from '../services/transaction/transaction';
 import { getHierarchy, isHierarchyMatch } from './operations';
 import { GridType } from '../grids/common/grid.interface';
@@ -24,7 +24,7 @@ import { IGroupingExpression } from './grouping-expression.interface';
 /**
  * @hidden
  */
- export const DataType = /*@__PURE__*/mkenum({
+ export const DataType = {
     String: 'string',
     Number: 'number',
     Boolean: 'boolean',
@@ -34,7 +34,7 @@ import { IGroupingExpression } from './grouping-expression.interface';
     Currency: 'currency',
     Percent: 'percent',
     Image: 'image'
-});
+} as const;
 export type DataType = (typeof DataType)[keyof typeof DataType];
 
 /**

--- a/projects/igniteui-angular/src/lib/date-common/types.ts
+++ b/projects/igniteui-angular/src/lib/date-common/types.ts
@@ -1,17 +1,16 @@
-import { mkenum } from '../core/utils';
 /** Header orientation in `dialog` mode. */
-export const PickerHeaderOrientation = /*@__PURE__*/mkenum({
+export const PickerHeaderOrientation = {
     Horizontal: 'horizontal',
     Vertical: 'vertical'
-});
+} as const;
 export type PickerHeaderOrientation = (typeof PickerHeaderOrientation)[keyof typeof PickerHeaderOrientation];
 
 /**
  * This enumeration is used to configure whether the date/time picker has an editable input with drop down
  * or is readonly - the date/time is selected only through a dialog.
  */
-export const PickerInteractionMode = /*@__PURE__*/mkenum({
+export const PickerInteractionMode = {
     DropDown: 'dropdown',
     Dialog: 'dialog'
-});
+} as const;
 export type PickerInteractionMode = (typeof PickerInteractionMode)[keyof typeof PickerInteractionMode];

--- a/projects/igniteui-angular/src/lib/directives/button/button-base.ts
+++ b/projects/igniteui-angular/src/lib/directives/button/button-base.ts
@@ -1,11 +1,10 @@
 import { Directive, ElementRef, EventEmitter, HostBinding, HostListener, Input, Output, booleanAttribute } from '@angular/core';
-import { mkenum } from '../../core/utils';
 
-export const IgxBaseButtonType = /*@__PURE__*/mkenum({
+export const IgxBaseButtonType = {
     Flat: 'flat',
     Contained: 'contained',
     Outlined: 'outlined'
-});
+} as const;
 
 @Directive()
 export abstract class IgxButtonBaseDirective {

--- a/projects/igniteui-angular/src/lib/directives/button/button.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/button/button.directive.ts
@@ -9,14 +9,13 @@ import {
     Renderer2,
     booleanAttribute,
 } from '@angular/core';
-import { mkenum } from '../../core/utils';
 import { IBaseEventArgs } from '../../core/utils';
 import { IgxBaseButtonType, IgxButtonBaseDirective } from './button-base';
 
-const IgxButtonType = /*@__PURE__*/mkenum({
+const IgxButtonType = {
     ...IgxBaseButtonType,
     FAB: 'fab'
-});
+} as const;
 
 /**
  * Determines the Button type.

--- a/projects/igniteui-angular/src/lib/directives/divider/divider.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/divider/divider.directive.ts
@@ -1,10 +1,9 @@
 import { Directive, HostBinding, Input, booleanAttribute } from '@angular/core';
-import { mkenum } from '../../core/utils';
 
-export const IgxDividerType = /*@__PURE__*/mkenum({
+export const IgxDividerType = {
     SOLID: 'solid',
     DASHED: 'dashed'
-});
+} as const;
 export type IgxDividerType = (typeof IgxDividerType)[keyof typeof IgxDividerType];
 
 let NEXT_ID = 0;

--- a/projects/igniteui-angular/src/lib/directives/radio/radio-group.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/radio/radio-group.directive.ts
@@ -18,7 +18,6 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, NgControl, Validators } from '@angular/forms';
 import { fromEvent, noop, Subject, takeUntil } from 'rxjs';
-import { mkenum } from '../../core/utils';
 import { IgxRadioComponent } from '../../radio/radio.component';
 import { IgxDirectionality } from '../../services/direction/directionality';
 import { IChangeCheckboxEventArgs } from '../../checkbox/public_api';
@@ -26,10 +25,10 @@ import { IChangeCheckboxEventArgs } from '../../checkbox/public_api';
 /**
  * Determines the Radio Group alignment
  */
-export const RadioGroupAlignment = mkenum({
+export const RadioGroupAlignment = {
     horizontal: 'horizontal',
     vertical: 'vertical'
-});
+} as const;
 export type RadioGroupAlignment = typeof RadioGroupAlignment[keyof typeof RadioGroupAlignment];
 
 let nextId = 0;

--- a/projects/igniteui-angular/src/lib/drop-down/drop-down.common.ts
+++ b/projects/igniteui-angular/src/lib/drop-down/drop-down.common.ts
@@ -1,4 +1,4 @@
-import { CancelableEventArgs, CancelableBrowserEventArgs, IBaseEventArgs, mkenum } from '../core/utils';
+import { CancelableEventArgs, CancelableBrowserEventArgs, IBaseEventArgs } from '../core/utils';
 import { IgxDropDownItemBaseDirective } from './drop-down-item.base';
 import { IToggleView } from '../core/navigation/IToggleView';
 import { EventEmitter, InjectionToken } from '@angular/core';
@@ -10,11 +10,11 @@ export enum Navigate {
 }
 
 /** Key actions that have designated handlers in IgxDropDownComponent */
-export const DropDownActionKey = /*@__PURE__*/mkenum({
+export const DropDownActionKey = {
     ESCAPE: 'escape',
     ENTER: 'enter',
     SPACE: 'space'
-});
+} as const;
 export type DropDownActionKey = (typeof DropDownActionKey)[keyof typeof DropDownActionKey];
 
 /**

--- a/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel-header.component.ts
+++ b/projects/igniteui-angular/src/lib/expansion-panel/expansion-panel-header.component.ts
@@ -15,17 +15,16 @@ import {
 } from '@angular/core';
 import { IgxExpansionPanelIconDirective } from './expansion-panel.directives';
 import { IGX_EXPANSION_PANEL_COMPONENT, IgxExpansionPanelBase, IExpansionPanelCancelableEventArgs } from './expansion-panel.common';
-import { mkenum } from '../core/utils';
 import { IgxIconComponent } from '../icon/icon.component';
 
 /**
  * @hidden
  */
-export const ExpansionPanelHeaderIconPosition = /*@__PURE__*/mkenum({
+export const ExpansionPanelHeaderIconPosition = {
     LEFT: 'left',
     NONE: 'none',
     RIGHT: 'right'
-});
+} as const;
 export type ExpansionPanelHeaderIconPosition = (typeof ExpansionPanelHeaderIconPosition)[keyof typeof ExpansionPanelHeaderIconPosition];
 
 

--- a/projects/igniteui-angular/src/lib/grids/common/enums.ts
+++ b/projects/igniteui-angular/src/lib/grids/common/enums.ts
@@ -1,14 +1,13 @@
 
-import { mkenum } from '../../core/utils';
 /**
  * Enumeration representing different filter modes for grid filtering.
  * - quickFilter: Default mode with a filter row UI between the column headers and the first row of records.
  * - excelStyleFilter: Filter mode where an Excel-style filter is used.
  */
-export const FilterMode = /*@__PURE__*/mkenum({
+export const FilterMode = {
     quickFilter: 'quickFilter',
     excelStyleFilter: 'excelStyleFilter'
-});
+} as const;
 export type FilterMode = (typeof FilterMode)[keyof typeof FilterMode];
 
 /**
@@ -16,10 +15,10 @@ export type FilterMode = (typeof FilterMode)[keyof typeof FilterMode];
  * - top: Default value; Summary rows are displayed at the top of the grid.
  * - bottom: Summary rows are displayed at the bottom of the grid.
  */
-export const GridSummaryPosition = /*@__PURE__*/mkenum({
+export const GridSummaryPosition = {
     top: 'top',
     bottom: 'bottom'
-});
+} as const;
 export type GridSummaryPosition = (typeof GridSummaryPosition)[keyof typeof GridSummaryPosition];
 
 /**
@@ -28,11 +27,11 @@ export type GridSummaryPosition = (typeof GridSummaryPosition)[keyof typeof Grid
  * - childLevelsOnly: Summaries are calculated only for child levels.
  * - rootAndChildLevels: Default value; Summaries are calculated for both root and child levels.
  */
-export const GridSummaryCalculationMode = /*@__PURE__*/mkenum({
+export const GridSummaryCalculationMode = {
     rootLevelOnly: 'rootLevelOnly',
     childLevelsOnly: 'childLevelsOnly',
     rootAndChildLevels: 'rootAndChildLevels'
-});
+} as const;
 export type GridSummaryCalculationMode = (typeof GridSummaryCalculationMode)[keyof typeof GridSummaryCalculationMode];
 
 /**
@@ -66,19 +65,19 @@ export type GridKeydownTargetType =
  * - 'multiple': Default cell selection mode. More than one element can be selected at a time.
  * - 'multipleCascade': Similar to multiple selection. It is used in hierarchical or tree grids. Allows selection not only to an individual item but also all its related or nested items in a single action
  */
-export const GridSelectionMode = /*@__PURE__*/mkenum({
+export const GridSelectionMode = {
     none: 'none',
     single: 'single',
     multiple: 'multiple',
     multipleCascade: 'multipleCascade'
-});
+} as const;
 export type GridSelectionMode = (typeof GridSelectionMode)[keyof typeof GridSelectionMode];
 
 /** Enumeration representing different column display order options. */
-export const ColumnDisplayOrder = /*@__PURE__*/mkenum({
+export const ColumnDisplayOrder = {
     Alphabetical: 'Alphabetical',
     DisplayOrder: 'DisplayOrder'
-});
+} as const;
 export type ColumnDisplayOrder = (typeof ColumnDisplayOrder)[keyof typeof ColumnDisplayOrder];
 
 /* mustCoerceToInt */
@@ -108,10 +107,10 @@ export enum RowPinningPosition {
  * - Local: The grid will use local data to extract pages during paging.
  * - Remote: The grid will expect pages to be delivered from a remote location and will only raise events during paging interactions.
  */
-export const GridPagingMode = /*@__PURE__*/mkenum({
+export const GridPagingMode = {
     Local: 'local',
     Remote: 'remote'
-});
+} as const;
 export type GridPagingMode = (typeof GridPagingMode)[keyof typeof GridPagingMode];
 
 /**
@@ -122,9 +121,9 @@ export type GridPagingMode = (typeof GridPagingMode)[keyof typeof GridPagingMode
  * - Medium: This is the middle size with 40px row height. Left and Right paddings are 16px. Minimal column width is 64px.
  * - Large:  this is the default Grid size with the lowest intense and row height equal to 50px. Left and Right paddings are 24px. Minimal column width is 80px.
  */
-export const Size = /*@__PURE__*/mkenum({
+export const Size = {
     Small: '1',
     Medium: '2',
     Large: '3'
-});
+} as const;
 export type Size = (typeof Size)[keyof typeof Size];

--- a/projects/igniteui-angular/src/lib/input-group/inputGroupType.ts
+++ b/projects/igniteui-angular/src/lib/input-group/inputGroupType.ts
@@ -1,20 +1,19 @@
 import { InjectionToken } from '@angular/core';
-import { mkenum } from '../core/utils';
 
-const IgxInputGroupEnum = /*@__PURE__*/mkenum({
+export const IgxInputGroupEnum = {
     Line: 'line',
     Box: 'box',
     Border: 'border',
     Search: 'search'
-});
+} as const;
 
 /**
  * Defines the InputGroupType DI token.
  */
- // Should this go trough Interface https://angular.io/api/core/InjectionToken
- export const IGX_INPUT_GROUP_TYPE = /*@__PURE__*/new InjectionToken<IgxInputGroupType>('InputGroupType');
+// Should this go trough Interface https://angular.io/api/core/InjectionToken
+export const IGX_INPUT_GROUP_TYPE = /*@__PURE__*/new InjectionToken<IgxInputGroupType>('InputGroupType');
 
- /**
-  * Determines the InputGroupType.
-  */
- export type IgxInputGroupType = (typeof IgxInputGroupEnum)[keyof typeof IgxInputGroupEnum];
+/**
+ * Determines the InputGroupType.
+ */
+export type IgxInputGroupType = (typeof IgxInputGroupEnum)[keyof typeof IgxInputGroupEnum];

--- a/projects/igniteui-angular/src/lib/progressbar/progressbar.component.ts
+++ b/projects/igniteui-angular/src/lib/progressbar/progressbar.component.ts
@@ -21,23 +21,23 @@ import {
     IgxProgressBarTextTemplateDirective,
     IgxProgressBarGradientDirective,
 } from './progressbar.common';
-import { IBaseEventArgs, mkenum } from '../core/utils';
+import { IBaseEventArgs } from '../core/utils';
 const ONE_PERCENT = 0.01;
 const MIN_VALUE = 0;
 
-export const IgxTextAlign = /*@__PURE__*/mkenum({
+export const IgxTextAlign = {
     START: 'start',
     CENTER: 'center',
     END: 'end'
-});
+} as const;
 export type IgxTextAlign = (typeof IgxTextAlign)[keyof typeof IgxTextAlign];
 
-export const IgxProgressType = /*@__PURE__*/mkenum({
+export const IgxProgressType = {
     ERROR: 'error',
     INFO: 'info',
     WARNING: 'warning',
     SUCCESS: 'success'
-});
+} as const;
 export type IgxProgressType = (typeof IgxProgressType)[keyof typeof IgxProgressType];
 
 export interface IChangeProgressEventArgs extends IBaseEventArgs {

--- a/projects/igniteui-angular/src/lib/services/theme/theme.token.ts
+++ b/projects/igniteui-angular/src/lib/services/theme/theme.token.ts
@@ -1,5 +1,4 @@
 import { inject, InjectionToken, DOCUMENT } from "@angular/core";
-import { mkenum } from "../../core/utils";
 import { BehaviorSubject } from "rxjs";
 
 export class ThemeToken {
@@ -38,12 +37,12 @@ export const THEME_TOKEN = new InjectionToken<ThemeToken>('ThemeToken', {
     factory: () => new ThemeToken()
 });
 
-const Theme = /*@__PURE__*/ mkenum({
+const Theme = {
     Material: "material",
     Fluent: "fluent",
     Bootstrap: "bootstrap",
     IndigoDesign: "indigo",
-});
+} as const;
 
 /**
  * Determines the component theme.

--- a/projects/igniteui-angular/src/lib/slider/slider.common.ts
+++ b/projects/igniteui-angular/src/lib/slider/slider.common.ts
@@ -1,5 +1,4 @@
 import { Directive } from '@angular/core';
-import { mkenum } from '../core/utils';
 
 /**
  * Template directive that allows you to set a custom template representing the lower label value of the {@link IgxSliderComponent}
@@ -56,7 +55,7 @@ export interface ISliderValueChangeEventArgs {
     value: number | IRangeSliderValue;
 }
 
-export const IgxSliderType = /*@__PURE__*/mkenum({
+export const IgxSliderType = {
     /**
      * Slider with single thumb.
      */
@@ -65,31 +64,31 @@ export const IgxSliderType = /*@__PURE__*/mkenum({
      *  Range slider with multiple thumbs, that can mark the range.
      */
     RANGE: 'range'
-});
+} as const;
 export type IgxSliderType = (typeof IgxSliderType)[keyof typeof IgxSliderType];
 
-export const SliderHandle = /*@__PURE__*/mkenum({
+export const SliderHandle = {
     FROM: 'from',
     TO: 'to'
-});
+} as const;
 export type SliderHandle = (typeof SliderHandle)[keyof typeof SliderHandle];
 
 /**
  * Slider Tick labels Orientation
  */
-export const TickLabelsOrientation = /*@__PURE__*/mkenum({
+export const TickLabelsOrientation = {
     Horizontal: 'horizontal',
     TopToBottom: 'toptobottom',
     BottomToTop: 'bottomtotop'
-});
+} as const;
 export type TickLabelsOrientation = (typeof TickLabelsOrientation)[keyof typeof TickLabelsOrientation];
 
 /**
  * Slider Ticks orientation
  */
-export const TicksOrientation = /*@__PURE__*/mkenum({
+export const TicksOrientation = {
     Top: 'top',
     Bottom: 'bottom',
     Mirror: 'mirror'
-});
+} as const;
 export type TicksOrientation = (typeof TicksOrientation)[keyof typeof TicksOrientation];

--- a/projects/igniteui-angular/src/lib/tabs/tabs/tabs.component.ts
+++ b/projects/igniteui-angular/src/lib/tabs/tabs/tabs.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, ChangeDetectorRef, Component, ElementRef, HostBinding, Inject, Input, NgZone, OnDestroy, ViewChild } from '@angular/core';
-import { getResizeObserver, mkenum, PlatformUtil } from '../../core/utils';
+import { getResizeObserver, PlatformUtil } from '../../core/utils';
 import { IgxAngularAnimationService } from '../../services/animation/angular-animation-service';
 import { AnimationService } from '../../services/animation/animation';
 import { IgxDirectionality } from '../../services/direction/directionality';
@@ -10,12 +10,12 @@ import { IgxIconComponent } from '../../icon/icon.component';
 import { IgxRippleDirective } from '../../directives/ripple/ripple.directive';
 import { IgxIconButtonDirective } from '../../directives/button/icon-button.directive';
 
-export const IgxTabsAlignment = /*@__PURE__*/mkenum({
+export const IgxTabsAlignment = {
     start: 'start',
     end: 'end',
     center: 'center',
     justify: 'justify'
-});
+} as const;
 
 /** @hidden */
 const enum TabScrollButtonStyle {

--- a/projects/igniteui-angular/src/lib/tree/common.ts
+++ b/projects/igniteui-angular/src/lib/tree/common.ts
@@ -1,5 +1,5 @@
 import { ElementRef, EventEmitter, InjectionToken, QueryList, TemplateRef } from '@angular/core';
-import { IBaseCancelableBrowserEventArgs, IBaseEventArgs, mkenum } from '../core/utils';
+import { IBaseCancelableBrowserEventArgs, IBaseEventArgs } from '../core/utils';
 import { ToggleAnimationSettings } from '../expansion-panel/toggle-animation-component';
 
 // Component interfaces
@@ -99,11 +99,11 @@ export interface ITreeNodeToggledEventArgs extends IBaseEventArgs {
 }
 
 // Enums
-export const IgxTreeSelectionType = /*@__PURE__*/mkenum({
+export const IgxTreeSelectionType = {
     None: 'None',
     BiState: 'BiState',
     Cascading: 'Cascading'
-});
+} as const;
 export type IgxTreeSelectionType = (typeof IgxTreeSelectionType)[keyof typeof IgxTreeSelectionType];
 
 // Token


### PR DESCRIPTION
const assertions have been a thing for a while and do exactly what the `mkenum` function was trying to do - get strict literal object types that be used to construct the main union ones. This should even be a _very_ minor optimization as well.

PS: Listed the minor change on chip variant is the changelog, even though it's not documented in any docs/samples.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 