### PR TITLE
Hide PDF export option by default

### DIFF
--- a/projects/igniteui-angular/grids/core/src/toolbar/grid-toolbar-exporter.component.ts
+++ b/projects/igniteui-angular/grids/core/src/toolbar/grid-toolbar-exporter.component.ts
@@ -68,7 +68,7 @@ export class IgxGridToolbarExporterComponent extends BaseToolbarDirective {
      * Show entry for PDF export.
      */
     @Input({ transform: booleanAttribute })
-    public exportPDF = true;
+    public exportPDF = false;
 
     /**
      * The name for the exported file.


### PR DESCRIPTION
Set `exportPDF` to false by default to prevent the new PDF export option from appearing unexpectedly for existing toolbar users. This ensures backward compatibility and avoids introducing the feature in apps that may not want it enabled.

Closes #  

### Additional information (check all that apply):
 - [ ] Bug fix
 - [X] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 