### PR TITLE
refactor(elements): externalize lit instead of just lit-html

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -323,7 +323,7 @@
               ],
               "outputHashing": "none",
               "optimization": true,
-              "externalDependencies": ["lit-html"]
+              "externalDependencies": ["lit"]
             },
             "development": {
               "optimization": false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "express": "^5.1.0",
         "fflate": "^0.8.1",
         "igniteui-theming": "^18.0.1",
-        "igniteui-trial-watermark": "^3.0.2",
+        "igniteui-trial-watermark": "^3.1.0",
         "lodash-es": "^4.17.21",
         "rxjs": "^7.8.2",
         "tslib": "^2.3.0",
@@ -2786,30 +2786,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/@lit-labs/virtualizer/node_modules/lit": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
-      "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^2.1.0",
-        "lit-element": "^4.2.0",
-        "lit-html": "^3.3.0"
-      }
-    },
-    "node_modules/@lit-labs/virtualizer/node_modules/lit-element": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.0.tgz",
-      "integrity": "sha512-MGrXJVAI5x+Bfth/pU9Kst1iWID6GHDLEzFEnyULB/sFiRLgkd8NPK/PeeXxktA3T6EIIaq8U3KcbTU5XFcP2Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
-        "@lit/reactive-element": "^2.1.0",
-        "lit-html": "^3.3.0"
-      }
-    },
     "node_modules/@lit/context": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.5.tgz",
@@ -2824,7 +2800,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.1.0.tgz",
       "integrity": "sha512-L2qyoZSQClcBmq0qajBVbhYEcG6iK0XfLn66ifLe/RfC0/ihpc+pl0Wdn8bJ8o+hj38cG0fGXRgSS20MuXn7qA==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "@lit-labs/ssr-dom-shim": "^1.2.0"
@@ -11023,12 +10998,12 @@
       }
     },
     "node_modules/igniteui-trial-watermark": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/igniteui-trial-watermark/-/igniteui-trial-watermark-3.0.2.tgz",
-      "integrity": "sha512-/tkraYJFEWNi6YET6u2G7/pzu6lFHQrnMXS3MrEORB6OdqP8L8hz6Wn3SNN7uwukud8qxRymtIy+cQLqTj5ljQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/igniteui-trial-watermark/-/igniteui-trial-watermark-3.1.0.tgz",
+      "integrity": "sha512-Nrc8pnLQ8jsppC+P7RyJwiTpU0bIUj0k4BGzo7QtA018/PLSrcsegdHPXuZTiP9DHp6wg7lgBd5n/rNSOavhbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "lit": "^2.7.0"
+        "lit": "^3.3.0"
       }
     },
     "node_modules/igniteui-webcomponents": {
@@ -11045,30 +11020,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/igniteui-webcomponents/node_modules/lit": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
-      "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit/reactive-element": "^2.1.0",
-        "lit-element": "^4.2.0",
-        "lit-html": "^3.3.0"
-      }
-    },
-    "node_modules/igniteui-webcomponents/node_modules/lit-element": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.0.tgz",
-      "integrity": "sha512-MGrXJVAI5x+Bfth/pU9Kst1iWID6GHDLEzFEnyULB/sFiRLgkd8NPK/PeeXxktA3T6EIIaq8U3KcbTU5XFcP2Q==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.2.0",
-        "@lit/reactive-element": "^2.1.0",
-        "lit-html": "^3.3.0"
       }
     },
     "node_modules/ignore": {
@@ -12785,68 +12736,31 @@
       }
     },
     "node_modules/lit": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit/-/lit-2.8.0.tgz",
