### PR TITLE
fix(for-of): call recalcUpdateSizes via afterNextRender in zoneless mode - 22.0.x

### DIFF
--- a/projects/igniteui-angular/directives/src/directives/for-of/for_of.directive.spec.ts
+++ b/projects/igniteui-angular/directives/src/directives/for-of/for_of.directive.spec.ts
@@ -1,6 +1,6 @@
 ﻿import { AsyncPipe, NgClass, NgForOfContext } from '@angular/common';
-import { AfterViewInit, ChangeDetectorRef, Component, Directive, Injectable, IterableDiffers, NgZone, OnInit, QueryList, TemplateRef, ViewChild, ViewChildren, ViewContainerRef, DebugElement, Pipe, PipeTransform, inject, ChangeDetectionStrategy } from '@angular/core';
-import { TestBed, ComponentFixture, waitForAsync } from '@angular/core/testing';
+import { AfterViewInit, ChangeDetectorRef, Component, Directive, Injectable, IterableDiffers, NgZone, OnInit, QueryList, TemplateRef, ViewChild, ViewChildren, ViewContainerRef, DebugElement, Pipe, PipeTransform, inject, ChangeDetectionStrategy, provideZonelessChangeDetection } from '@angular/core';
+import { TestBed, ComponentFixture, waitForAsync, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { IForOfState, IgxForOfDirective } from './for_of.directive';
@@ -1228,6 +1228,34 @@ describe('IgxForOf directive -', () => {
             const firstInnerDisplayContainer = displayContainer.children[0];
             expect(firstInnerDisplayContainer.children[0].textContent).toBe('0');
         });
+    });
+
+    describe('zoneless', () => {
+        let fix: ComponentFixture<VerticalVirtualComponent>;
+
+        beforeEach(async () => {
+            TestBed.resetTestingModule();
+            await TestBed.configureTestingModule({
+                imports: [VerticalVirtualComponent],
+                providers: [provideZonelessChangeDetection()]
+            }).compileComponents();
+
+            fix = TestBed.createComponent(VerticalVirtualComponent);
+            dg.generateData(300, 5, fix.componentInstance);
+            fix.detectChanges();
+        });
+
+        it('should call recalcUpdateSizes after vertical scroll', fakeAsync(() => {
+            const virtDir = fix.componentInstance.parentVirtDir;
+            const spy = spyOn(virtDir, 'recalcUpdateSizes').and.callThrough();
+
+            fix.componentInstance.scrollTop(300);
+            tick(100);
+            fix.detectChanges();
+
+            expect(spy).toHaveBeenCalled();
+        }));
+
     });
 
     describe('on create new instance', () => {

--- a/projects/igniteui-angular/directives/src/directives/for-of/for_of.directive.spec.ts
+++ b/projects/igniteui-angular/directives/src/directives/for-of/for_of.directive.spec.ts
@@ -1,6 +1,6 @@
 ﻿import { AsyncPipe, NgClass, NgForOfContext } from '@angular/common';
 import { AfterViewInit, ChangeDetectorRef, Component, Directive, Injectable, IterableDiffers, NgZone, OnInit, QueryList, TemplateRef, ViewChild, ViewChildren, ViewContainerRef, DebugElement, Pipe, PipeTransform, inject, ChangeDetectionStrategy, provideZonelessChangeDetection } from '@angular/core';
-import { TestBed, ComponentFixture, waitForAsync, fakeAsync, tick } from '@angular/core/testing';
+import { TestBed, ComponentFixture, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BehaviorSubject, Observable } from 'rxjs';
 import { IForOfState, IgxForOfDirective } from './for_of.directive';
@@ -1231,30 +1231,41 @@ describe('IgxForOf directive -', () => {
     });
 
     describe('zoneless', () => {
-        let fix: ComponentFixture<VerticalVirtualComponent>;
+        let fix: ComponentFixture<VirtualComponent>;
 
         beforeEach(async () => {
             TestBed.resetTestingModule();
             await TestBed.configureTestingModule({
-                imports: [VerticalVirtualComponent],
+                imports: [VirtualComponent],
                 providers: [provideZonelessChangeDetection()]
             }).compileComponents();
 
-            fix = TestBed.createComponent(VerticalVirtualComponent);
+            fix = TestBed.createComponent(VirtualComponent);
             dg.generateData(300, 5, fix.componentInstance);
             fix.detectChanges();
         });
 
-        it('should call recalcUpdateSizes after vertical scroll', fakeAsync(() => {
+        it('should call recalcUpdateSizes after vertical scroll', async () => {
             const virtDir = fix.componentInstance.parentVirtDir;
             const spy = spyOn(virtDir, 'recalcUpdateSizes').and.callThrough();
 
             fix.componentInstance.scrollTop(300);
-            tick(100);
+            await wait(100);
             fix.detectChanges();
 
             expect(spy).toHaveBeenCalled();
-        }));
+        });
+
+        it('should call recalcUpdateSizes after horizontal scroll', async () => {
+            const childDirs = fix.componentInstance.childVirtDirs.toArray();
+            const spy = spyOn(childDirs[0], 'recalcUpdateSizes').and.callThrough();
+
+            fix.componentInstance.scrollLeft(500);
+            await wait(100);
+            fix.detectChanges();
+
+            expect(spy).toHaveBeenCalled();
+        });
 
     });
 

--- a/projects/igniteui-angular/directives/src/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/directives/src/directives/for-of/for_of.directive.ts
@@ -961,16 +961,21 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         }
         const prevStartIndex = this.state.startIndex;
         const scrollOffset = this.fixedUpdateAllElements(this._virtScrollPosition);
+        const isZoneless = this._zone.constructor.name === 'NoopNgZone';
 
         runInInjectionContext(this._injector, () => {
             afterNextRender({
                 write: () => {
                     this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
-                }
+                },
+                read: isZoneless ? () => {
+                    this.recalcUpdateSizes();
+                } : undefined
               });
           });
