### PR TITLE
fix(toast): exclude igx-icon from typography styles

### DIFF
--- a/projects/igniteui-angular/core/src/core/styles/components/toast/_toast-theme.scss
+++ b/projects/igniteui-angular/core/src/core/styles/components/toast/_toast-theme.scss
@@ -52,7 +52,7 @@
     $text: map.get($categories, 'text');
 
     %igx-toast-display,
-    %igx-toast-display > * {
+    %igx-toast-display > *:not(igx-icon) {
         @include type-style($text) {
             margin: 0;
         }


### PR DESCRIPTION
Fixes issue where Material icons in toast were not displayed correctly. Typography styles were being applied to all child elements including icons, which interfered with icon rendering. Now explicitly excludes igx-icon elements from typography styles using :not() selector.

Closes #16760

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 