### PR TITLE
fix(hierarchical-grid): hide child row editing overlay on scroll - 21.2.x

### DIFF
--- a/projects/igniteui-angular/grids/core/src/grid.common.ts
+++ b/projects/igniteui-angular/grids/core/src/grid.common.ts
@@ -63,6 +63,64 @@ export class RowEditPositionStrategy extends ConnectedPositioningStrategy {
 
         super.position(contentElement, { width: targetElement.clientWidth, height: targetElement.clientHeight },
             document, initialCall, targetElement);
+
+        this.updateContentClip(contentElement);
+    }
+
+    private updateContentClip(contentElement: HTMLElement): void {
+        const container = this.settings.container;
+
+        if (!container) {
+            return;
+        }
+
+        const clippingRect = this.getClippingRect(container);
+        const contentRect = contentElement.getBoundingClientRect();
+
+        const top = Math.round(Math.max(clippingRect.top - contentRect.top, 0));
+        const right = Math.round(Math.max(contentRect.right - clippingRect.right, 0));
+        const bottom = Math.round(Math.max(contentRect.bottom - clippingRect.bottom, 0));
+        const left = Math.round(Math.max(clippingRect.left - contentRect.left, 0));
+
+        const fullyClipped = top >= contentRect.height || bottom >= contentRect.height ||
+            left >= contentRect.width || right >= contentRect.width;
+
+        contentElement.style.clipPath = fullyClipped ? 'inset(100%)' :
+            (top || right || bottom || left ? `inset(${top}px ${right}px ${bottom}px ${left}px)` : '');
+
+        contentElement.style.pointerEvents = fullyClipped ? 'none' : '';
+        contentElement.style.visibility = '';
+    }
+
+    private getClippingRect(element: HTMLElement): Pick<DOMRect, 'top' | 'right' | 'bottom' | 'left'> {
+        const document = element.ownerDocument;
+        const rect = element.getBoundingClientRect();
+        const clippingRect = { top: rect.top, right: rect.right, bottom: rect.bottom, left: rect.left };
+
+        let parent = element.parentElement;
+
+        while (parent && parent !== document.body && parent !== document.documentElement) {
+            const style = getComputedStyle(parent);
+            const overflow = `${style.overflow}${style.overflowX}${style.overflowY}`;
+
+            if (/(auto|scroll|hidden|clip)/.test(overflow)) {
+                const parentRect = parent.getBoundingClientRect();
+
+                clippingRect.top = Math.max(clippingRect.top, parentRect.top);
+                clippingRect.right = Math.min(clippingRect.right, parentRect.right);
+                clippingRect.bottom = Math.min(clippingRect.bottom, parentRect.bottom);
+                clippingRect.left = Math.max(clippingRect.left, parentRect.left);
+            }
+
+            parent = parent.parentElement;
+        }
+
+        return {
+            top: Math.max(clippingRect.top, 0),
+            right: Math.min(clippingRect.right, document.documentElement.clientWidth),
+            bottom: Math.min(clippingRect.bottom, document.documentElement.clientHeight),
+            left: Math.max(clippingRect.left, 0)
+        };
     }
 
     /**

--- a/projects/igniteui-angular/grids/core/src/grid.common.ts
+++ b/projects/igniteui-angular/grids/core/src/grid.common.ts
@@ -64,6 +64,7 @@ export class RowEditPositionStrategy extends ConnectedPositioningStrategy {
         super.position(contentElement, { width: targetElement.clientWidth, height: targetElement.clientHeight },
             document, initialCall, targetElement);
 
+        // After positioning in the top layer, keep the overlay clipped to the visible grid body.
         this.updateContentClip(contentElement);
     }
 
@@ -77,32 +78,38 @@ export class RowEditPositionStrategy extends ConnectedPositioningStrategy {
         const clippingRect = this.getClippingRect(container);
         const contentRect = contentElement.getBoundingClientRect();
 
+        // Convert the clipped overflow on each side to CSS inset values.
         const top = Math.round(Math.max(clippingRect.top - contentRect.top, 0));
         const right = Math.round(Math.max(contentRect.right - clippingRect.right, 0));
         const bottom = Math.round(Math.max(contentRect.bottom - clippingRect.bottom, 0));
         const left = Math.round(Math.max(clippingRect.left - contentRect.left, 0));
 
+        // When the overlay is fully outside the clipping rect, hide it and block its action buttons.
         const fullyClipped = top >= contentRect.height || bottom >= contentRect.height ||
             left >= contentRect.width || right >= contentRect.width;
 
+        // Row-edit overlays are rendered in the top layer, so clip the content explicitly to the grid's visible area.
         contentElement.style.clipPath = fullyClipped ? 'inset(100%)' :
             (top || right || bottom || left ? `inset(${top}px ${right}px ${bottom}px ${left}px)` : '');
 
         contentElement.style.pointerEvents = fullyClipped ? 'none' : '';
-        contentElement.style.visibility = '';
+        contentElement.style.visibility = fullyClipped ? 'hidden' : '';
     }
 
     private getClippingRect(element: HTMLElement): Pick<DOMRect, 'top' | 'right' | 'bottom' | 'left'> {
         const document = element.ownerDocument;
         const rect = element.getBoundingClientRect();
+        // Start with the current grid body, then narrow it by every clipping parent.
         const clippingRect = { top: rect.top, right: rect.right, bottom: rect.bottom, left: rect.left };
 
         let parent = element.parentElement;
 
+        // Intersect with clipping ancestors so nested grids respect their parent grid scroll bounds.
         while (parent && parent !== document.body && parent !== document.documentElement) {
-            const style = getComputedStyle(parent);
+            const style = document.defaultView?.getComputedStyle(parent) ?? parent.style;
             const overflow = `${style.overflow}${style.overflowX}${style.overflowY}`;
 
+            // Only ancestors that clip their children should reduce the visible area.
             if (/(auto|scroll|hidden|clip)/.test(overflow)) {
                 const parentRect = parent.getBoundingClientRect();
 
@@ -115,6 +122,7 @@ export class RowEditPositionStrategy extends ConnectedPositioningStrategy {
             parent = parent.parentElement;
         }
 
+        // Keep the clipping area inside the viewport because popover content is viewport-positioned.
         return {
             top: Math.max(clippingRect.top, 0),
             right: Math.min(clippingRect.right, document.documentElement.clientWidth),

--- a/projects/igniteui-angular/grids/core/src/grid.common.ts
+++ b/projects/igniteui-angular/grids/core/src/grid.common.ts
@@ -18,6 +18,7 @@ export class IgxGridBodyDirective { }
  */
 export interface RowEditPositionSettings extends PositionSettings {
     container?: HTMLElement;
+    clipToVisibleArea?: boolean;
 }
 
 /**
@@ -64,8 +65,10 @@ export class RowEditPositionStrategy extends ConnectedPositioningStrategy {
         super.position(contentElement, { width: targetElement.clientWidth, height: targetElement.clientHeight },
             document, initialCall, targetElement);
 
-        // After positioning in the top layer, keep the overlay clipped to the visible grid body.
-        this.updateContentClip(contentElement);
+        if (this.settings.clipToVisibleArea) {
+            // After positioning in the top layer, keep the overlay clipped to the visible grid body.
+            this.updateContentClip(contentElement);
+        }
     }
 
     private updateContentClip(contentElement: HTMLElement): void {
@@ -98,28 +101,27 @@ export class RowEditPositionStrategy extends ConnectedPositioningStrategy {
 
     private getClippingRect(element: HTMLElement): Pick<DOMRect, 'top' | 'right' | 'bottom' | 'left'> {
         const document = element.ownerDocument;
-        const rect = element.getBoundingClientRect();
-        // Start with the current grid body, then narrow it by every clipping parent.
+        const gridBody = element.closest('[igxgridbody]') as HTMLElement || element;
+        const rect = gridBody.getBoundingClientRect();
+        // Start with the current grid body, then narrow it by parent grid bodies.
         const clippingRect = { top: rect.top, right: rect.right, bottom: rect.bottom, left: rect.left };
 
-        let parent = element.parentElement;
+        let parent = gridBody.parentElement?.closest('[igxgridbody]') as HTMLElement;
 
-        // Intersect with clipping ancestors so nested grids respect their parent grid scroll bounds.
-        while (parent && parent !== document.body && parent !== document.documentElement) {
-            const style = document.defaultView?.getComputedStyle(parent) ?? parent.style;
-            const overflow = `${style.overflow}${style.overflowX}${style.overflowY}`;
+        // Intersect with parent grid bodies so nested grids respect their parent scroll bounds.
+        while (parent) {
+            const parentRect = parent.getBoundingClientRect();
 
-            // Only ancestors that clip their children should reduce the visible area.
-            if (/(auto|scroll|hidden|clip)/.test(overflow)) {
-                const parentRect = parent.getBoundingClientRect();
+            clippingRect.top = Math.max(clippingRect.top, parentRect.top);
+            clippingRect.right = Math.min(clippingRect.right, parentRect.right);
+            clippingRect.bottom = Math.min(clippingRect.bottom, parentRect.bottom);
+            clippingRect.left = Math.max(clippingRect.left, parentRect.left);
 
-                clippingRect.top = Math.max(clippingRect.top, parentRect.top);
-                clippingRect.right = Math.min(clippingRect.right, parentRect.right);
-                clippingRect.bottom = Math.min(clippingRect.bottom, parentRect.bottom);
-                clippingRect.left = Math.max(clippingRect.left, parentRect.left);
+            if (clippingRect.top >= clippingRect.bottom || clippingRect.left >= clippingRect.right) {
+                break;
             }
 
-            parent = parent.parentElement;
+            parent = parent.parentElement?.closest('[igxgridbody]') as HTMLElement;
         }
 
         // Keep the clipping area inside the viewport because popover content is viewport-positioned.

--- a/projects/igniteui-angular/grids/grid/src/grid-base.directive.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid-base.directive.ts
@@ -8143,6 +8143,8 @@ export abstract class IgxGridBaseDirective implements GridType,
             settings = overlay.settings;
         }
         this.rowEditPositioningStrategy.settings.container = this.tbody.nativeElement;
+        this.rowEditPositioningStrategy.settings.clipToVisibleArea =
+            this.type === 'hierarchical' && (this as GridType).rootGrid !== this;
         const pinned = this._pinnedRecordIDs.indexOf(rowID) !== -1;
         const targetRow = !pinned ?
             this.gridAPI.get_row_by_key(rowID) as IgxRowDirective

--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.component.ts
@@ -8,7 +8,7 @@ import { IgxColumnComponent, } from 'igniteui-angular/grids/core';
 import { IgxHierarchicalGridNavigationService } from './hierarchical-grid-navigation.service';
 import { IgxGridSummaryService } from 'igniteui-angular/grids/core';
 import { IgxHierarchicalGridBaseDirective } from './hierarchical-grid-base.directive';
-import { first, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 import { CellType, GridType, IGX_GRID_BASE, IGX_GRID_SERVICE_BASE, RowType } from 'igniteui-angular/grids/core';
 import { IgxRowIslandAPIService } from './row-island-api.service';
 import { IgxGridCRUDService } from 'igniteui-angular/grids/core';
@@ -1115,7 +1115,6 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
     /** @hidden @internal **/
     public onContainerScroll() {
         this.hideOverlays();
-        this.updateChildRowEditingOverlayStateOnScroll();
     }
 
     /**
@@ -1136,15 +1135,6 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
     /** @hidden @internal */
     public getChildGrids(inDeph?: boolean) {
         return this.gridAPI.getChildGrids(inDeph);
-    }
-
-    /** @hidden @internal **/
-    protected override verticalScrollHandler(event) {
-        super.verticalScrollHandler(event);
-
-        this.zone.onStable.pipe(first()).subscribe(() => {
-            this.updateChildRowEditingOverlayStateOnScroll();
-        });
     }
 
     protected override generateDataFields(data: any[]): string[] {
@@ -1304,30 +1294,5 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
             fields: fields,
             childEntities: childEntities
         }
