### PR TITLE
refactor(input-group): add styling support for more input types

### DIFF
--- a/projects/igniteui-angular/core/src/core/styles/components/input/_input-group-theme.scss
+++ b/projects/igniteui-angular/core/src/core/styles/components/input/_input-group-theme.scss
@@ -317,10 +317,30 @@
             color: var-get($theme, 'input-suffix-color--filled');
             background: var-get($theme, 'input-suffix-background--filled');
         }
+
+        &:not(%form-group-display--readonly, %form-group-display--disabled) {
+            &:hover {
+                %form-group-input {
+                    color: var-get($theme, 'filled-text-hover-color');
+                }
+            }
+
+            &%form-group-display--focused {
+                %form-group-input {
+                    color: var-get($theme, 'focused-text-color');
+                }
+            }
+        }
     }
 
     %form-group-display--focused {
         color: var-get($theme, 'input-prefix-color--focused');
+
+        &:not(%form-group-display--filled) {
+            %form-group-input {
+                color: var-get($theme, 'idle-text-color');
+            }
+        }
 
         igx-prefix,
         [igxPrefix] {
@@ -409,7 +429,6 @@
         &:hover {
             %form-group-input--hover {
                 cursor: default;
-                color: var-get($theme, 'filled-text-color');
 
                 &:not(:focus-within)::placeholder {
                     color: var-get($theme, 'placeholder-color');
@@ -1491,16 +1510,12 @@
     }
 
     %form-group-input--hover {
-        color: var-get($theme, 'filled-text-hover-color');
-
         &::placeholder {
             color: var-get($theme, 'hover-placeholder-color');
         }
     }
 
     %form-group-input--focus {
-        color: var-get($theme, 'focused-text-color');
-
         &::placeholder {
             color: var-get($theme, 'hover-placeholder-color');
         }

--- a/projects/igniteui-angular/core/src/core/styles/components/input/_input-group-theme.scss
+++ b/projects/igniteui-angular/core/src/core/styles/components/input/_input-group-theme.scss
@@ -1,4 +1,5 @@
 @use 'sass:map';
+@use 'sass:string';
 @use '../../base' as *;
 @use 'igniteui-theming/sass/animations/easings' as *;
 
@@ -11,6 +12,7 @@
     // The --variant CSS produced by css-vars is needed also
     // when dynamically switching between the input `type` attribute.
     $variant: map.get($theme, '_meta', 'theme');
+    $mode: map.get($theme, '_meta', 'variant');
     $transition-timing: .25s $out-cubic;
     $material-theme: $variant == 'material';
     $indigo-theme: $variant == 'indigo';
@@ -112,7 +114,15 @@
 
     @if $variant == 'material' {
         %form-group-display--border {
-            &:has(input:-webkit-autofill, input:autofill) {
+            &:has(
+                input:-webkit-autofill,
+                input:autofill,
+                input[type='date'],
+                input[type='time'],
+                input[type='datetime-local'],
+                input[type='month'],
+                input[type='week']
+            ) {
                 %igx-input-group__notch--border {
                     border-block-start-color: transparent;
                 }
@@ -137,12 +147,14 @@
 
     %form-group-display {
         @include sizable();
+
         --component-size: var(--ig-size, #{var-get($theme, 'default-size')});
         --input-size: var(--component-size);
         --input-icon: #{sizable(rem(14px), rem(16px), rem(16px))};
 
         position: relative;
         display: block;
+        color-scheme: string.unquote($mode);
         color: var-get($theme, 'idle-text-color');
 
         igx-prefix,
@@ -192,7 +204,7 @@
         }
 
         input[type='number'] {
-            -moz-appearance: textfield;
+            appearance: textfield;
         }
 
         // Don't show the number spinner
@@ -218,7 +230,15 @@
 
         @if $variant == 'material' {
             &:not(%form-group-display--border) {
-                &:has(input:-webkit-autofill, input:autofill) {
+                &:has(
+                    input:-webkit-autofill,
+                    input:autofill,
+                    input[type='date'],
+                    input[type='time'],
+                    input[type='datetime-local'],
+                    input[type='month'],
+                    input[type='week']
+                ) {
                     %form-group-label {
                         --floating-label-position: -73%;
 
@@ -230,10 +250,34 @@
             }
 
             &:not(%form-group-display--focused, %form-group-display--filled) {
-                &:has(input:not(:placeholder-shown, [type='file'])) {
+                &:has(input:not(
+                    :placeholder-shown,
+                    [type='file'],
+                    [type='date'],
+                    [type='time'],
+                    [type='datetime-local'],
+                    [type='month'],
+                    [type='week']
+                )) {
                     %form-group-label {
                         @include type-style('subtitle-1');
                         transform: translateY(0);
+                    }
+                }
+
+                &:has(
+                    input[type='date'],
+                    input[type='time'],
+                    input[type='datetime-local'],
+                    input[type='month'],
+                    input[type='week']
+                ) {
+                    %form-group-label {
+                        @include type-style('caption');
+                    }
+
+                    %igx-input-group__notch {
+                        border-block-start-color: transparent !important;
                     }
                 }
             }
@@ -366,10 +410,8 @@
                 cursor: default;
                 color: var-get($theme, 'filled-text-color');
 
-                &:not(:focus-within) {
-                    &::placeholder {
-                        color: var-get($theme, 'placeholder-color');
-                    }
+                &:not(:focus-within)::placeholder {
+                    color: var-get($theme, 'placeholder-color');
                 }
             }
         }
@@ -388,6 +430,10 @@
         igx-suffix,
         [igxSuffix] {
             @extend %form-group-suffix--disabled;
+        }
+
+        input::-webkit-datetime-edit {
+            color: var-get($theme, 'disabled-text-color');
         }
     }
 
@@ -1334,7 +1380,6 @@
 
     %form-group-input {
         position: relative;
-        display: block;
         border: none;
         padding-block-start: $input-top-padding;
         padding-block-end: $input-bottom-padding;
@@ -1348,8 +1393,16 @@
         box-shadow: none;
         overflow: hidden;
         text-overflow: ellipsis;
+        appearance: none;
 
-        &:not(%form-group-textarea, [type='date']) {
+        &:not(
+            %form-group-textarea,
+            [type='date'],
+            [type='time'],
+            [type='datetime-local'],
+            [type='month'],
+            [type='week']
+        ) {
             line-height: 0 !important; /* Reset typography */
         }
 
@@ -1361,6 +1414,16 @@
             color: var-get($theme, 'placeholder-color');
             opacity: 1;
             line-height: normal; /* Fix placeholder position in Safari */
+        }
+
+        &::-webkit-datetime-edit-fields-wrapper {
+            width: 100%;
+            padding: 0;
+        }
+
+        &::-webkit-datetime-edit {
+            color: inherit;
+            line-height: normal;
         }
 
         @if $variant == 'indigo' {
@@ -2299,7 +2362,15 @@
 
     // The :not selector is needed otherwise bootstrap will override the %autofill-background-fix
     %form-group-display--bootstrap {
-        :not(:has(input:-webkit-autofill, input:autofill)) {
+        :not(:has(
+            input:-webkit-autofill,
+            input:autofill,
+            input[type='date'],
+            input[type='time'],
+            input[type='datetime-local'],
+            input[type='month'],
+            input[type='week'])
+        ) {
             %bootstrap-input {
                 transition: box-shadow .15s ease-out, border .15s ease-out;
             }

--- a/projects/igniteui-angular/core/src/core/styles/components/input/_input-group-theme.scss
+++ b/projects/igniteui-angular/core/src/core/styles/components/input/_input-group-theme.scss
@@ -204,6 +204,7 @@
         }
 
         input[type='number'] {
+            -moz-appearance: textfield;
             appearance: textfield;
         }
 

--- a/projects/igniteui-angular/core/src/core/styles/components/input/_input-group-theme.scss
+++ b/projects/igniteui-angular/core/src/core/styles/components/input/_input-group-theme.scss
@@ -1389,7 +1389,7 @@
         width: 100%;
         min-width: 0;
         background: transparent;
-        color: var-get($theme, 'filled-text-color');
+        color: inherit;
         outline-style: none;
         box-shadow: none;
         overflow: hidden;

--- a/src/app/input-group-showcase/input-group-showcase.sample.ts
+++ b/src/app/input-group-showcase/input-group-showcase.sample.ts
@@ -51,6 +51,7 @@ defineComponents(
 })
 export class InputGroupShowcaseSampleComponent {
     public field = viewChild<IgxInputGroupComponent>('field');
+    public fieldNativeDate = viewChild<IgxInputGroupComponent>('fieldNativeDate');
     public fieldTextarea = viewChild<IgxInputGroupComponent>('fieldTextarea');
     public fieldFile = viewChild<IgxInputGroupComponent>('fieldFile');
     public select = viewChild<IgxSelectComponent>('selectReactive');
@@ -71,15 +72,28 @@ export class InputGroupShowcaseSampleComponent {
             control: {
                 type: 'button-group',
                 options: ['box', 'border', 'line', 'search'],
-                defaultValue: 'box'
+                defaultValue: 'border'
             }
         },
         type: {
             label: 'Native Input Type',
             control: {
                 type: 'select',
-                options: ['email', 'number', 'password', 'search', 'tel', 'text', 'url'],
-                defaultValue: 'text'
+                options: [
+                    'email',
+                    'number',
+                    'date',
+                    'time',
+                    'datetime-local',
+                    'month',
+                    'week',
+                    'password',
+                    'search',
+                    'tel',
+                    'text',
+                    'url'
+                ],
+                defaultValue: 'datetime-local'
             }
         },
         label: {
@@ -156,6 +170,7 @@ export class InputGroupShowcaseSampleComponent {
         angularSelect: [this.properties()?.value || ''],
         angularCombo: [this.properties()?.value || ''],
         field: [this.properties()?.value || ''],
+        fieldNativeDate: [this.properties()?.value || ''],
         fieldTextarea: [this.properties()?.value || ''],
         fieldFile: [this.properties()?.value || '']
     });
@@ -192,6 +207,7 @@ export class InputGroupShowcaseSampleComponent {
             angularSelect: this.properties()?.value || '',
             angularCombo: this.properties()?.value || '',
             field: this.properties()?.value || '',
+            fieldNativeDate: this.properties()?.value || '',
             fieldTextarea: this.properties()?.value || '',
         };
 
@@ -205,6 +221,7 @@ export class InputGroupShowcaseSampleComponent {
     private updateDisabledState(isDisabled: boolean): void {
         Object.keys(this.reactiveForm.controls).forEach((controlName) => {
             const control = this.reactiveForm.get(controlName);
+
             if (control) {
                 isDisabled ? control.disable() : control.enable();
             }

--- a/src/app/input-group-showcase/input-group-showcase.sample.ts
+++ b/src/app/input-group-showcase/input-group-showcase.sample.ts
@@ -51,7 +51,6 @@ defineComponents(
 })
 export class InputGroupShowcaseSampleComponent {
     public field = viewChild<IgxInputGroupComponent>('field');
-    public fieldNativeDate = viewChild<IgxInputGroupComponent>('fieldNativeDate');
     public fieldTextarea = viewChild<IgxInputGroupComponent>('fieldTextarea');
     public fieldFile = viewChild<IgxInputGroupComponent>('fieldFile');
     public select = viewChild<IgxSelectComponent>('selectReactive');
@@ -170,7 +169,6 @@ export class InputGroupShowcaseSampleComponent {
         angularSelect: [this.properties()?.value || ''],
         angularCombo: [this.properties()?.value || ''],
         field: [this.properties()?.value || ''],
-        fieldNativeDate: [this.properties()?.value || ''],
         fieldTextarea: [this.properties()?.value || ''],
         fieldFile: [this.properties()?.value || '']
     });
@@ -207,7 +205,6 @@ export class InputGroupShowcaseSampleComponent {
             angularSelect: this.properties()?.value || '',
             angularCombo: this.properties()?.value || '',
             field: this.properties()?.value || '',
-            fieldNativeDate: this.properties()?.value || '',
             fieldTextarea: this.properties()?.value || '',
         };
 


### PR DESCRIPTION
Closes #17156  

## Description
This PR adds minimal styling support for input types `date`, `time`, `datetime-local`, `month`, and `week` in the context of the `igx-input-group` component.


### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [x] Refactoring (no functional changes)
 - [ ] Documentation
 - [x] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
The only affected component is the Input Group.


## How Has This Been Tested?
 - [ ] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests

## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 