-
-        this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+        if (!isZoneless) {
+            this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+        }
 
         this.dc.changeDetectorRef.detectChanges();
         if (prevStartIndex !== this.state.startIndex) {
@@ -1184,7 +1189,18 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         } else {
             this.dc.instance._viewContainer.element.nativeElement.style.left = -scrollOffset + 'px';
         }
-        this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+        const isZoneless = this._zone.constructor.name === 'NoopNgZone';
+        if (isZoneless) {
+            runInInjectionContext(this._injector, () => {
+                afterNextRender({
+                    read: () => {
+                        this.recalcUpdateSizes();
+                    }
+                });
+            });
+        } else {
+            this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+        }
 
         this.dc.changeDetectorRef.detectChanges();
         if (prevStartIndex !== this.state.startIndex) {
@@ -1787,12 +1803,18 @@ export class IgxGridForOfDirective<T, U extends T[] = T[]> extends IgxForOfDirec
         }
         const prevState = Object.assign({}, this.state);
         const scrollOffset = this.fixedUpdateAllElements(this._virtScrollPosition);
+        const isZoneless = this._zone.constructor.name === 'NoopNgZone';
         runInInjectionContext(this._injector, () => {
             afterNextRender({
                 write: () => {
                     this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
-                    this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this, prevState));
-                }
+                    if (!isZoneless) {
+                        this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this, prevState));
+                    }
+                },
+                read: isZoneless ? () => {
+                    this.recalcUpdateSizes(prevState);
+                } : undefined
               });
           });
 

--- a/projects/igniteui-angular/directives/src/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/directives/src/directives/for-of/for_of.directive.ts
@@ -858,6 +858,10 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
     }
 
 
