### PR TITLE
refactor(elements): type base private componentRef/inject/etc access

### DIFF
--- a/projects/igniteui-angular-elements/src/app/custom-strategy.ts
+++ b/projects/igniteui-angular-elements/src/app/custom-strategy.ts
@@ -257,21 +257,21 @@ class IgxCustomNgElementStrategy extends ComponentNgElementStrategy {
     }
 
     public override setInputValue(property: string, value: any): void {
-        if (this._componentRef === null ||
-            !this._componentRef.instance) {
+        if (this._componentRef === null || !this._componentRef.instance) {
             this._initialInputValues.set(property, value);
             return;
         }
-        const componentRef = this._componentRef;
-        const componentConfig = this.config?.find(x => x.component === this._componentFactory.componentType);
 
-        if (value === componentRef.instance[property]) {
+        if (value === this._componentRef.instance[property]) {
             return;
         }
-        if (componentRef && componentConfig?.templateProps?.includes(property)) {
+
+        const componentConfig = this.config?.find(x => x.component === this._componentFactory.componentType);
+
+        if (componentConfig?.templateProps?.includes(property)) {
             // const oldValue = this.getInputValue(property);
             if (this.templateWrapper.templateFunctions.includes(value)) return;
-            const oldRef = componentRef.instance[property];
+            const oldRef = this._componentRef.instance[property];
             const oldValue = oldRef && this.templateWrapper.getTemplateFunction(oldRef);
             if (oldValue === value) {
                 return;
@@ -280,18 +280,18 @@ class IgxCustomNgElementStrategy extends ComponentNgElementStrategy {
             // TODO: discard oldValue
 
             // check template for any angular-element components
-            this.templateWrapper.templateRendered.pipe(takeUntilDestroyed(componentRef.injector.get(DestroyRef))).subscribe((element) => {
+            this.templateWrapper.templateRendered.pipe(takeUntilDestroyed(this._componentRef.injector.get(DestroyRef))).subscribe((element) => {
                 element.querySelectorAll<IgcNgElement>(this.configSelectors)?.forEach((c) => {
                     // tie to angularParent lifecycle for cached scenarios like detailTemplate:
-                    c.ngElementStrategy.angularParent = componentRef;
+                    c.ngElementStrategy.angularParent = this._componentRef;
                 });
             });
         }
-        if (componentRef && componentConfig?.boolProps?.includes(property)) {
+        if (componentConfig?.boolProps?.includes(property)) {
             // bool coerce:
             value = value != null && `${value}` !== 'false';
         }
-        if (componentRef && componentConfig?.numericProps?.includes(property)) {
+        if (componentConfig?.numericProps?.includes(property)) {
             // number coerce:
             if (!isNaN(Number(value) - parseFloat(value))) {
                 value = Number(value);

--- a/projects/igniteui-angular-elements/src/app/wrapper/wrapper.component.ts
+++ b/projects/igniteui-angular-elements/src/app/wrapper/wrapper.component.ts
@@ -27,7 +27,7 @@ export class TemplateWrapperComponent {
     public templateRefs: QueryList<TemplateRef<any>>;
 
     constructor(private cdr: ChangeDetectorRef) { }
-  
+
     protected litRender(container: HTMLElement, templateFunc: (arg: any) => TemplateResult, arg: any) {
         const part = render(templateFunc(arg), container);
 


### PR DESCRIPTION
Updated `IgxCustomNgElementStrategy` access of base private props to go through typed get/set accessors so `(this as any)` workarounds shouldn't be needed anymore.

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 