### PR TITLE
ci(lint): [WIP] lib local rules setup and bool input transform check

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
         "ghostclass",
         "groupable",
         "groupby",
+        "igniteui",
         "maxlength",
         "ungroup"
     ]

--- a/projects/igniteui-angular/eslint.config.mjs
+++ b/projects/igniteui-angular/eslint.config.mjs
@@ -2,6 +2,7 @@ import { FlatCompat } from "@eslint/eslintrc";
 import js from "@eslint/js";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import localRules from "./rules/index.mjs";
 import rootConfig from "../../eslint.config.mjs";
 // import tseslint from "typescript-eslint";
 // import angular from "angular-eslint";
@@ -18,6 +19,9 @@ export default [
     ...rootConfig,
     {
         files: ["**/*.ts"],
+        plugins: {
+            'igniteui-angular-local': localRules,
+        },
         rules: {
             "@angular-eslint/component-selector": ["error", {
                 type: "element",
@@ -48,6 +52,7 @@ export default [
             }],
 
             "no-debugger": "error",
+            "igniteui-angular-local/boolean-input-transform": ["error"],
         },
     },
     ...compat.extends(

--- a/projects/igniteui-angular/rules/README.md
+++ b/projects/igniteui-angular/rules/README.md
@@ -1,0 +1,11 @@
+## Custom ESLint rules
+
+This folder contains local custom ESLint rules for the Ignite UI for Angular library.
+
+
+### Useful links for development
+
+- [Writing custom ESLint rules with angular-eslint utils](https://github.com/angular-eslint/angular-eslint/blob/main/docs/WRITING_CUSTOM_RULES.md)
+- Working with AST
+    - AST Specification https://typescript-eslint.io/packages/typescript-estree/ast-spec
+    - AST Explorer https://astexplorer.net (pick from the options dropdown)

--- a/projects/igniteui-angular/rules/boolean-input-transform.mjs
+++ b/projects/igniteui-angular/rules/boolean-input-transform.mjs
@@ -1,0 +1,110 @@
+import { ASTUtils, Selectors } from '@angular-eslint/utils';
+// import type { TSESTree } from '@typescript-eslint/utils';
+import { ESLintUtils } from '@typescript-eslint/utils';
+import { TypeFlags } from 'typescript';
+
+// export type Options = [
+//   {
+//     suffixes?: string[];
+//   },
+// ];
+
+// export type MessageIds = 'serviceSuffix';
+
+export const RULE_NAME = 'boolean-input-transform';
+
+/**
+ * Check if a property is of boolean type.
+ * @param {import('@typescript-eslint/utils').TSESTree.PropertyDefinition | import('@typescript-eslint/utils').TSESTree.MethodDefinition} property
+ * @param {import('@typescript-eslint/utils').ParserServicesWithTypeInformation} parserServices
+ * @returns {boolean}
+ */
+function isBooleanProperty(property, parserServices) {
+    let isBoolean = false;
+    let typeAnnotation = null;
+
+    if (property.type === 'MethodDefinition' && (property.kind === 'get' || property.kind === 'set')) {
+        // getter/setter
+        const typeAnnotation = property.value.returnType?.typeAnnotation || property.value.params[0]?.typeAnnotation?.typeAnnotation;
+        isBoolean = typeAnnotation
+            ? typeAnnotation === 'TSBooleanKeyword'
+            : isBooleanType(property, parserServices);
+
+    } else if (property.type === 'PropertyDefinition') {
+        isBoolean = property.typeAnnotation
+            && property.typeAnnotation.typeAnnotation.type === 'TSBooleanKeyword';
+
+        isBoolean ||= property.value
+            && property.value.type === 'Literal'
+            && typeof property.value.value === 'boolean';
+    }
+    return isBoolean;
+}
+
+/**
+ * Type-aware check if a property is of boolean type.
+ * @param {import('@typescript-eslint/utils').TSESTree.Node} node
+ * @param {import('@typescript-eslint/utils').ParserServicesWithTypeInformation} parserServices
+ * @returns {boolean}
+ */
+function isBooleanType(node, parserServices) {
+    const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
+    const checker = parserServices.program.getTypeChecker();
+    const type = checker.getTypeAtLocation(tsNode);
+    return (type.flags & TypeFlags.BooleanLike) !== 0;
+}
+
+export const rule = ESLintUtils.RuleCreator.withoutDocs({
+  name: RULE_NAME,
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Require boolean @Input properties to use { transform: booleanAttribute }',
+      recommended: 'error',
+    },
+    schema: [],
+    messages: {
+      missingTransform:
+        'Boolean @Input properties must have { transform: booleanAttribute }.',
+    },
+  },
+  defaultOptions: [],
+  create(context, [ /* options*/ ]) {
+    // const parserServices = ESLintUtils.getParserServices(context);
+    // const checker = parserServices.program.getTypeChecker();
+
+    const ruleOptions = {
+      [Selectors.INPUT_DECORATOR](decorator) {
+        const property = decorator.parent;
+
+        if (!ASTUtils.isPropertyOrMethodDefinition(property)) return;
+
+        const classDeclaration = ASTUtils.getNearestNodeFrom(
+            decorator,
+            ASTUtils.isClassDeclaration,
+        );
+
+
+        let isBoolean = isBooleanProperty(property/*, parserServices*/);
+
+        if (!isBoolean) return;
+
+        const arg = decorator.expression.arguments[0];
+        const hasTransform =
+            arg &&
+            arg.type === 'ObjectExpression' &&
+            arg.properties.some(
+            (p) =>
+                p.key.name === 'transform' &&
+                p.value.name === 'booleanAttribute'
+            );
+
+        if (hasTransform) return;
+
+        context.report({ node: decorator, messageId: 'missingTransform' });
+      },
+    };
+    return ruleOptions;
+  },
+});

--- a/projects/igniteui-angular/rules/boolean-input-transform.mjs
+++ b/projects/igniteui-angular/rules/boolean-input-transform.mjs
@@ -84,11 +84,15 @@ export const rule = ESLintUtils.RuleCreator.withoutDocs({
             decorator,
             ASTUtils.isClassDeclaration,
         );
-
+        // classDeclaration.body.body.indexOff(property);
 
         let isBoolean = isBooleanProperty(property/*, parserServices*/);
 
         if (!isBoolean) return;
+
+        const comments = context.sourceCode.getCommentsBefore(classDeclaration.decorators[0] ?? classDeclaration);
+        if (comments.some(x => x.value.includes('@hidden') || x.value.includes('@internal')))
+            return;
 
         const arg = decorator.expression.arguments[0];
         const hasTransform =

--- a/projects/igniteui-angular/rules/boolean-input-transform.mjs
+++ b/projects/igniteui-angular/rules/boolean-input-transform.mjs
@@ -5,11 +5,11 @@ import { TypeFlags } from 'typescript';
 
 // export type Options = [
 //   {
-//     suffixes?: string[];
+//     prop?: string;
 //   },
 // ];
 
-// export type MessageIds = 'serviceSuffix';
+// export type MessageIds = 'missingTransform';
 
 export const RULE_NAME = 'boolean-input-transform';
 
@@ -48,6 +48,7 @@ function isBooleanProperty(property, parserServices) {
  * @returns {boolean}
  */
 function isBooleanType(node, parserServices) {
+    return false;
     const tsNode = parserServices.esTreeNodeToTSNodeMap.get(node);
     const checker = parserServices.program.getTypeChecker();
     const type = checker.getTypeAtLocation(tsNode);
@@ -84,7 +85,7 @@ export const rule = ESLintUtils.RuleCreator.withoutDocs({
             decorator,
             ASTUtils.isClassDeclaration,
         );
-        // classDeclaration.body.body.indexOff(property);
+        // classDeclaration.body.body.indexOf(property);
 
         let isBoolean = isBooleanProperty(property/*, parserServices*/);
 

--- a/projects/igniteui-angular/rules/boolean-input-transform.mjs
+++ b/projects/igniteui-angular/rules/boolean-input-transform.mjs
@@ -94,15 +94,7 @@ export const rule = ESLintUtils.RuleCreator.withoutDocs({
         if (comments.some(x => x.value.includes('@hidden') || x.value.includes('@internal')))
             return;
 
-        const arg = decorator.expression.arguments[0];
-        const hasTransform =
-            arg &&
-            arg.type === 'ObjectExpression' &&
-            arg.properties.some(
-            (p) =>
-                p.key.name === 'transform' &&
-                p.value.name === 'booleanAttribute'
-            );
+        const hasTransform = ASTUtils.getDecoratorProperty(decorator, 'transform')?.value.name === 'booleanAttribute';
 
         if (hasTransform) return;
 

--- a/projects/igniteui-angular/rules/boolean-input-transform.mjs
+++ b/projects/igniteui-angular/rules/boolean-input-transform.mjs
@@ -118,7 +118,13 @@ export const rule = ESLintUtils.RuleCreator.withoutDocs({
 
         if (!isBoolean) return;
 
-        const comments = context.sourceCode.getCommentsBefore(classDeclaration.decorators[0] ?? classDeclaration);
+        // ignore hidden/internal properties
+        const propComments = context.sourceCode.getCommentsBefore(decorator).filter(x => x.type === 'Block');
+        if (propComments.some(x => x.value.includes('@hidden') || x.value.includes('@internal')))
+            return;
+
+        // ignore hidden/internal classes
+        const comments = context.sourceCode.getCommentsBefore(classDeclaration.decorators[0] ?? classDeclaration).filter(x => x.type === 'Block');
         if (comments.some(x => x.value.includes('@hidden') || x.value.includes('@internal')))
             return;
 

--- a/projects/igniteui-angular/rules/index.mjs
+++ b/projects/igniteui-angular/rules/index.mjs
@@ -1,0 +1,10 @@
+import {
+  rule as booleanInputTransform,
+  RULE_NAME as booleanInputTransformRuleName,
+} from './boolean-input-transform.mjs';
+
+export default {
+  rules: {
+    [booleanInputTransformRuleName]: booleanInputTransform,
+  }
+};


### PR DESCRIPTION
Add setup to create custom local rules used in linting the Ignite UI for Angular library.
The initial rule checks the `@Input` decorator on boolean component properties is correctly setup with input transform function producing:
![terminal lint error](https://github.com/user-attachments/assets/612aa13d-250d-42e0-9e35-88e73320f56c)
and in IDE w/ plugin:
![VS Code tooltip with lint error](https://github.com/user-attachments/assets/1ade8dc8-4bd3-4642-b73a-cea09822a57d)

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 