### PR TITLE
fix(grids): getState no longer mutates live sorting/groupBy/filtering expressions - 21.1.x

### DIFF
--- a/projects/igniteui-angular/grids/core/src/state-base.directive.ts
+++ b/projects/igniteui-angular/grids/core/src/state-base.directive.ts
@@ -156,10 +156,10 @@ export class IgxGridStateBaseDirective {
                 const filteringState = context.currGrid.filteringExpressionsTree;
                 if (filteringState) {
                     const copy: IFilteringExpressionsTree = { ...filteringState };
-                    delete (copy as any).owner;
+                    delete copy.owner;
                     copy.filteringOperands = filteringState.filteringOperands.map(item => {
                         const operandCopy = { ...(item as IFilteringExpressionsTree) };
-                        delete (operandCopy as any).owner;
+                        delete operandCopy.owner;
                         return operandCopy;
                     });
                     return { filtering: copy };
@@ -177,10 +177,10 @@ export class IgxGridStateBaseDirective {
                 let advancedFiltering: any;
                 if (filteringState) {
                     const copy: IFilteringExpressionsTree = { ...filteringState };
-                    delete (copy as any).owner;
+                    delete copy.owner;
                     copy.filteringOperands = filteringState.filteringOperands.map(item => {
                         const operandCopy = { ...(item as IFilteringExpressionsTree) };
-                        delete (operandCopy as any).owner;
+                        delete operandCopy.owner;
                         return operandCopy;
                     });
                     advancedFiltering = copy;

--- a/projects/igniteui-angular/grids/core/src/state-base.directive.ts
+++ b/projects/igniteui-angular/grids/core/src/state-base.directive.ts
@@ -158,9 +158,12 @@ export class IgxGridStateBaseDirective {
                     const copy: IFilteringExpressionsTree = { ...filteringState };
                     delete copy.owner;
                     copy.filteringOperands = filteringState.filteringOperands.map(item => {
-                        const operandCopy = { ...(item as IFilteringExpressionsTree) };
-                        delete operandCopy.owner;
-                        return operandCopy;
+                        if ('filteringOperands' in item) {
+                            const operandCopy = { ...item };
+                            delete operandCopy.owner;
+                            return operandCopy;
+                        }
+                        return { ...item };
                     });
                     return { filtering: copy };
                 }
@@ -179,9 +182,12 @@ export class IgxGridStateBaseDirective {
                     const copy: IFilteringExpressionsTree = { ...filteringState };
                     delete copy.owner;
                     copy.filteringOperands = filteringState.filteringOperands.map(item => {
-                        const operandCopy = { ...(item as IFilteringExpressionsTree) };
-                        delete operandCopy.owner;
-                        return operandCopy;
+                        if ('filteringOperands' in item) {
+                            const operandCopy = { ...item };
+                            delete operandCopy.owner;
+                            return operandCopy;
+                        }
+                        return { ...item };
                     });
                     advancedFiltering = copy;
                 } else {
@@ -234,21 +240,21 @@ export class IgxGridStateBaseDirective {
             },
             restoreFeatureState: (context: IgxGridStateBaseDirective, state: IColumnState[]): void => {
                 const newColumns = [];
-                
+
                 // Helper to restore column state without auto-persisting widths
                 const restoreColumnState = (column: IgxColumnComponent | IgxColumnGroupComponent, colState: IColumnState) => {
                     // Extract width to handle it separately
                     const width = colState.width;
                     delete colState.width;
-                    
+
                     Object.assign(column, colState);
-                    
+
                     // Only restore width if it was explicitly set by the user (not undefined)
                     if (width !== undefined) {
                         column.width = width;
                     }
                 };
-                
+
                 state.forEach((colState) => {
                     const hasColumnGroup = colState.columnGroup;
                     const hasColumnLayouts = colState.columnLayout;
@@ -265,9 +271,9 @@ export class IgxGridStateBaseDirective {
                         } else {
                             ref1.children.reset([]);
                         }
-                        
+
                         restoreColumnState(ref1, colState);
-                        
+
                         ref1.grid = context.currGrid;
                         if (colState.parent || colState.parentKey) {
                             const columnGroup: IgxColumnGroupComponent = newColumns.find(e => e.columnGroup && (e.key ? e.key === colState.parentKey : e.header === ref1.parent));
@@ -285,7 +291,7 @@ export class IgxGridStateBaseDirective {
                         }
 
                         restoreColumnState(ref, colState);
-                        
+
                         ref.grid = context.currGrid;
                         if (colState.parent || colState.parentKey) {
                             const columnGroup: IgxColumnGroupComponent = newColumns.find(e =>  e.columnGroup && (e.key ? e.key === colState.parentKey : e.header === ref.parent));

--- a/projects/igniteui-angular/grids/core/src/state-base.directive.ts
+++ b/projects/igniteui-angular/grids/core/src/state-base.directive.ts
@@ -139,10 +139,11 @@ export class IgxGridStateBaseDirective {
     private FEATURES = {
         sorting:  {
             getFeatureState: (context: IgxGridStateBaseDirective): IGridState => {
-                const sortingState = context.currGrid.sortingExpressions;
-                sortingState.forEach(s => {
-                    delete s.strategy;
-                    delete s.owner;
+                const sortingState = context.currGrid.sortingExpressions.map(s => {
+                    const copy = { ...s };
+                    delete copy.strategy;
+                    delete copy.owner;
+                    return copy;
                 });
                 return { sorting: sortingState };
             },
@@ -154,10 +155,14 @@ export class IgxGridStateBaseDirective {
             getFeatureState: (context: IgxGridStateBaseDirective): IGridState => {
                 const filteringState = context.currGrid.filteringExpressionsTree;
                 if (filteringState) {
-                    delete filteringState.owner;
-                    for (const item of filteringState.filteringOperands) {
-                        delete (item as IFilteringExpressionsTree).owner;
-                    }
+                    const copy: IFilteringExpressionsTree = { ...filteringState };
+                    delete (copy as any).owner;
+                    copy.filteringOperands = filteringState.filteringOperands.map(item => {
+                        const operandCopy = { ...(item as IFilteringExpressionsTree) };
+                        delete (operandCopy as any).owner;
+                        return operandCopy;
+                    });
+                    return { filtering: copy };
                 }
                 return { filtering: filteringState };
             },
@@ -171,11 +176,14 @@ export class IgxGridStateBaseDirective {
                 const filteringState = context.currGrid.advancedFilteringExpressionsTree;
                 let advancedFiltering: any;
                 if (filteringState) {
-                    delete filteringState.owner;
-                    for (const item of filteringState.filteringOperands) {
-                        delete (item as IFilteringExpressionsTree).owner;
-                    }
-                    advancedFiltering = filteringState;
+                    const copy: IFilteringExpressionsTree = { ...filteringState };
+                    delete (copy as any).owner;
+                    copy.filteringOperands = filteringState.filteringOperands.map(item => {
+                        const operandCopy = { ...(item as IFilteringExpressionsTree) };
+                        delete (operandCopy as any).owner;
+                        return operandCopy;
+                    });
+                    advancedFiltering = copy;
                 } else {
                     advancedFiltering = {};
                 }
@@ -299,9 +307,10 @@ export class IgxGridStateBaseDirective {
         groupBy: {
             getFeatureState: (context: IgxGridStateBaseDirective): IGridState => {
                 const grid = context.currGrid;
-                const groupingExpressions = grid.groupingExpressions;
-                groupingExpressions.forEach(expr => {
-                    delete expr.strategy;
+                const groupingExpressions = grid.groupingExpressions.map(expr => {
+                    const copy = { ...expr };
+                    delete copy.strategy;
+                    return copy;
                 });
                 const expansionState = grid.groupingExpansionState;
                 const groupsExpanded = grid.groupsExpanded;

--- a/projects/igniteui-angular/grids/core/src/state-base.directive.ts
+++ b/projects/igniteui-angular/grids/core/src/state-base.directive.ts
@@ -155,17 +155,7 @@ export class IgxGridStateBaseDirective {
             getFeatureState: (context: IgxGridStateBaseDirective): IGridState => {
                 const filteringState = context.currGrid.filteringExpressionsTree;
                 if (filteringState) {
-                    const copy: IFilteringExpressionsTree = { ...filteringState };
-                    delete copy.owner;
-                    copy.filteringOperands = filteringState.filteringOperands.map(item => {
-                        if ('filteringOperands' in item) {
-                            const operandCopy = { ...item };
-                            delete operandCopy.owner;
-                            return operandCopy;
-                        }
-                        return { ...item };
-                    });
-                    return { filtering: copy };
+                    return { filtering: context.cloneFilteringTree(filteringState) };
                 }
                 return { filtering: filteringState };
             },
@@ -177,22 +167,7 @@ export class IgxGridStateBaseDirective {
         advancedFiltering: {
             getFeatureState: (context: IgxGridStateBaseDirective): IGridState => {
                 const filteringState = context.currGrid.advancedFilteringExpressionsTree;
-                let advancedFiltering: any;
-                if (filteringState) {
-                    const copy: IFilteringExpressionsTree = { ...filteringState };
-                    delete copy.owner;
-                    copy.filteringOperands = filteringState.filteringOperands.map(item => {
-                        if ('filteringOperands' in item) {
-                            const operandCopy = { ...item };
-                            delete operandCopy.owner;
-                            return operandCopy;
-                        }
-                        return { ...item };
-                    });
-                    advancedFiltering = copy;
-                } else {
-                    advancedFiltering = {};
-                }
+                const advancedFiltering: any = filteringState ? context.cloneFilteringTree(filteringState) : {};
                 return { advancedFiltering };
             },
             restoreFeatureState: (context: IgxGridStateBaseDirective, state: IFilteringExpressionsTree): void => {
@@ -690,6 +665,22 @@ export class IgxGridStateBaseDirective {
                 }
             }
         }
+    }
+
+    /**
+     * Recursively clones a filtering expression tree, stripping the `owner` property
+     * from each cloned node so the live tree is never mutated.
+     */
+    private cloneFilteringTree(tree: IFilteringExpressionsTree): IFilteringExpressionsTree {
+        const copy: IFilteringExpressionsTree = { ...tree };
+        delete copy.owner;
+        copy.filteringOperands = tree.filteringOperands.map(item => {
+            if ('filteringOperands' in item) {
+                return this.cloneFilteringTree(item as IFilteringExpressionsTree);
+            }
+            return { ...item };
+        });
+        return copy;
     }
 
     /**

--- a/projects/igniteui-angular/grids/core/src/state.directive.spec.ts
+++ b/projects/igniteui-angular/grids/core/src/state.directive.spec.ts
@@ -825,23 +825,26 @@ describe('IgxGridState - input properties #grid', () => {
         expect(grid.sortingExpressions[0].owner).toBe(owner, 'owner should not be removed from live expressions after getState');
     });
 
-    it('getState should not mutate live groupBy expressions (strategy)', () => {
+    it('getState should not mutate live groupBy expressions (strategy/owner)', () => {
         const fix = TestBed.createComponent(IgxGridStateComponent);
         fix.detectChanges();
         const grid = fix.componentInstance.grid;
         const state = fix.componentInstance.state;
 
         const customStrategy = DefaultSortingStrategy.instance();
+        const owner = {} as any;
         grid.groupingExpressions = [
-            { fieldName: 'ProductID', dir: SortingDirection.Asc, ignoreCase: false, strategy: customStrategy }
+            { fieldName: 'ProductID', dir: SortingDirection.Asc, ignoreCase: false, strategy: customStrategy, owner }
         ];
         fix.detectChanges();
 
         expect(grid.groupingExpressions[0].strategy).toBe(customStrategy, 'strategy should be set before getState');
+        expect(grid.groupingExpressions[0].owner).toBe(owner, 'owner should be set before getState');
 
         state.getState(false, 'groupBy');
 
         expect(grid.groupingExpressions[0].strategy).toBe(customStrategy, 'strategy should not be removed from live groupBy expressions after getState');
+        expect(grid.groupingExpressions[0].owner).toBe(owner, 'owner should not be removed from live groupBy expressions after getState');
     });
 
     it('getState should not mutate live filtering expressions (owner)', () => {
@@ -873,6 +876,37 @@ describe('IgxGridState - input properties #grid', () => {
         expect(grid.filteringExpressionsTree.owner).toBe('rootOwner', 'root owner should not be removed from live filtering tree after getState');
         expect((grid.filteringExpressionsTree.filteringOperands[0] as IFilteringExpressionsTree).owner)
             .toBe('nestedOwner', 'nested owner should not be removed from live filtering operand after getState');
+    });
+
+    it('getState should not mutate live advancedFiltering expressions (owner)', () => {
+        const fix = TestBed.createComponent(IgxGridStateComponent);
+        fix.detectChanges();
+        const grid = fix.componentInstance.grid;
+        const state = fix.componentInstance.state;
+
+        const filteringTree = new FilteringExpressionsTree(FilteringLogic.And);
+        const productFilteringTree = new FilteringExpressionsTree(FilteringLogic.And, 'ProductName');
+        productFilteringTree.filteringOperands.push({
+            condition: IgxBooleanFilteringOperand.instance().condition('true'),
+            conditionName: 'true',
+            fieldName: 'InStock',
+            ignoreCase: true
+        });
+        (productFilteringTree as IFilteringExpressionsTree).owner = 'nestedOwner';
+        filteringTree.filteringOperands.push(productFilteringTree);
+        (filteringTree as IFilteringExpressionsTree).owner = 'rootOwner';
+        grid.advancedFilteringExpressionsTree = filteringTree;
+        fix.detectChanges();
+
+        expect(grid.advancedFilteringExpressionsTree.owner).toBe('rootOwner', 'root owner should be set before getState');
+        expect((grid.advancedFilteringExpressionsTree.filteringOperands[0] as IFilteringExpressionsTree).owner)
+            .toBe('nestedOwner', 'nested owner should be set before getState');
+
+        state.getState(false, 'advancedFiltering');
+
+        expect(grid.advancedFilteringExpressionsTree.owner).toBe('rootOwner', 'root owner should not be removed from live advanced filtering tree after getState');
+        expect((grid.advancedFilteringExpressionsTree.filteringOperands[0] as IFilteringExpressionsTree).owner)
+            .toBe('nestedOwner', 'nested owner should not be removed from live advanced filtering operand after getState');
     });
 
     it('should preserve column widths when restoring state with all columns hidden', () => {

--- a/projects/igniteui-angular/grids/core/src/state.directive.spec.ts
+++ b/projects/igniteui-angular/grids/core/src/state.directive.spec.ts
@@ -803,6 +803,70 @@ describe('IgxGridState - input properties #grid', () => {
         expect(prodIdColumn.colEnd).toBe(1);
     });
 
+    it('getState should not mutate live sorting expressions (strategy/owner)', () => {
+        const fix = TestBed.createComponent(IgxGridStateComponent);
+        fix.detectChanges();
+        const grid = fix.componentInstance.grid;
+        const state = fix.componentInstance.state;
+
+        const customStrategy = DefaultSortingStrategy.instance();
+        grid.sortingExpressions = [
+            { fieldName: 'ProductID', dir: SortingDirection.Asc, ignoreCase: false, strategy: customStrategy }
+        ];
+        fix.detectChanges();
+
+        expect(grid.sortingExpressions[0].strategy).toBe(customStrategy, 'strategy should be set before getState');
+
+        state.getState(false, 'sorting');
+
+        expect(grid.sortingExpressions[0].strategy).toBe(customStrategy, 'strategy should not be removed from live expressions after getState');
+    });
+
+    it('getState should not mutate live groupBy expressions (strategy)', () => {
+        const fix = TestBed.createComponent(IgxGridStateComponent);
+        fix.detectChanges();
+        const grid = fix.componentInstance.grid;
+        const state = fix.componentInstance.state;
+
+        const customStrategy = DefaultSortingStrategy.instance();
+        grid.groupingExpressions = [
+            { fieldName: 'ProductID', dir: SortingDirection.Asc, ignoreCase: false, strategy: customStrategy }
+        ];
+        fix.detectChanges();
+
+        expect(grid.groupingExpressions[0].strategy).toBe(customStrategy, 'strategy should be set before getState');
+
+        state.getState(false, 'groupBy');
+
+        expect(grid.groupingExpressions[0].strategy).toBe(customStrategy, 'strategy should not be removed from live groupBy expressions after getState');
+    });
+
+    it('getState should not mutate live filtering expressions (owner)', () => {
+        const fix = TestBed.createComponent(IgxGridStateComponent);
+        fix.detectChanges();
+        const grid = fix.componentInstance.grid;
+        const state = fix.componentInstance.state;
+
+        const filteringTree = new FilteringExpressionsTree(FilteringLogic.And);
+        const productFilteringTree = new FilteringExpressionsTree(FilteringLogic.And, 'ProductName');
+        productFilteringTree.filteringOperands.push({
+            condition: IgxBooleanFilteringOperand.instance().condition('true'),
+            conditionName: 'true',
+            fieldName: 'InStock',
+            ignoreCase: true
+        });
+        filteringTree.filteringOperands.push(productFilteringTree);
+        (filteringTree as any).owner = 'testOwner';
+        grid.filteringExpressionsTree = filteringTree;
+        fix.detectChanges();
+
+        expect((grid.filteringExpressionsTree as any).owner).toBe('testOwner', 'owner should be set before getState');
+
+        state.getState(false, 'filtering');
+
+        expect((grid.filteringExpressionsTree as any).owner).toBe('testOwner', 'owner should not be removed from live filtering tree after getState');
+    });
+
     it('should preserve column widths when restoring state with all columns hidden', () => {
         const fix = TestBed.createComponent(IgxGridStateComponent);
         fix.detectChanges();

--- a/projects/igniteui-angular/grids/core/src/state.directive.spec.ts
+++ b/projects/igniteui-angular/grids/core/src/state.directive.spec.ts
@@ -810,16 +810,19 @@ describe('IgxGridState - input properties #grid', () => {
         const state = fix.componentInstance.state;
 
         const customStrategy = DefaultSortingStrategy.instance();
+        const owner = {} as any;
         grid.sortingExpressions = [
-            { fieldName: 'ProductID', dir: SortingDirection.Asc, ignoreCase: false, strategy: customStrategy }
+            { fieldName: 'ProductID', dir: SortingDirection.Asc, ignoreCase: false, strategy: customStrategy, owner }
         ];
         fix.detectChanges();
 
         expect(grid.sortingExpressions[0].strategy).toBe(customStrategy, 'strategy should be set before getState');
+        expect(grid.sortingExpressions[0].owner).toBe(owner, 'owner should be set before getState');
 
         state.getState(false, 'sorting');
 
         expect(grid.sortingExpressions[0].strategy).toBe(customStrategy, 'strategy should not be removed from live expressions after getState');
+        expect(grid.sortingExpressions[0].owner).toBe(owner, 'owner should not be removed from live expressions after getState');
     });
 
     it('getState should not mutate live groupBy expressions (strategy)', () => {
@@ -855,16 +858,21 @@ describe('IgxGridState - input properties #grid', () => {
             fieldName: 'InStock',
             ignoreCase: true
         });
+        (productFilteringTree as IFilteringExpressionsTree).owner = 'nestedOwner';
         filteringTree.filteringOperands.push(productFilteringTree);
-        (filteringTree as any).owner = 'testOwner';
+        (filteringTree as IFilteringExpressionsTree).owner = 'rootOwner';
         grid.filteringExpressionsTree = filteringTree;
         fix.detectChanges();
 
-        expect((grid.filteringExpressionsTree as any).owner).toBe('testOwner', 'owner should be set before getState');
+        expect(grid.filteringExpressionsTree.owner).toBe('rootOwner', 'root owner should be set before getState');
+        expect((grid.filteringExpressionsTree.filteringOperands[0] as IFilteringExpressionsTree).owner)
+            .toBe('nestedOwner', 'nested owner should be set before getState');
 
         state.getState(false, 'filtering');
 
-        expect((grid.filteringExpressionsTree as any).owner).toBe('testOwner', 'owner should not be removed from live filtering tree after getState');
+        expect(grid.filteringExpressionsTree.owner).toBe('rootOwner', 'root owner should not be removed from live filtering tree after getState');
+        expect((grid.filteringExpressionsTree.filteringOperands[0] as IFilteringExpressionsTree).owner)
+            .toBe('nestedOwner', 'nested owner should not be removed from live filtering operand after getState');
     });
 
     it('should preserve column widths when restoring state with all columns hidden', () => {


### PR DESCRIPTION
Closes #  

### Additional information (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD

### Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 