### PR TITLE
fix(date-picker): invoke markForCheck() on overlay open/close to prevent NG0100 in zoneless apps

### DIFF
--- a/projects/igniteui-angular/date-picker/src/date-picker/date-picker.component.spec.ts
+++ b/projects/igniteui-angular/date-picker/src/date-picker/date-picker.component.spec.ts
@@ -13,7 +13,7 @@ import {
     OverlayCancelableEventArgs, OverlayClosingEventArgs, OverlayEventArgs, OverlaySettings,
     WEEKDAYS
 } from 'igniteui-angular/core';
-import { ChangeDetectorRef, Component, DebugElement, ElementRef, EventEmitter, Injector, QueryList, Renderer2, ViewChild } from '@angular/core';
+import { ChangeDetectorRef, Component, DebugElement, ElementRef, EventEmitter, Injector, provideZonelessChangeDetection, QueryList, Renderer2, ViewChild } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { PickerCalendarOrientation, PickerHeaderOrientation, PickerInteractionMode } from '../../../core/src/date-common/types';
 import { DatePart } from '../../../core/src/date-common/public_api';
@@ -903,8 +903,8 @@ describe('IgxDatePicker', () => {
                 get: mockNgControl
             });
 
-            mockCdr = jasmine.createSpyObj('ChangeDetectorRef', ['detectChanges']);
-            mockCalendar = { selected: new EventEmitter<any>(), selectDate: () => {} };
+            mockCdr = jasmine.createSpyObj('ChangeDetectorRef', ['detectChanges', 'markForCheck']);
+            mockCalendar = { selected: new EventEmitter<any>(), selectDate: () => { } };
             const mockComponentInstance = {
                 calendar: mockCalendar,
                 todaySelection: new EventEmitter<any>(),
@@ -1664,6 +1664,43 @@ describe('IgxDatePicker', () => {
                 expect(mockInputDirective.valid).toEqual(IgxInputState.INVALID);
             });
         });
+    });
+
+    describe('Zoneless', () => {
+        let fixture: ComponentFixture<IgxDatePickerNgModelComponent>;
+        let datePicker: IgxDatePickerComponent;
+
+        beforeEach(async () => {
+            await TestBed.configureTestingModule({
+                imports: [
+                    NoopAnimationsModule,
+                    IgxDatePickerNgModelComponent,
+                ],
+                providers: [
+                    provideZonelessChangeDetection()
+                ]
+            }).compileComponents();
+
+            fixture = TestBed.createComponent(IgxDatePickerNgModelComponent);
+            await fixture.whenStable();
+        });
+
+        it('should not throw ExpressionChangedAfterItHasBeenCheckedError when closing - issue #17305', fakeAsync(async () => {
+            datePicker = fixture.componentInstance.datePicker;
+
+            datePicker.open();
+            await fixture.whenStable();
+
+            expect(async () => {
+                datePicker.close();
+                fixture.detectChanges();
+                tick(100);
+                await fixture.whenStable();
+
+                const input = fixture.debugElement.query(By.css('input'));
+                expect(input.nativeElement.getAttribute('aria-expanded')).toBe('false');
+            }).not.toThrow();
+        }));
     });
 });
 @Component({

--- a/projects/igniteui-angular/date-picker/src/date-picker/date-picker.component.spec.ts
+++ b/projects/igniteui-angular/date-picker/src/date-picker/date-picker.component.spec.ts
@@ -1682,24 +1682,25 @@ describe('IgxDatePicker', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(IgxDatePickerNgModelComponent);
-            await fixture.whenStable();
+            fixture.detectChanges();
         });
 
-        it('should not throw ExpressionChangedAfterItHasBeenCheckedError when closing - issue #17305', fakeAsync(async () => {
+        it('should not throw ExpressionChangedAfterItHasBeenCheckedError when closing - issue #17305', fakeAsync(() => {
             datePicker = fixture.componentInstance.datePicker;
 
             datePicker.open();
-            await fixture.whenStable();
+            fixture.detectChanges();
+            tick();
 
-            expect(async () => {
+            expect(() => {
                 datePicker.close();
                 fixture.detectChanges();
-                tick(100);
-                await fixture.whenStable();
-
-                const input = fixture.debugElement.query(By.css('input'));
-                expect(input.nativeElement.getAttribute('aria-expanded')).toBe('false');
             }).not.toThrow();
+
+            fixture.detectChanges();
+            tick(100);
+            const input = fixture.debugElement.query(By.css('input'));
+            expect(input.nativeElement.getAttribute('aria-expanded')).toBe('false');
         }));
     });
 });

--- a/projects/igniteui-angular/date-picker/src/date-picker/date-picker.component.ts
+++ b/projects/igniteui-angular/date-picker/src/date-picker/date-picker.component.ts
@@ -904,6 +904,7 @@ export class IgxDatePickerComponent extends PickerBaseDirective implements Contr
             this._initializeCalendarContainer(e.componentRef.instance);
             this._calendarContainer = e.componentRef.location.nativeElement;
             this._collapsed = false;
+            this.cdr.markForCheck();
         });
 
         this._overlayService.opened.pipe(...this._overlaySubFilter).subscribe(() => {
@@ -936,6 +937,7 @@ export class IgxDatePickerComponent extends PickerBaseDirective implements Contr
             this._overlayId = null;
             this._calendar = null;
             this._calendarContainer = undefined;
+            this.cdr.markForCheck();
         });
     }
 


### PR DESCRIPTION
Closes #17305  

## Description
Invokes cdr `markForCheck` in the overlay service's opening and closing callbacks after the internal `_collapsed` member has been changed.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
IgxDatePicker

## How Has This Been Tested?
 - [x] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 