### PR TITLE
chore(grid-lite): bump to latest & enable adoptRootStyles by default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
         "hammerjs": "^2.0.8",
         "ig-typedoc-theme": "^7.0.1",
         "igniteui-dockmanager": "^1.17.0",
-        "igniteui-grid-lite": "~0.4.0",
+        "igniteui-grid-lite": "~0.5.0",
         "igniteui-i18n-resources": "^1.0.2",
         "igniteui-sassdoc-theme": "^2.1.0",
         "igniteui-webcomponents": "^6.5.0",
@@ -13985,9 +13985,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/igniteui-grid-lite": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/igniteui-grid-lite/-/igniteui-grid-lite-0.4.0.tgz",
-      "integrity": "sha512-QZ12Q9C9FxrJIZIO0beOQMAZ2E9UADEqS0cjL2Qt2YP1DNge7+x+AzXCp8aOOzT5Y5E+O6O0u6u7JPdtc3RhxA==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/igniteui-grid-lite/-/igniteui-grid-lite-0.5.0.tgz",
+      "integrity": "sha512-VrpVBRcoO7fCJaEFLcGtslIz3t/5ygaV8dYPYfmZT0amTBYiQYDLlpmey7XrKJQ0loYUZYVIIzbm9WrvIEksPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "hammerjs": "^2.0.8",
     "ig-typedoc-theme": "^7.0.1",
     "igniteui-dockmanager": "^1.17.0",
-    "igniteui-grid-lite": "~0.4.0",
+    "igniteui-grid-lite": "~0.5.0",
     "igniteui-i18n-resources": "^1.0.2",
     "igniteui-sassdoc-theme": "^2.1.0",
     "igniteui-webcomponents": "^6.5.0",

--- a/projects/igniteui-angular/grids/lite/src/grid-lite.component.ts
+++ b/projects/igniteui-angular/grids/lite/src/grid-lite.component.ts
@@ -44,7 +44,8 @@ class IgxGridLite<T extends object = any> extends IgcGridLite<T> {
         '[sortingOptions]': "sortingOptions()",
         '[dataPipelineConfiguration]': "dataPipelineConfiguration()",
         '(sorted)': "onSorted($any($event))",
-        '(filtered)': "onFiltered($any($event))"
+        '(filtered)': "onFiltered($any($event))",
+        'adopt-root-styles': '',
     },
     template: `<ng-content></ng-content>`
 })

--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -87,7 +87,7 @@
         "hammerjs": "^2.0.8",
         "@types/hammerjs": "^2.0.46",
         "igniteui-webcomponents": "^6.5.0",
-        "igniteui-grid-lite": "~0.4.0"
+        "igniteui-grid-lite": "~0.5.0"
     },
     "peerDependenciesMeta": {
         "hammerjs": {

--- a/src/app/grid-lite/grid-lite.sample.html
+++ b/src/app/grid-lite/grid-lite.sample.html
@@ -50,7 +50,7 @@
       let-column="column"
       let-parent="parent"
     >
-      <div>Cell {{value}}</div>
+      <igx-checkbox [checked]="value" readonly>Cell {{value}}</igx-checkbox>
     </ng-template>
   </igx-grid-lite-column>
 </igx-grid-lite>

--- a/src/app/grid-lite/grid-lite.sample.ts
+++ b/src/app/grid-lite/grid-lite.sample.ts
@@ -1,12 +1,13 @@
 import { Component, CUSTOM_ELEMENTS_SCHEMA, inject, viewChild } from '@angular/core';
 import { IgxGridLiteCellTemplateDirective, IgxGridLiteColumnComponent, IgxGridLiteComponent, IgxGridLiteFilteringExpression, IgxGridLiteHeaderTemplateDirective, IgxGridLiteSortingExpression, IgxGridLiteSortingOptions } from "igniteui-angular/grids/lite";
 import { GridLiteDataService } from './data.service';
+import { IgxCheckboxComponent } from 'igniteui-angular';
 @Component({
     selector: 'app-grid-lite-sample',
     templateUrl: 'grid-lite.sample.html',
     styleUrls: ['grid-lite.sample.scss'],
     schemas: [CUSTOM_ELEMENTS_SCHEMA],
-    imports: [IgxGridLiteComponent, IgxGridLiteColumnComponent, IgxGridLiteHeaderTemplateDirective, IgxGridLiteCellTemplateDirective]
+    imports: [IgxCheckboxComponent, IgxGridLiteComponent, IgxGridLiteColumnComponent, IgxGridLiteHeaderTemplateDirective, IgxGridLiteCellTemplateDirective]
 })
 export class GridLiteSampleComponent {
     protected grid = viewChild<IgxGridLiteComponent<any>>('grid');


### PR DESCRIPTION
Related #16700

Resolves template styling issue described in https://github.com/IgniteUI/igniteui-angular/pull/16777#issuecomment-3861101902

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 