### PR TITLE
fix(api-docs): export chat and grid lite

### DIFF
--- a/scripts/build-typedoc.mjs
+++ b/scripts/build-typedoc.mjs
@@ -21,7 +21,11 @@ function entryPoints() {
         return ROOT("dist", "igniteui-angular", "docs", "typescript-exported", "igniteui-angular.json");
     }
 
-    return ROOT("projects", "igniteui-angular", "src", "public_api.ts");
+    return [
+        ROOT("projects", "igniteui-angular", "src", "public_api.ts"),
+        ROOT("projects", "igniteui-angular", "chat", "src", "public_api.ts"),
+        ROOT("projects", "igniteui-angular", "grids", "lite", "src", "public_api.ts"),
+    ];
 }
 
 /*


### PR DESCRIPTION
Same as https://github.com/IgniteUI/igniteui-angular/pull/17284

Reverts https://github.com/IgniteUI/igniteui-angular/pull/17207

Adding this back for the new api docs so that chat and grid-lite generate in typedoc json.