### PR TITLE
fix(grid): fix type-style declaration to not override button-group styles

### DIFF
--- a/projects/igniteui-angular/core/src/core/styles/components/grid/_excel-filtering-theme.scss
+++ b/projects/igniteui-angular/core/src/core/styles/components/grid/_excel-filtering-theme.scss
@@ -190,6 +190,8 @@
                 &:not(:nth-child(1)) {
                     margin: 0;
                 }
+
+                @include type-style('button');
             }
         }
 
@@ -804,10 +806,6 @@
         %cbx-label {
             @include type-style('body-2');
         }
-    }
-
-    %igx-group-item {
-        @include type-style('button');
     }
 
     %grid-excel-menu__secondary--cosy {


### PR DESCRIPTION
A bug was introduces with this PR https://github.com/IgniteUI/igniteui-angular/pull/16697 and changed the type-style of the button-group globally

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 