-      "integrity": "sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.3.0.tgz",
+      "integrity": "sha512-DGVsqsOIHBww2DqnuZzW7QsuCdahp50ojuDaBPC7jUDRpYoH0z7kHBBYZewRzer75FwtrkmkKk7iOAwSaWdBmw==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit/reactive-element": "^1.6.0",
-        "lit-element": "^3.3.0",
-        "lit-html": "^2.8.0"
+        "@lit/reactive-element": "^2.1.0",
+        "lit-element": "^4.2.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-element": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-3.3.3.tgz",
-      "integrity": "sha512-XbeRxmTHubXENkV4h8RIPyr8lXc+Ff28rkcQzw3G6up2xg5E8Zu1IgOWIwBLEQsu3cOVFqdYwiVi0hv0SlpqUA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.2.0.tgz",
+      "integrity": "sha512-MGrXJVAI5x+Bfth/pU9Kst1iWID6GHDLEzFEnyULB/sFiRLgkd8NPK/PeeXxktA3T6EIIaq8U3KcbTU5XFcP2Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.1.0",
-        "@lit/reactive-element": "^1.3.0",
-        "lit-html": "^2.8.0"
-      }
-    },
-    "node_modules/lit-element/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/lit-element/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.1.0",
+        "lit-html": "^3.3.0"
       }
     },
     "node_modules/lit-html": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.3.0.tgz",
       "integrity": "sha512-RHoswrFAxY2d8Cf2mm4OZ1DgzCoBKUKSPvA1fhtSELxUERq2aQQ2h05pO9j81gS1o7RIRJ+CePLogfyahwmynw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@types/trusted-types": "^2.0.2"
-      }
-    },
-    "node_modules/lit/node_modules/@lit/reactive-element": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-1.6.3.tgz",
-      "integrity": "sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@lit-labs/ssr-dom-shim": "^1.0.0"
-      }
-    },
-    "node_modules/lit/node_modules/lit-html": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-2.8.0.tgz",
-      "integrity": "sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@types/trusted-types": "^2.0.2"

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "express": "^5.1.0",
     "fflate": "^0.8.1",
     "igniteui-theming": "^18.0.1",
-    "igniteui-trial-watermark": "^3.0.2",
+    "igniteui-trial-watermark": "^3.1.0",
     "lodash-es": "^4.17.21",
     "rxjs": "^7.8.2",
     "tslib": "^2.3.0",

--- a/projects/igniteui-angular-elements/esbuild.mjs
+++ b/projects/igniteui-angular-elements/esbuild.mjs
@@ -8,7 +8,7 @@ const config = {
     minify: false, // temporary disabled due to Webpack issues https://github.com/webpack/webpack/issues/16262
     outfile: `${ROOT}/elements.js`,
     format: 'esm',
-    external: ['lit-html'],
+    external: ['lit'],
     target: 'es2022',
     metafile: true,
     treeShaking: true

--- a/projects/igniteui-angular-elements/src/app/custom-strategy.spec.ts
+++ b/projects/igniteui-angular-elements/src/app/custom-strategy.spec.ts
@@ -1,5 +1,5 @@
 import { IgxColumnComponent, IgxGridComponent, IgxHierarchicalGridComponent } from 'igniteui-angular';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import { firstValueFrom, fromEvent, skip, timer } from 'rxjs';
 import { ComponentRefKey, IgcNgElement } from './custom-strategy';
 import hgridData from '../assets/data/projects-hgrid.js';

--- a/projects/igniteui-angular-elements/src/app/wrapper/wrapper.component.spec.ts
+++ b/projects/igniteui-angular-elements/src/app/wrapper/wrapper.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { html } from 'lit-html';
+import { html } from 'lit';
 import { AsyncDirective, directive } from 'lit/async-directive.js';
 import { TemplateWrapperComponent } from './wrapper.component';
 

--- a/projects/igniteui-angular-elements/src/app/wrapper/wrapper.component.ts
+++ b/projects/igniteui-angular-elements/src/app/wrapper/wrapper.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectorRef, Component, QueryList, TemplateRef, ViewChildren } fr
 import { Subject } from 'rxjs';
 import { TemplateRefWrapper } from './template-ref-wrapper';
 
-import { render, type RootPart, type TemplateResult } from 'lit-html';
+import { render, type RootPart, type TemplateResult } from 'lit';
 
 type TemplateFunction = (arg: any) => TemplateResult;
 

--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -71,7 +71,7 @@
     "dependencies": {
         "fflate": "^0.8.1",
         "tslib": "^2.3.0",
-        "igniteui-trial-watermark": "^3.0.2",
+        "igniteui-trial-watermark": "^3.1.0",
         "lodash-es": "^4.17.21",
         "igniteui-theming": "^18.0.1",
         "@igniteui/material-icons-extended": "^3.1.0"


### PR DESCRIPTION
This is dedupe lit deps with other packages that might use more than the limited set Elements use form `lit-html` and should allow us to sync versions easier too.

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 