### PR TITLE
fix(combo): address NG0100 in zoneless apps - 21.2.x

### DIFF
--- a/projects/igniteui-angular/combo/src/combo/combo-dropdown.component.ts
+++ b/projects/igniteui-angular/combo/src/combo/combo-dropdown.component.ts
@@ -17,6 +17,8 @@ export class IgxComboDropDownComponent extends IgxDropDownComponent implements I
     public combo = inject<IgxComboBase>(IGX_COMBO_COMPONENT);
     protected comboAPI = inject(IgxComboAPIService);
 
+    private _activeDescendantId: string | null = null;
+
     /** @hidden @internal */
     @Input({ transform: booleanAttribute })
     public singleMode = false;
@@ -52,6 +54,40 @@ export class IgxComboDropDownComponent extends IgxDropDownComponent implements I
                 .sort((a: IgxDropDownItemBaseDirective, b: IgxDropDownItemBaseDirective) => a.index - b.index);
         }
         return null;
+    }
+
+    /**
+     * @hidden @internal
+     */
+    public override get focusedItem(): IgxDropDownItemBaseDirective {
+        return super.focusedItem;
+    }
+
+    /**
+     * @hidden @internal
+     * Returns a stable aria-activedescendant id, unaffected by virtual scroll position.
+     * The base class computes this from the live focusedItem getter, which reads from the
+     * children QueryList. During virtual scroll the QueryList is recycled, so the getter
+     * can return null mid-CD-cycle causing NG0100 in zoneless apps. The id is cached instead.
+     */
+    public override get activeDescendant(): string | null {
+        return this._activeDescendantId;
+    }
+
+    /** @hidden @internal */
+    public override set focusedItem(item: IgxDropDownItemBaseDirective) {
+        if (!item) {
+            this._activeDescendantId = null;
+        } else if (item.id !== undefined) {
+            this._activeDescendantId = item.id;
+        } else {
+            // Virtual { value, index } object passed by navigateItem() under virtual scrolling.
+            const resolved = this.children?.find(e => e.index === item.index);
+            if (resolved) {
+                this._activeDescendantId = resolved.id;
+            }
+        }
+        super.focusedItem = item;
     }
 
     /**
@@ -141,6 +177,7 @@ export class IgxComboDropDownComponent extends IgxDropDownComponent implements I
             return;
         }
         this.comboAPI.set_selected_item(item.itemID);
+        this._activeDescendantId = item.id;
         this._focusedItem = item;
         this.combo.setActiveDescendant();
     }

--- a/projects/igniteui-angular/combo/src/combo/combo-dropdown.component.ts
+++ b/projects/igniteui-angular/combo/src/combo/combo-dropdown.component.ts
@@ -59,7 +59,7 @@ export class IgxComboDropDownComponent extends IgxDropDownComponent implements I
     /**
      * @hidden @internal
      */
-    public override get focusedItem(): IgxDropDownItemBaseDirective {
+    public override get focusedItem(): IgxDropDownItemBaseDirective | null {
         return super.focusedItem;
     }
 
@@ -75,7 +75,7 @@ export class IgxComboDropDownComponent extends IgxDropDownComponent implements I
     }
 
     /** @hidden @internal */
-    public override set focusedItem(item: IgxDropDownItemBaseDirective) {
+    public override set focusedItem(item: IgxDropDownItemBaseDirective | null) {
         if (!item) {
             this._activeDescendantId = null;
         } else if (item.id !== undefined) {
@@ -83,9 +83,7 @@ export class IgxComboDropDownComponent extends IgxDropDownComponent implements I
         } else {
             // Virtual { value, index } object passed by navigateItem() under virtual scrolling.
             const resolved = this.children?.find(e => e.index === item.index);
-            if (resolved) {
-                this._activeDescendantId = resolved.id;
-            }
+            this._activeDescendantId = resolved?.id ?? null;
         }
         super.focusedItem = item;
     }
@@ -177,7 +175,7 @@ export class IgxComboDropDownComponent extends IgxDropDownComponent implements I
             return;
         }
         this.comboAPI.set_selected_item(item.itemID);
-        this._activeDescendantId = item.id;
+        this._activeDescendantId = item.id ?? null;
         this._focusedItem = item;
         this.combo.setActiveDescendant();
     }

