### PR TITLE
fix(*): add mustCoerceToInt to relevant props - 21.1.x

### DIFF
--- a/projects/igniteui-angular/core/src/data-operations/filtering-expressions-tree.ts
+++ b/projects/igniteui-angular/core/src/data-operations/filtering-expressions-tree.ts
@@ -11,6 +11,7 @@ export enum FilteringExpressionsTreeType {
 /* marshalByValue */
 export declare interface IExpressionTree {
     filteringOperands: (IExpressionTree | IFilteringExpression)[];
+    /* mustCoerceToInt */
     operator: FilteringLogic;
     fieldName?: string | null;
     entity?: string | null;
@@ -22,6 +23,7 @@ export declare interface IExpressionTree {
 export declare interface IFilteringExpressionsTree extends IBaseEventArgs, IExpressionTree {
     filteringOperands: (IFilteringExpressionsTree | IFilteringExpression)[];
     /* alternateName: treeType */
+    /* mustCoerceToInt */
     type?: FilteringExpressionsTreeType;
 
     /* blazorSuppress */

--- a/projects/igniteui-angular/core/src/services/overlay/utilities.ts
+++ b/projects/igniteui-angular/core/src/services/overlay/utilities.ts
@@ -98,12 +98,16 @@ export interface OutOfViewPort {
 
 export interface PositionSettings {
     /** Direction in which the component should show */
+    /* mustCoerceToInt */
     horizontalDirection?: HorizontalAlignment;
     /** Direction in which the component should show */
+    /* mustCoerceToInt */
     verticalDirection?: VerticalAlignment;
     /** Target's starting point */
+    /* mustCoerceToInt */
     horizontalStartPoint?: HorizontalAlignment;
     /** Target's starting point */
+    /* mustCoerceToInt */
     verticalStartPoint?: VerticalAlignment;
     /* blazorSuppress */
     /** Animation applied while overlay opens */

--- a/projects/igniteui-angular/core/src/services/overlay/utilities.ts
+++ b/projects/igniteui-angular/core/src/services/overlay/utilities.ts
@@ -97,17 +97,17 @@ export interface OutOfViewPort {
 }
 
 export interface PositionSettings {
-    /** Direction in which the component should show */
     /* mustCoerceToInt */
+    /** Direction in which the component should show */
     horizontalDirection?: HorizontalAlignment;
+    /* mustCoerceToInt */
     /** Direction in which the component should show */
-    /* mustCoerceToInt */
     verticalDirection?: VerticalAlignment;
-    /** Target's starting point */
     /* mustCoerceToInt */
+    /** Target's starting point */
     horizontalStartPoint?: HorizontalAlignment;
-    /** Target's starting point */
     /* mustCoerceToInt */
+    /** Target's starting point */
     verticalStartPoint?: VerticalAlignment;
     /* blazorSuppress */
     /** Animation applied while overlay opens */

--- a/projects/igniteui-angular/grids/core/src/common/grid.interface.ts
+++ b/projects/igniteui-angular/grids/core/src/common/grid.interface.ts
@@ -1217,7 +1217,9 @@ export interface IgxGridPaginatorTemplateContext {
  * An interface describing settings for row/column pinning position.
  */
 export interface IPinningConfig {
+    /* mustCoerceToInt */
     columns?: ColumnPinningPosition;
+    /* mustCoerceToInt */
     rows?: RowPinningPosition;
 }
 

--- a/projects/igniteui-angular/grids/core/src/pivot-grid.interface.ts
+++ b/projects/igniteui-angular/grids/core/src/pivot-grid.interface.ts
@@ -16,6 +16,7 @@ export interface IDimensionsChange {
     /** The new list of dimensions. */
     dimensions: IPivotDimension[],
     /** The dimension list type - Row, Column or Filter. */
+    /* mustCoerceToInt */
     dimensionCollectionType: PivotDimensionType
 }
 

--- a/projects/igniteui-angular/grids/core/src/pivot-grid.interface.ts
+++ b/projects/igniteui-angular/grids/core/src/pivot-grid.interface.ts
@@ -15,8 +15,8 @@ export const DEFAULT_PIVOT_KEYS = {
 export interface IDimensionsChange {
     /** The new list of dimensions. */
     dimensions: IPivotDimension[],
-    /** The dimension list type - Row, Column or Filter. */
     /* mustCoerceToInt */
+    /** The dimension list type - Row, Column or Filter. */
     dimensionCollectionType: PivotDimensionType
 }
 


### PR DESCRIPTION
Attribute is needed so the metadata descriptions which are used by Blazor can be updated which would resolve the enum values as numbers instead of strings.

Related to: https://infragistics.visualstudio.com/Indigo_Platform/_workitems/edit/34678

### Additional information (check all that apply):
 - [ ] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 