### PR TITLE
fix: circular and linear progress values in Safari

### DIFF
--- a/projects/igniteui-angular/core/src/core/styles/components/progress/circular/_circular-theme.scss
+++ b/projects/igniteui-angular/core/src/core/styles/components/progress/circular/_circular-theme.scss
@@ -212,8 +212,8 @@
 
         animation: igx-initial-counter var(--_transition-duration) ease-in-out;
         counter-reset:
-            progress-integer var(--_progress-integer, 0)
-            progress-fraction var(--_progress-fraction, 0);
+            progress-integer round(down, var(--_progress-integer, 0), 1)
+            progress-fraction round(down, var(--_progress-fraction, 0), 1);
         transition:
             --_progress-integer var(--_transition-duration) ease-in-out,
             --_progress-fraction var(--_transition-duration) ease-in-out;

--- a/projects/igniteui-angular/core/src/core/styles/components/progress/linear/_linear-theme.scss
+++ b/projects/igniteui-angular/core/src/core/styles/components/progress/linear/_linear-theme.scss
@@ -227,8 +227,8 @@ $easing-curves: (
         color: var-get($theme, 'text-color');
         animation: initial-counter var(--_transition-duration) ease-in-out;
         counter-reset:
-            progress-integer var(--_progress-integer, 0)
-            progress-fraction var(--_progress-fraction, 0);
+            progress-integer round(down, var(--_progress-integer, 0), 1)
+            progress-fraction round(down, var(--_progress-fraction, 0), 1);
         transition:
             --_progress-integer var(--_transition-duration) ease-in-out,
             --_progress-fraction var(--_transition-duration) ease-in-out;

--- a/projects/igniteui-angular/core/src/core/styles/themes/_core.scss
+++ b/projects/igniteui-angular/core/src/core/styles/themes/_core.scss
@@ -118,13 +118,13 @@
     @include theming.spacing();
 
     @property --_progress-integer {
-        syntax: '<integer>';
+        syntax: '<number>';
         initial-value: 0;
         inherits: true;
     }
 
     @property --_progress-fraction {
-        syntax: '<integer>';
+        syntax: '<number>';
         initial-value: 0;
         inherits: true;
     }


### PR DESCRIPTION
Closes #17210 

## Description
The issue occurred because Safari cannot perform smooth transitions on integer properties and jumps directly to the provided value. By changing those custom properties to <number>, Safari transitions them normally, and the counter value animates consistently across all browsers.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
Circular and Linear Progress

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Include relevant details so reviewers can reproduce. -->
 - [ ] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests
 