### PR TITLE
fix(for-of): call recalcUpdateSizes via afterNextRender in zoneless mode - 20.1.x

### DIFF
--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.spec.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.spec.ts
@@ -1,22 +1,5 @@
-﻿import { AsyncPipe, NgClass, NgForOfContext } from '@angular/common';
-import {
-    AfterViewInit,
-    ChangeDetectorRef,
-    Component,
-    Directive,
-    Injectable,
-    IterableDiffers,
-    NgZone,
-    OnInit,
-    QueryList,
-    TemplateRef,
-    ViewChild,
-    ViewChildren,
-    ViewContainerRef,
-    DebugElement,
-    Pipe,
-    PipeTransform
-} from '@angular/core';
+import { AsyncPipe, NgClass, NgForOfContext } from '@angular/common';
+import { AfterViewInit, ChangeDetectorRef, Component, Directive, Injectable, IterableDiffers, NgZone, OnInit, QueryList, TemplateRef, ViewChild, ViewChildren, ViewContainerRef, DebugElement, Pipe, PipeTransform, provideZonelessChangeDetection } from '@angular/core';
 import { TestBed, ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BehaviorSubject, Observable } from 'rxjs';
@@ -1244,6 +1227,34 @@ describe('IgxForOf directive -', () => {
             const firstInnerDisplayContainer = displayContainer.children[0];
             expect(firstInnerDisplayContainer.children[0].textContent).toBe('0');
         });