+    protected isZonelessChangeDetection(): boolean {
+        return this._zone.constructor.name === 'NoopNgZone';
+    }
+
     /**
      * @hidden
      * Function that recalculates and updates cache sizes.
@@ -961,14 +965,14 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         }
         const prevStartIndex = this.state.startIndex;
         const scrollOffset = this.fixedUpdateAllElements(this._virtScrollPosition);
-        const isZoneless = this._zone.constructor.name === 'NoopNgZone';
+        const isZoneless = this.isZonelessChangeDetection();
 
         runInInjectionContext(this._injector, () => {
             afterNextRender({
                 write: () => {
                     this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
                 },
-                read: isZoneless ? () => {
+                mixedReadWrite: isZoneless ? () => {
                     this.recalcUpdateSizes();
                 } : undefined
               });
@@ -1189,11 +1193,11 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         } else {
             this.dc.instance._viewContainer.element.nativeElement.style.left = -scrollOffset + 'px';
         }
-        const isZoneless = this._zone.constructor.name === 'NoopNgZone';
+        const isZoneless = this.isZonelessChangeDetection();
         if (isZoneless) {
             runInInjectionContext(this._injector, () => {
                 afterNextRender({
-                    read: () => {
+                    mixedReadWrite: () => {
                         this.recalcUpdateSizes();
                     }
                 });
@@ -1803,7 +1807,7 @@ export class IgxGridForOfDirective<T, U extends T[] = T[]> extends IgxForOfDirec
         }
         const prevState = Object.assign({}, this.state);
         const scrollOffset = this.fixedUpdateAllElements(this._virtScrollPosition);
-        const isZoneless = this._zone.constructor.name === 'NoopNgZone';
+        const isZoneless = this.isZonelessChangeDetection();
         runInInjectionContext(this._injector, () => {
             afterNextRender({
                 write: () => {
@@ -1812,7 +1816,7 @@ export class IgxGridForOfDirective<T, U extends T[] = T[]> extends IgxForOfDirec
                         this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this, prevState));
                     }
                 },
-                read: isZoneless ? () => {
+                mixedReadWrite: isZoneless ? () => {
                     this.recalcUpdateSizes(prevState);
                 } : undefined
               });

--- a/projects/igniteui-angular/grids/grid/src/grid-base.directive.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid-base.directive.ts
@@ -3710,7 +3710,7 @@ export abstract class IgxGridBaseDirective implements GridType,
             destructor
         )
             .subscribe(() => {
-                this.zone.run(() => {
+                const work = () => {
                     // do not trigger reflow if element is detached.
                     if (this.nativeElement.isConnected) {
                         if (this.shouldResize) {
@@ -3725,7 +3725,12 @@ export abstract class IgxGridBaseDirective implements GridType,
                         }
                         this.notifyChanges(true);
                     }
-                });
+                };
+                if (this.isZonelessChangeDetection()) {
+                    work();
+                } else {
+                    this.zone.run(work);
+                }
             });
 
         this.pipeTriggerNotifier.pipe(takeUntil(this.destroy$)).subscribe(() => this.pipeTrigger++);


### PR DESCRIPTION
Closes #17280

## Description
In zoneless Angular (`provideZonelessChangeDetection`), `NoopNgZone.onStable` never emits, so `recalcUpdateSizes()` was never called after scrolling. This left the virtual scroll size cache uncorrected, causing the last visible row in MRL grids to appear partially clipped.

## Motivation / Context
In `for_of.directive.ts`, at all three scroll handler sites, detect zoneless mode and use `afterNextRender({ read: () => recalcUpdateSizes() })` instead of `zone.onStable.pipe(first()).subscribe(recalcUpdateSizes)`. Zone mode keeps the original path unchanged (replacing it unconditionally breaks an existing zone-based scroll test).
In `grid-base.directive.ts`, the resizeNotify handler skips zone.run() in zoneless mode - `notifyChanges()` already calls `markForCheck()` which schedules CD via the zoneless scheduler.


### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
Grid, For-of


## How Has This Been Tested?
Added a zoneless describe block in `for_of.directive.spec.ts` verifying `recalcUpdateSizes` is called after scroll when using `provideZonelessChangeDetection`. 
 - [x] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **Angular version**: 
 - **Browser(s)**: 
 - **OS**: 

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain the visual changes. -->


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 