### PR TITLE
fix(drop-down): focusedItem null type check - 21.2.x

### DIFF
--- a/projects/igniteui-angular/drop-down/src/drop-down/drop-down.base.ts
+++ b/projects/igniteui-angular/drop-down/src/drop-down/drop-down.base.ts
@@ -24,7 +24,7 @@ export abstract class IgxDropDownBaseDirective implements IDropDownList, OnInit 
     protected elementRef = inject(ElementRef);
     protected cdr = inject(ChangeDetectorRef);
     public document = inject(DOCUMENT);
-    
+
     /**
      * Emitted when item selection is changing, before the selection completes
      *
@@ -227,14 +227,14 @@ export abstract class IgxDropDownBaseDirective implements IDropDownList, OnInit 
     /**
      * @hidden @internal
      */
-    public get focusedItem(): IgxDropDownItemBaseDirective {
+    public get focusedItem(): IgxDropDownItemBaseDirective | null {
         return this._focusedItem;
     }
 
     /**
      * @hidden @internal
      */
-    public set focusedItem(item: IgxDropDownItemBaseDirective) {
+    public set focusedItem(item: IgxDropDownItemBaseDirective | null) {
         this._focusedItem = item;
     }
 

--- a/projects/igniteui-angular/drop-down/src/drop-down/drop-down.common.ts
+++ b/projects/igniteui-angular/drop-down/src/drop-down/drop-down.common.ts
@@ -56,7 +56,7 @@ export interface IDropDownList {
     collapsed: boolean;
     items: IgxDropDownItemBaseDirective[];
     headers: IgxDropDownItemBaseDirective[];
-    focusedItem: IgxDropDownItemBaseDirective;
+    focusedItem: IgxDropDownItemBaseDirective | null;
     navigateFirst(): void;
     navigateLast(): void;
     navigateNext(): void;

--- a/projects/igniteui-angular/drop-down/src/drop-down/drop-down.component.ts
+++ b/projects/igniteui-angular/drop-down/src/drop-down/drop-down.component.ts
@@ -155,7 +155,7 @@ export class IgxDropDownComponent extends IgxDropDownBaseDirective implements ID
     /**
      * @hidden @internal
      */
-    public override get focusedItem(): IgxDropDownItemBaseDirective {
+    public override get focusedItem(): IgxDropDownItemBaseDirective | null {
         if (this.virtDir) {
             return this._focusedItem && this._focusedItem.index !== -1 ?
                 (this.children.find(e => e.index === this._focusedItem.index) || null) :
@@ -164,7 +164,7 @@ export class IgxDropDownComponent extends IgxDropDownBaseDirective implements ID
         return this._focusedItem;
     }
 
-    public override set focusedItem(value: IgxDropDownItemBaseDirective) {
+    public override set focusedItem(value: IgxDropDownItemBaseDirective | null) {
         if (!value) {
             this.selection.clear(`${this.id}-active`);
             this._focusedItem = null;


### PR DESCRIPTION
Closes #17346 

## Description
Fixes interface type by adding null.

## Motivation / Context
#17346 

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
DropDown, Combo

## How Has This Been Tested?
 - [ ] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **Angular version**: 21.2.x
 - **Browser(s)**: any
 - **OS**: any

## Screenshots / Recordings


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 