+    });
+
+    describe('zoneless', () => {
+        let fix: ComponentFixture<VerticalVirtualComponent>;
+
+        beforeEach(async () => {
+            TestBed.resetTestingModule();
+            await TestBed.configureTestingModule({
+                imports: [VerticalVirtualComponent],
+                providers: [provideZonelessChangeDetection()]
+            }).compileComponents();
+
+            fix = TestBed.createComponent(VerticalVirtualComponent);
+            dg.generateData(300, 5, fix.componentInstance);
+            fix.detectChanges();
+        });
+
+        it('should call recalcUpdateSizes after vertical scroll', async () => {
+            const virtDir = fix.componentInstance.parentVirtDir;
+            const spy = spyOn(virtDir, 'recalcUpdateSizes').and.callThrough();
+
+            fix.componentInstance.scrollTop(300);
+            await wait(100);
+            fix.detectChanges();
+
+            expect(spy).toHaveBeenCalled();
+        });
+
     });
 
     describe('on create new instance', () => {

--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
@@ -937,17 +937,17 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         const scrollOffset = this.fixedUpdateAllElements(this._virtScrollPosition);
         const isZoneless = this.isZonelessChangeDetection();
 
-        runInInjectionContext(this._injector, () => {
-            afterNextRender({
-                write: () => {
-                    this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
-                },
-                mixedReadWrite: isZoneless ? () => {
-                    this.recalcUpdateSizes();
-                } : undefined
-              });
-          });
-        if (!isZoneless) {
+        this.dc.instance._viewContainer.element.nativeElement.style.top = -(scrollOffset) + 'px';
+
+        if (isZoneless) {
+            runInInjectionContext(this._injector, () => {
+                afterNextRender({
+                    mixedReadWrite: () => {
+                        this.recalcUpdateSizes();
+                    }
+                });
+            });
+        } else {
             this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
         }
 
@@ -1746,19 +1746,20 @@ export class IgxGridForOfDirective<T, U extends T[] = T[]> extends IgxForOfDirec
         }
         const scrollOffset = this.fixedUpdateAllElements(this._virtScrollPosition);
         const isZoneless = this.isZonelessChangeDetection();
-        runInInjectionContext(this._injector, () => {
-            afterNextRender({
-                write: () => {
-                    this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
-                    if (!isZoneless) {
-                        this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+
+        this.dc.instance._viewContainer.element.nativeElement.style.top = -(scrollOffset) + 'px';
+
+        if (isZoneless) {
+            runInInjectionContext(this._injector, () => {
+                afterNextRender({
+                    mixedReadWrite: () => {
+                        this.recalcUpdateSizes();
                     }
-                },
-                mixedReadWrite: isZoneless ? () => {
-                    this.recalcUpdateSizes();
-                } : undefined
-              });
-          });
+                });
+            });
+        } else {
+            this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+        }
         this.cdr.markForCheck();
     }
 

--- a/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/src/lib/directives/for-of/for_of.directive.ts
@@ -22,7 +22,11 @@ import {
     AfterViewInit,
     Inject,
     booleanAttribute,
-    DOCUMENT
+    DOCUMENT,
+    afterNextRender,
+    runInInjectionContext,
+    Injector,
+    inject
 } from '@angular/core';
 
 import { DisplayContainerComponent } from './display.container';
@@ -406,6 +410,8 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
     private get _isAtBottomIndex() {
         return this.igxForOf && this.state.startIndex + this.state.chunkSize > this.igxForOf.length;
     }
+
+    protected readonly _injector = inject(Injector);
 
     constructor(
         private _viewContainer: ViewContainerRef,
@@ -815,6 +821,10 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
             || containerSize && endTopOffset - containerSize > 5;
     }
 
+    protected isZonelessChangeDetection(): boolean {
+        return this._zone.constructor.name === 'NoopNgZone';
+    }
+
     /**
      * @hidden
      * Function that recalculates and updates cache sizes.
@@ -925,10 +935,21 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         }
         const prevStartIndex = this.state.startIndex;
         const scrollOffset = this.fixedUpdateAllElements(this._virtScrollPosition);
+        const isZoneless = this.isZonelessChangeDetection();
 
-        this.dc.instance._viewContainer.element.nativeElement.style.top = -(scrollOffset) + 'px';
-
-        this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+        runInInjectionContext(this._injector, () => {
+            afterNextRender({
+                write: () => {
+                    this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
+                },
+                mixedReadWrite: isZoneless ? () => {
+                    this.recalcUpdateSizes();
+                } : undefined
+              });
+          });
+        if (!isZoneless) {
+            this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+        }
 
         this.dc.changeDetectorRef.detectChanges();
         if (prevStartIndex !== this.state.startIndex) {
@@ -1121,7 +1142,18 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         } else {
             this.dc.instance._viewContainer.element.nativeElement.style.left = -scrollOffset + 'px';
         }
-        this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+        const isZoneless = this.isZonelessChangeDetection();
+        if (isZoneless) {
+            runInInjectionContext(this._injector, () => {
+                afterNextRender({
+                    mixedReadWrite: () => {
+                        this.recalcUpdateSizes();
+                    }
+                });
+            });
+        } else {
+            this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+        }
 
         this.dc.changeDetectorRef.detectChanges();
         if (prevStartIndex !== this.state.startIndex) {
@@ -1713,10 +1745,20 @@ export class IgxGridForOfDirective<T, U extends T[] = T[]> extends IgxForOfDirec
             this._bScrollInternal = false;
         }
         const scrollOffset = this.fixedUpdateAllElements(this._virtScrollPosition);
-
-        this.dc.instance._viewContainer.element.nativeElement.style.top = -(scrollOffset) + 'px';
-
-        this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+        const isZoneless = this.isZonelessChangeDetection();
+        runInInjectionContext(this._injector, () => {
+            afterNextRender({
+                write: () => {
+                    this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
+                    if (!isZoneless) {
+                        this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+                    }
+                },
+                mixedReadWrite: isZoneless ? () => {
+                    this.recalcUpdateSizes();
+                } : undefined
+              });
+          });
         this.cdr.markForCheck();
     }
 

--- a/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
+++ b/projects/igniteui-angular/src/lib/grids/grid-base.directive.ts
@@ -3806,7 +3806,7 @@ export abstract class IgxGridBaseDirective implements GridType,
             destructor
         )
             .subscribe(() => {
-                this.zone.run(() => {
+                const work = () => {
                     // do not trigger reflow if element is detached.
                     if (this.nativeElement.isConnected) {
                         if (this.shouldResize) {
@@ -3821,7 +3821,12 @@ export abstract class IgxGridBaseDirective implements GridType,
                         }
                         this.notifyChanges(true);
                     }
-                });
+                };
+                if (this.isZonelessChangeDetection()) {
+                    work();
+                } else {
+                    this.zone.run(work);
+                }
             });
 
         this.pipeTriggerNotifier.pipe(takeUntil(this.destroy$)).subscribe(() => this.pipeTrigger++);
@@ -4528,6 +4533,10 @@ export abstract class IgxGridBaseDirective implements GridType,
      */
     public get nativeElement() {
         return this.elementRef.nativeElement;
+    }
+
+    protected isZonelessChangeDetection(): boolean {
+        return this.zone.constructor.name === 'NoopNgZone';
     }
 
     /**


### PR DESCRIPTION
Closes #17280

## Description
In zoneless Angular (`provideZonelessChangeDetection`), `NoopNgZone.onStable` never emits, so `recalcUpdateSizes()` was never called after scrolling. This left the virtual scroll size cache uncorrected, causing the last visible row in MRL grids to appear partially clipped.

## Motivation / Context
In `for_of.directive.ts`, at all three scroll handler sites, detect zoneless mode and use `afterNextRender({ read: () => recalcUpdateSizes() })` instead of `zone.onStable.pipe(first()).subscribe(recalcUpdateSizes)`. Zone mode keeps the original path unchanged (replacing it unconditionally breaks an existing zone-based scroll test).
In `grid-base.directive.ts`, the resizeNotify handler skips zone.run() in zoneless mode - `notifyChanges()` already calls `markForCheck()` which schedules CD via the zoneless scheduler.


### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
Grid, For-of


## How Has This Been Tested?
Added a zoneless describe block in `for_of.directive.spec.ts` verifying `recalcUpdateSizes` is called after scroll when using `provideZonelessChangeDetection`. 
 - [x] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **Angular version**: 
 - **Browser(s)**: 
 - **OS**: 

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain the visual changes. -->


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 