### PR TITLE
fix(hierarchical-grid): align selected data with expanded row indexes - master

### DIFF
--- a/projects/igniteui-angular-elements/src/analyzer/elements.config.ts
+++ b/projects/igniteui-angular-elements/src/analyzer/elements.config.ts
@@ -585,6 +585,7 @@ export var registerConfig = [
     methods: [
       "getRowByIndex",
       "getRowByKey",
+      "getSelectedData",
       "getCellByColumn",
       "getCellByKey",
       "pinRow",
@@ -631,7 +632,6 @@ export var registerConfig = [
       "clearCellSelection",
       "selectRange",
       "getSelectedRanges",
-      "getSelectedData",
       "selectedColumns",
       "selectColumns",
       "deselectColumns",

--- a/projects/igniteui-angular/grids/grid/src/grid-base.directive.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid-base.directive.ts
@@ -7433,7 +7433,7 @@ export abstract class IgxGridBaseDirective implements GridType,
         const keysAndData = [];
         const activeEl = this.selectionService.activeElement;
 
-        if (this.type === 'hierarchical') {
+        if (this.type === 'hierarchical' && source === this.filteredSortedData) {
             const expansionRowIndexes = [];
             for (const [key, value] of this.expansionStates.entries()) {
                 if (value) {

--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.component.ts
@@ -1165,6 +1165,20 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
         super.initColumns(collection, cb);
     }
 
+    /**
+     * @hidden @internal
+     */
+    public override getSelectedData(formatters = false, headers = false): any[] {
+        const source: any[] = [];
+        this.dataView.forEach((record) => {
+            if (this.isChildGridRecord(record)) {
+                source.push(null);
+                return;
+            }
+            source.push(record);
+        });
+        return this.extractDataFromSelection(source, formatters, headers);
+    }
 
     protected override setupColumns() {
         if (this.parentIsland && this.parentIsland.childColumns.length > 0 && !this.autoGenerate) {

--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.component.ts
@@ -803,6 +803,22 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
     }
 
     /**
+     * Returns an array of the current cell selection.
+     */
+    public override getSelectedData(formatters = false, headers = false): any[] {
+        const source: any[] = [];
+        this.dataView.forEach((record) => {
+            if (this.isChildGridRecord(record)) {
+                source.push(null);
+                return;
+            }
+            const rowData = record as any;
+            source.push(this.isGhostRecord(rowData) || this.isRecordMerged(rowData) ? rowData.recordRef : rowData);
+        });
+        return this.extractDataFromSelection(source, formatters, headers);
+    }
+
+    /**
      * Returns a `CellType` object that matches the conditions.
      *
      * @example
@@ -1163,21 +1179,6 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
             this.updateColumns(nonColumnLayoutColumns);
         }
         super.initColumns(collection, cb);
-    }
-
-    /**
-     * @hidden @internal
-     */
-    public override getSelectedData(formatters = false, headers = false): any[] {
-        const source: any[] = [];
-        this.dataView.forEach((record) => {
-            if (this.isChildGridRecord(record)) {
-                source.push(null);
-                return;
-            }
-            source.push(record);
-        });
-        return this.extractDataFromSelection(source, formatters, headers);
     }
 
     protected override setupColumns() {

--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.component.ts
@@ -803,18 +803,25 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
     }
 
     /**
-     * Returns an array of the current cell selection.
+     *
+     * Returns an array of the current cell selection in the form of `[{ column.field: cell.value }, ...]`.
+     *
+     * @remarks
+     * If `formatters` is enabled, the cell value will be formatted by its respective column formatter (if any).
+     * If `headers` is enabled, it will use the column header (if any) instead of the column field.
      */
     public override getSelectedData(formatters = false, headers = false): any[] {
         const source: any[] = [];
-        this.dataView.forEach((record) => {
+
+        const process = (record: any) => {
             if (this.isChildGridRecord(record)) {
                 source.push(null);
                 return;
             }
-            const rowData = record as any;
-            source.push(this.isGhostRecord(rowData) || this.isRecordMerged(rowData) ? rowData.recordRef : rowData);
-        });
+            source.push(this.isGhostRecord(record) || this.isRecordMerged(record) ? record.recordRef : record);
+        };
+
+        this.dataView.forEach(process);
         return this.extractDataFromSelection(source, formatters, headers);
     }
 

--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.integration.spec.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.integration.spec.ts
@@ -176,21 +176,22 @@ describe('IgxHierarchicalGrid Integration #hGrid', () => {
             const previousArtist = singersData[1].Artist;
             const targetArtist = singersData[2].Artist;
             const targetRow = grid.dataRowList.toArray()
-                .find(row => row.data.Artist === targetArtist) as IgxHierarchicalRowComponent;
+                .find(row => row.data.Artist === targetArtist) as IgxHierarchicalRowComponent | undefined;
 
-            targetRow.toggle();
+            expect(targetRow).toBeDefined();
+            targetRow!.toggle();
             tick(DEBOUNCE_TIME);
             singersFixture.detectChanges();
 
             grid.selectRange({
-                rowStart: targetRow.index,
-                rowEnd: targetRow.index,
+                rowStart: targetRow!.index,
+                rowEnd: targetRow!.index,
                 columnStart: 'Artist',
                 columnEnd: 'Artist'
             });
             singersFixture.detectChanges();
 
-            expect(targetRow.expanded).toBeTruthy();
+            expect(targetRow!.expanded).toBeTruthy();
 
             const selectedData = grid.getSelectedData();
             expect(selectedData).toEqual([{ Artist: targetArtist }]);

--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.integration.spec.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.integration.spec.ts
@@ -7,6 +7,7 @@ import { IgxColumnMovingDragDirective, IgxGridNavigationService } from 'igniteui
 import { IgxHierarchicalRowComponent } from './hierarchical-row.component';
 import { take } from 'rxjs/operators';
 import {
+    IgxHierarchicalGridEmptyDataExportComponent,
     IgxHierarchicalGridTestBaseComponent,
     IgxHierarchicalGridTestCustomToolbarComponent,
     IgxHierarchicalGridTestInputPaginatorComponent,
@@ -35,6 +36,7 @@ describe('IgxHierarchicalGrid Integration #hGrid', () => {
         TestBed.configureTestingModule({
             imports: [
                 NoopAnimationsModule,
+                IgxHierarchicalGridEmptyDataExportComponent,
                 IgxHierarchicalGridTestBaseComponent,
                 IgxHierarchicalGridTestCustomToolbarComponent,
                 IgxHierarchicalGridWithTransactionProviderComponent,
@@ -161,6 +163,38 @@ describe('IgxHierarchicalGrid Integration #hGrid', () => {
             fixture.detectChanges();
             expect(fChildCell.selected).toBeFalsy();
             expect(fCell.selected).toBeTruthy();
+        }));
+
+        it('should not copy the previous row value from an expanded parent row', fakeAsync(() => {
+            const singersFixture = TestBed.createComponent(IgxHierarchicalGridEmptyDataExportComponent);
+            const singersData = SampleTestData.hierarchicalGridSingersFullData();
+            (singersFixture.componentInstance as { data: unknown[] }).data = singersData;
+            singersFixture.detectChanges();
+
+            const grid = singersFixture.componentInstance.hGrid;
+
+            const previousArtist = singersData[1].Artist;
+            const targetArtist = singersData[2].Artist;
+            const targetRow = grid.dataRowList.toArray()
+                .find(row => row.data.Artist === targetArtist) as IgxHierarchicalRowComponent;
+
+            targetRow.toggle();
+            tick(DEBOUNCE_TIME);
+            singersFixture.detectChanges();
+
+            grid.selectRange({
+                rowStart: targetRow.index,
+                rowEnd: targetRow.index,
+                columnStart: 'Artist',
+                columnEnd: 'Artist'
+            });
+            singersFixture.detectChanges();
+
+            expect(targetRow.expanded).toBeTruthy();
+
+            const selectedData = grid.getSelectedData();
+            expect(selectedData).toEqual([{ Artist: targetArtist }]);
+            expect(selectedData[0].Artist).not.toBe(previousArtist);
         }));
     });
 


### PR DESCRIPTION
Closes #17295   

## Description
This PR fixes a Hierarchical Grid issue where copying/selecting a cell from an expanded parent row returned the value from the previous row.

The fix uses `dataView` as the selected data source and keeps child-grid placeholder rows as `null` to preserve index alignment with visible rows.

## Motivation / Context
After expanding the `Artist Ahmad Nazeri` row, copying its `Artist` cell returned `Artist Babila Ebwélé` instead of the selected row value.

This happened because selection indexes were based on visible rows, while the selected data source did not account for expanded child-grid placeholder rows.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
Hierarchical Grid, cell selection/copy

## How Has This Been Tested?
Added a regression test that expands the `Artist Ahmad Nazeri` row, selects its `Artist` cell, and verifies `getSelectedData()` returns the correct value instead of the previous row value.|

 - [x] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **Angular version**: 22.0.x
 - **Browser(s)**: All
 - **OS**: All

## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 