--- a/projects/igniteui-angular/combo/src/combo/combo-item.component.ts
+++ b/projects/igniteui-angular/combo/src/combo/combo-item.component.ts
@@ -66,15 +66,17 @@ export class IgxComboItemComponent extends IgxDropDownItemComponent {
      * @hidden
      * @internal
      */
-    public get disableTransitions() {
-        return this.comboAPI.disableTransitions;
+    public override ngDoCheck(): void {
+        // Sync state from services once per CD cycle so template bindings return stable field values
+        this._selected = !this.isHeader && this.value != null && this.comboAPI.is_item_selected(this.itemID);
+        this._disableTransitions = this.comboAPI.disableTransitions;
     }
 
     /**
      * @hidden
      */
     public override get selected(): boolean {
-        return this.comboAPI.is_item_selected(this.itemID);
+        return this._selected;
     }
 
     public override set selected(value: boolean) {
@@ -83,6 +85,16 @@ export class IgxComboItemComponent extends IgxDropDownItemComponent {
         }
         this._selected = value;
     }
+
+    /**
+     * @hidden
+     * @internal
+     */
+    public get disableTransitions() {
+        return this._disableTransitions;
+    }
+
+    private _disableTransitions = false;
 
     /**
      * @hidden

--- a/projects/igniteui-angular/combo/src/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/combo/src/combo/combo.component.spec.ts
@@ -1,5 +1,5 @@
 import { AsyncPipe } from '@angular/common';
-import { AfterViewInit, ChangeDetectorRef, Component, DebugElement, ElementRef, Injectable, Injector, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, DebugElement, ElementRef, Injectable, Injector, OnDestroy, OnInit, ViewChild, inject, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import {
     FormsModule, NgForm, NgModel, ReactiveFormsModule, UntypedFormBuilder, UntypedFormControl, UntypedFormGroup, Validators
@@ -2712,7 +2712,7 @@ describe('igxCombo', () => {
                 fixture.detectChanges();
                 expect(combo.dropdown.headers[0].element.nativeElement.innerText).toEqual('New England')
             });
-            it('should sort groups with diacritics correctly', async() => {
+            it('should sort groups with diacritics correctly', async () => {
                 combo.data = [
                     { field: "Alaska", region: "Méxícó" },
                     { field: "California", region: "Méxícó" },
@@ -3658,6 +3658,65 @@ describe('igxCombo', () => {
                     expect(ngModel.touched).toBeTrue();
                 }));
             });
+        });
+
+        describe('Zoneless', () => {
+            beforeEach(async () => {
+                await TestBed.configureTestingModule({
+                    imports: [
+                        NoopAnimationsModule,
+                        IgxComboComponent,
+                    ],
+                    providers: [
+                        provideZonelessChangeDetection()
+                    ]
+                }).compileComponents();
+
+                fixture = TestBed.createComponent(IgxComboSampleComponent);
+                fixture.detectChanges();
+                combo = fixture.componentInstance.combo;
+            });
+
+            it('should not reproduce NG0100 when virtualized combo items update on scroll - issue #17310', async () => {
+                combo.open();
+                await fixture.whenStable();
+
+                const scrollEl = combo.virtualScrollContainer.getScroll();
+                expect(scrollEl).toBeTruthy();
+
+                expect(() => {
+                    scrollEl.scrollTop = 300;
+                    scrollEl.dispatchEvent(new Event('scroll'));
+
+                    fixture.whenStable();
+                    fixture.detectChanges();
+                }).not.toThrowError(/NG0100|ExpressionChangedAfterItHasBeenCheckedError/);
+            });
+
+            it('should not reproduce NG0100 related to active descendant on scroll - issue #17310', fakeAsync(() => {
+                combo.toggle();
+                tick();
+                fixture.detectChanges();
+
+                const dropdownContent = fixture.debugElement.query(By.css(`.${CSS_CLASS_CONTENT}`));
+                dropdownContent.triggerEventHandler('focus', {});
+                tick();
+                fixture.detectChanges();
+
+                const activeDescendantId = combo.dropdown.activeDescendant;
+                expect(activeDescendantId).toBeTruthy();
+
+                fixture.detectChanges();
+
+                expect(() => {
+                    const scrollEl = combo.virtualScrollContainer.getScroll();
+                    scrollEl.scrollTop = 1000;
+                    scrollEl.dispatchEvent(new Event('scroll'));
+
+                    tick(100);
+                    fixture.detectChanges();
+                }).not.toThrowError(/NG0100|ExpressionChangedAfterItHasBeenCheckedError/);
+            }));
         });
     });
 });

--- a/projects/igniteui-angular/combo/src/combo/combo.component.spec.ts
+++ b/projects/igniteui-angular/combo/src/combo/combo.component.spec.ts
@@ -3662,13 +3662,14 @@ describe('igxCombo', () => {
 
         describe('Zoneless', () => {
             beforeEach(async () => {
+                TestBed.resetTestingModule();
                 await TestBed.configureTestingModule({
                     imports: [
                         NoopAnimationsModule,
-                        IgxComboComponent,
+                        IgxComboSampleComponent,
                     ],
                     providers: [
-                        provideZonelessChangeDetection()
+                        provideZonelessChangeDetection(),
                     ]
                 }).compileComponents();
 
@@ -3677,21 +3678,23 @@ describe('igxCombo', () => {
                 combo = fixture.componentInstance.combo;
             });
 
-            it('should not reproduce NG0100 when virtualized combo items update on scroll - issue #17310', async () => {
+            it('should not reproduce NG0100 when virtualized combo items update on scroll - issue #17310', fakeAsync(() => {
                 combo.open();
-                await fixture.whenStable();
+                tick();
+                fixture.detectChanges();
 
                 const scrollEl = combo.virtualScrollContainer.getScroll();
                 expect(scrollEl).toBeTruthy();
 
-                expect(() => {
-                    scrollEl.scrollTop = 300;
-                    scrollEl.dispatchEvent(new Event('scroll'));
+                scrollEl.scrollTop = 300;
+                scrollEl.dispatchEvent(new Event('scroll'));
+                tick(100);
 
-                    fixture.whenStable();
+                expect(() => {
+
                     fixture.detectChanges();
                 }).not.toThrowError(/NG0100|ExpressionChangedAfterItHasBeenCheckedError/);
-            });
+            }));
 
             it('should not reproduce NG0100 related to active descendant on scroll - issue #17310', fakeAsync(() => {
                 combo.toggle();

--- a/projects/igniteui-angular/drop-down/src/drop-down/drop-down.base.ts
+++ b/projects/igniteui-angular/drop-down/src/drop-down/drop-down.base.ts
@@ -172,7 +172,7 @@ export abstract class IgxDropDownBaseDirective implements IDropDownList, OnInit 
      * This is used to update the `aria-activedescendant` attribute of
      * the IgxDropDownNavigationDirective host element.
      */
-    public get activeDescendant (): string {
+    public get activeDescendant (): string | null {
         return this.focusedItem ? this.focusedItem.id : null;
     }
 

--- a/projects/igniteui-angular/drop-down/src/drop-down/drop-down.base.ts
+++ b/projects/igniteui-angular/drop-down/src/drop-down/drop-down.base.ts
@@ -173,7 +173,7 @@ export abstract class IgxDropDownBaseDirective implements IDropDownList, OnInit 
      * the IgxDropDownNavigationDirective host element.
      */
     public get activeDescendant (): string | null {
-        return this.focusedItem ? this.focusedItem.id : null;
+        return this.focusedItem?.id ?? null;
     }
 
     /**


### PR DESCRIPTION
Closes #17310 

## Description
Addresses the causes of NG0100 error in zoneless apps.
1. `'attr.aria-activedescendant`: As the `focusedItem` is read from a `QueryList`, when a focused item scrolls out of the viewport, the `children` QueryList no longer contains it and `focusedItem` would be null. The `IgxDropDownItemNavigationDirective` `activeDescendant`  HostBinding reads the target's (dropdown) `activeDescendant` field, which calls `focusedItem`. With Angular's new zoneless run-time, on scroll the value gets updated between two diferent change detection passes, so the error is thrown.
The fix caches the active desc. id in the combo-dropdown component.

2. combo item template bindings properties errors - Sync `_selected` and `_disableTransitions` from the `comboApi` service once per CD cycle - in ngDoCheck. 

## Motivation / Context
Prevent the NG0100 error.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
Combo, Simple combo

## How Has This Been Tested?
 - [x] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **Angular version**: 
 - **Browser(s)**: 
 - **OS**: 

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain the visual changes. -->


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 