-    }
-
-    private updateChildRowEditingOverlayStateOnScroll() {
-        const visibleArea = this.tbodyContainer.nativeElement.getBoundingClientRect();
-        const childGrids = this.gridAPI.getChildGrids(true) as IgxHierarchicalGridComponent[];
-
-        childGrids.forEach((grid) => {
-            if (!grid.rowEditable || !grid.rowEditingOverlay || grid.rowEditingOverlay.collapsed) {
-                return;
-            }
-
-            const row = grid.crudService.rowInEditMode;
-
-            if (!row || !this.isElementInVisibleArea(row.nativeElement, visibleArea)) {
-                grid.toggleRowEditingOverlay(false);
-            } else {
-                grid.toggleRowEditingOverlay(true);
-                grid.repositionRowEditingOverlay(row);
-            }
-        });
-    }
-
-    private isElementInVisibleArea(element: HTMLElement, visibleArea: DOMRect) {
-        const rect = element.getBoundingClientRect();
-        return rect.bottom > visibleArea.top && rect.top < visibleArea.bottom;
     }
 }

--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.component.ts
@@ -1311,11 +1311,11 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
         const childGrids = this.gridAPI.getChildGrids(true) as IgxHierarchicalGridComponent[];
 
         childGrids.forEach((grid) => {
-            const row = grid.crudService.rowInEditMode;
-
             if (!grid.rowEditable || !grid.rowEditingOverlay || grid.rowEditingOverlay.collapsed) {
                 return;
             }
+
+            const row = grid.crudService.rowInEditMode;
 
             if (!row || !this.isElementInVisibleArea(row.nativeElement, visibleArea)) {
                 grid.toggleRowEditingOverlay(false);

--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.component.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.component.ts
@@ -8,7 +8,7 @@ import { IgxColumnComponent, } from 'igniteui-angular/grids/core';
 import { IgxHierarchicalGridNavigationService } from './hierarchical-grid-navigation.service';
 import { IgxGridSummaryService } from 'igniteui-angular/grids/core';
 import { IgxHierarchicalGridBaseDirective } from './hierarchical-grid-base.directive';
-import { takeUntil } from 'rxjs/operators';
+import { first, takeUntil } from 'rxjs/operators';
 import { CellType, GridType, IGX_GRID_BASE, IGX_GRID_SERVICE_BASE, RowType } from 'igniteui-angular/grids/core';
 import { IgxRowIslandAPIService } from './row-island-api.service';
 import { IgxGridCRUDService } from 'igniteui-angular/grids/core';
@@ -1115,6 +1115,7 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
     /** @hidden @internal **/
     public onContainerScroll() {
         this.hideOverlays();
+        this.updateChildRowEditingOverlayStateOnScroll();
     }
 
     /**
@@ -1135,6 +1136,15 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
     /** @hidden @internal */
     public getChildGrids(inDeph?: boolean) {
         return this.gridAPI.getChildGrids(inDeph);
+    }
+
+    /** @hidden @internal **/
+    protected override verticalScrollHandler(event) {
+        super.verticalScrollHandler(event);
+
+        this.zone.onStable.pipe(first()).subscribe(() => {
+            this.updateChildRowEditingOverlayStateOnScroll();
+        });
     }
 
     protected override generateDataFields(data: any[]): string[] {
@@ -1294,5 +1304,30 @@ export class IgxHierarchicalGridComponent extends IgxHierarchicalGridBaseDirecti
             fields: fields,
             childEntities: childEntities
         }
+    }
+
+    private updateChildRowEditingOverlayStateOnScroll() {
+        const visibleArea = this.tbodyContainer.nativeElement.getBoundingClientRect();
+        const childGrids = this.gridAPI.getChildGrids(true) as IgxHierarchicalGridComponent[];
+
+        childGrids.forEach((grid) => {
+            const row = grid.crudService.rowInEditMode;
+
+            if (!grid.rowEditable || !grid.rowEditingOverlay || grid.rowEditingOverlay.collapsed) {
+                return;
+            }
+
+            if (!row || !this.isElementInVisibleArea(row.nativeElement, visibleArea)) {
+                grid.toggleRowEditingOverlay(false);
+            } else {
+                grid.toggleRowEditingOverlay(true);
+                grid.repositionRowEditingOverlay(row);
+            }
+        });
+    }
+
+    private isElementInVisibleArea(element: HTMLElement, visibleArea: DOMRect) {
+        const rect = element.getBoundingClientRect();
+        return rect.bottom > visibleArea.top && rect.top < visibleArea.bottom;
     }
 }

--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.spec.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.spec.ts
@@ -783,6 +783,73 @@ describe('Basic IgxHierarchicalGrid #hGrid', () => {
             expect(childGrids[1].height).toBe('200px');
         });
 
+        it('should hide child row editing overlay when parent scroll moves child row out of view', () => {
+            hierarchicalGrid.getRowByIndex(0).expanded = true;
+            fixture.detectChanges();
+
+            const childGrid = hierarchicalGrid.gridAPI.getChildGrids()[0] as IgxHierarchicalGridComponent;
+            childGrid.primaryKey = 'ID';
+            childGrid.rowEditable = true;
+            fixture.detectChanges();
+
+            const row = childGrid.gridAPI.get_row_by_index(0);
+            spyOnProperty(childGrid.crudService, 'rowInEditMode', 'get').and.returnValue(row);
+            spyOnProperty(childGrid.rowEditingOverlay, 'collapsed', 'get').and.returnValue(false);
+            childGrid.rowEditingOverlay.element.style.display = 'block';
+
+            spyOn((hierarchicalGrid as any).tbodyContainer.nativeElement, 'getBoundingClientRect').and.returnValue({
+                top: 0,
+                bottom: 200
+            } as DOMRect);
+            let childRowRect = {
+                top: 40,
+                bottom: 80
+            } as DOMRect;
+            spyOn(row.nativeElement, 'getBoundingClientRect').and.callFake(() => childRowRect);
+            const repositionOverlaySpy = spyOn(childGrid, 'repositionRowEditingOverlay');
+            const toggleOverlaySpy = spyOn(childGrid, 'toggleRowEditingOverlay').and.callThrough();
+
+            const scroll = hierarchicalGrid.verticalScrollContainer.getScroll();
+            scroll.scrollTop = 10;
+            (hierarchicalGrid as any).verticalScrollHandler({ target: scroll });
+            (hierarchicalGrid as any).zone.onStable.emit(null);
+            fixture.detectChanges();
+
+            expect(repositionOverlaySpy).toHaveBeenCalledWith(row);
+            expect(toggleOverlaySpy).not.toHaveBeenCalledWith(false);
+            expect(childGrid.rowEditingOverlay.element.style.display).not.toBe('none');
+
+            repositionOverlaySpy.calls.reset();
+            toggleOverlaySpy.calls.reset();
+            childRowRect = {
+                top: -80,
+                bottom: -40
+            } as DOMRect;
+            scroll.scrollTop = 1000;
+            (hierarchicalGrid as any).verticalScrollHandler({ target: scroll });
+            (hierarchicalGrid as any).zone.onStable.emit(null);
+            fixture.detectChanges();
+
+            expect(repositionOverlaySpy).not.toHaveBeenCalled();
+            expect(toggleOverlaySpy).toHaveBeenCalledWith(false);
+            expect(childGrid.rowEditingOverlay.element.style.display).toBe('none');
+
+            repositionOverlaySpy.calls.reset();
+            toggleOverlaySpy.calls.reset();
+            childRowRect = {
+                top: 40,
+                bottom: 80
+            } as DOMRect;
+            scroll.scrollTop = 10;
+            (hierarchicalGrid as any).verticalScrollHandler({ target: scroll });
+            (hierarchicalGrid as any).zone.onStable.emit(null);
+            fixture.detectChanges();
+
+            expect(toggleOverlaySpy).toHaveBeenCalledWith(true);
+            expect(repositionOverlaySpy).toHaveBeenCalledWith(row);
+            expect(childGrid.rowEditingOverlay.element.style.display).not.toBe('none');
+        });
+
         it('Should apply runtime option changes to all related child grids (both existing and not yet initialized).', () => {
             const row = hierarchicalGrid.gridAPI.get_row_by_index(0) as IgxHierarchicalRowComponent;
             UIInteractions.simulateClickAndSelectEvent(row.expander);

--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.spec.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.spec.ts
@@ -794,60 +794,38 @@ describe('Basic IgxHierarchicalGrid #hGrid', () => {
 
             const row = childGrid.gridAPI.get_row_by_index(0);
             spyOnProperty(childGrid.crudService, 'rowInEditMode', 'get').and.returnValue(row);
-            spyOnProperty(childGrid.rowEditingOverlay, 'collapsed', 'get').and.returnValue(false);
-            childGrid.rowEditingOverlay.element.style.display = 'block';
+            childGrid.openRowOverlay(row.key);
+            fixture.detectChanges();
 
-            spyOn((hierarchicalGrid as any).tbodyContainer.nativeElement, 'getBoundingClientRect').and.returnValue({
-                top: 0,
-                bottom: 200
+            expect(childGrid.rowEditingOverlay.collapsed).toBeFalse();
+
+            const parentTbody = hierarchicalGrid.tbody.nativeElement.parentElement;
+            const childTbody = childGrid.tbody.nativeElement.parentElement;
+            const overlayContent = childGrid.rowEditingOverlay.element.parentElement;
+
+            parentTbody.style.overflow = 'hidden';
+            childTbody.style.overflow = 'hidden';
+            spyOn(parentTbody, 'getBoundingClientRect').and.returnValue({
+                top: 0, right: 500, bottom: 200, left: 0
             } as DOMRect);
-            let childRowRect = {
-                top: 40,
-                bottom: 80
-            } as DOMRect;
-            spyOn(row.nativeElement, 'getBoundingClientRect').and.callFake(() => childRowRect);
-            const repositionOverlaySpy = spyOn(childGrid, 'repositionRowEditingOverlay');
-            const toggleOverlaySpy = spyOn(childGrid, 'toggleRowEditingOverlay').and.callThrough();
+            spyOn(childTbody, 'getBoundingClientRect').and.returnValue({
+                top: 0, right: 500, bottom: 200, left: 0
+            } as DOMRect);
+            spyOn(childGrid.tbody.nativeElement, 'getBoundingClientRect').and.returnValue({
+                top: -100, right: 500, bottom: 500, left: 0
+            } as DOMRect);
+            spyOn(row.nativeElement, 'getBoundingClientRect').and.returnValue({
+                top: -120, right: 500, bottom: -80, left: 0
+            } as DOMRect);
+            spyOn(overlayContent, 'getBoundingClientRect').and.returnValue({
+                top: -80, right: 500, bottom: -32, left: 0, width: 500, height: 48
+            } as DOMRect);
 
-            const scroll = hierarchicalGrid.verticalScrollContainer.getScroll();
-            scroll.scrollTop = 10;
-            (hierarchicalGrid as any).verticalScrollHandler({ target: scroll });
-            (hierarchicalGrid as any).zone.onStable.emit(null);
+            childGrid.rowEditingOverlay.reposition();
             fixture.detectChanges();
 
-            expect(repositionOverlaySpy).toHaveBeenCalledWith(row);
-            expect(toggleOverlaySpy).not.toHaveBeenCalledWith(false);
-            expect(childGrid.rowEditingOverlay.element.style.display).not.toBe('none');
-
-            repositionOverlaySpy.calls.reset();
-            toggleOverlaySpy.calls.reset();
-            childRowRect = {
-                top: -80,
-                bottom: -40
-            } as DOMRect;
-            scroll.scrollTop = 1000;
-            (hierarchicalGrid as any).verticalScrollHandler({ target: scroll });
-            (hierarchicalGrid as any).zone.onStable.emit(null);
-            fixture.detectChanges();
-
-            expect(repositionOverlaySpy).not.toHaveBeenCalled();
-            expect(toggleOverlaySpy).toHaveBeenCalledWith(false);
-            expect(childGrid.rowEditingOverlay.element.style.display).toBe('none');
-
-            repositionOverlaySpy.calls.reset();
-            toggleOverlaySpy.calls.reset();
-            childRowRect = {
-                top: 40,
-                bottom: 80
-            } as DOMRect;
-            scroll.scrollTop = 10;
-            (hierarchicalGrid as any).verticalScrollHandler({ target: scroll });
-            (hierarchicalGrid as any).zone.onStable.emit(null);
-            fixture.detectChanges();
-
-            expect(toggleOverlaySpy).toHaveBeenCalledWith(true);
-            expect(repositionOverlaySpy).toHaveBeenCalledWith(row);
-            expect(childGrid.rowEditingOverlay.element.style.display).not.toBe('none');
+            expect(overlayContent.style.clipPath).toBe('inset(100%)');
+            expect(overlayContent.style.pointerEvents).toBe('none');
         });
 
         it('Should apply runtime option changes to all related child grids (both existing and not yet initialized).', () => {


### PR DESCRIPTION
Closes #17275   

## Description
Fixes an issue where a row editing overlay could remain visible outside the grid boundaries while scrolling, especially in nested Hierarchical Grid row islands.

The fix clips the row editing overlay to the effective visible grid area after it is positioned. Since the overlay is rendered in the top layer, it no longer relies on the grid body overflow to hide it when the edited row scrolls out of view.

The clipping area is calculated from the row edit container and its clipping ancestors, so nested grids respect their parent grid scroll bounds.

## Motivation / Context
When row editing is started inside a child grid and the user scrolls a parent or nested grid, the editing overlay could visually escape the grid body and appear detached from the edited row.

This happened because the overlay is positioned outside the normal grid body clipping context. The fix keeps the overlay visually constrained to the same visible area as the edited row.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [x] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
- Hierarchical Grid
- Row Editing
- Overlay positioning / clipping on scroll

## How Has This Been Tested?
Added unit tests for Hierarchical Grid child row editing overlay behavior during scroll.

 - [x] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **Angular version**: 21.2.x
 - **Browser(s)**: all
 - **OS**: all

## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 