### PR TITLE
fix(tooltip): mark tooltip as dirty when changing its role

### DIFF
--- a/projects/igniteui-angular/directives/src/directives/toggle/toggle.directive.ts
+++ b/projects/igniteui-angular/directives/src/directives/toggle/toggle.directive.ts
@@ -42,7 +42,7 @@ export interface ToggleViewCancelableEventArgs extends ToggleViewEventArgs, Canc
 })
 export class IgxToggleDirective implements IToggleView, OnInit, OnDestroy {
     private elementRef = inject(ElementRef);
-    private cdr = inject(ChangeDetectorRef);
+    protected cdr = inject(ChangeDetectorRef);
     protected overlayService = inject<IgxOverlayService>(IgxOverlayService);
     private navigationService = inject(IgxNavigationService, { optional: true });
     private platform = inject(PlatformUtil, { optional: true });

--- a/projects/igniteui-angular/directives/src/directives/tooltip/tooltip-target.directive.ts
+++ b/projects/igniteui-angular/directives/src/directives/tooltip/tooltip-target.directive.ts
@@ -689,6 +689,9 @@ export class IgxTooltipTargetDirective extends IgxToggleActionDirective implemen
             this._renderer.appendChild(this.target.element, this._closeButtonRef.location.nativeElement);
             this._closeButtonRef.changeDetectorRef.detectChanges();
             this.target.role = "status"
+            // Mark the tooltip directive as Dirty to ensure that
+            // the CD refreshes the bindings
+            this.target.cdr?.markForCheck();
         }
     }
 
@@ -700,6 +703,9 @@ export class IgxTooltipTargetDirective extends IgxToggleActionDirective implemen
             this._renderer.removeChild(this.target.element, this._closeButtonRef.location.nativeElement);
             this._closeButtonRef.changeDetectorRef.detectChanges();
             this.target.role = "tooltip"
+            // Mark the tooltip directive as Dirty to ensure that
+            // the CD refreshes the bindings
+            this.target.cdr?.markForCheck();
         }
     }
 

--- a/projects/igniteui-angular/directives/src/directives/tooltip/tooltip.directive.spec.ts
+++ b/projects/igniteui-angular/directives/src/directives/tooltip/tooltip.directive.spec.ts
@@ -1,9 +1,9 @@
-import { DebugElement } from '@angular/core';
+import { DebugElement, ErrorHandler, provideZonelessChangeDetection } from '@angular/core';
 import { fakeAsync, TestBed, tick, flush, waitForAsync, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IgxTooltipSingleTargetComponent, IgxTooltipMultipleTargetsComponent, IgxTooltipPlainStringComponent, IgxTooltipWithToggleActionComponent, IgxTooltipWithCloseButtonComponent, IgxTooltipWithNestedContentComponent, IgxTooltipNestedTooltipsComponent } from '../../../../test-utils/tooltip-components.spec';
-import { UIInteractions } from '../../../../test-utils/ui-interactions.spec';
+import { UIInteractions, wait } from '../../../../test-utils/ui-interactions.spec';
 import { HorizontalAlignment, VerticalAlignment, AutoPositionStrategy } from '../../../../core/src/services/public_api';
 import { IgxTooltipDirective } from './tooltip.directive';
 import { IgxTooltipTargetDirective } from './tooltip-target.directive';
@@ -1101,6 +1101,40 @@ describe('IgxTooltip', () => {
             expect(closeBtn).toBeTruthy();
             expect(tooltipNativeElement.getAttribute('role')).toBe('status');
         }));
+
+        describe('Zoneless', () => {
+            beforeEach(async () => {
+                TestBed.resetTestingModule();
+                await TestBed.configureTestingModule({
+                    imports: [
+                        NoopAnimationsModule,
+                        IgxTooltipWithCloseButtonComponent
+                    ],
+                    providers: [provideZonelessChangeDetection()]
+                }).compileComponents();
+            });
+
+            beforeEach(() => {
+                fix = TestBed.createComponent(IgxTooltipWithCloseButtonComponent);
+                fix.detectChanges();
+                tooltipNativeElement = fix.debugElement.query(By.directive(IgxTooltipDirective)).nativeElement;
+                tooltipTarget = fix.componentInstance.tooltipTarget as IgxTooltipTargetDirective;
+                button = fix.debugElement.query(By.directive(IgxTooltipTargetDirective));
+            });
+
+            it('should not throw ExpressionChangedAfterItHasBeenChecked when showing sticky tooltip with close button', async () => {
+                const errorHandler = TestBed.inject(ErrorHandler);
+                const handleErrorSpy = spyOn(errorHandler, 'handleError');
+
+                hoverElement(button);
+                await wait(SHOW_DELAY + 50);
+                fix.detectChanges();
+
+                expect(handleErrorSpy).not.toHaveBeenCalled();
+                verifyTooltipVisibility(tooltipNativeElement, tooltipTarget, true);
+                expect(tooltipNativeElement.getAttribute('role')).toBe('status');
+            });
+        });
     });
 
     describe('IgxTooltip placement and offset', () => {

--- a/projects/igniteui-angular/directives/src/directives/tooltip/tooltip.directive.spec.ts
+++ b/projects/igniteui-angular/directives/src/directives/tooltip/tooltip.directive.spec.ts
@@ -1134,6 +1134,27 @@ describe('IgxTooltip', () => {
                 verifyTooltipVisibility(tooltipNativeElement, tooltipTarget, true);
                 expect(tooltipNativeElement.getAttribute('role')).toBe('status');
             });
+
+            it('should correctly remove the close button and update the role when sticky is set to false', async () => {
+                tooltipTarget.sticky = true;
+                fix.detectChanges();
+                hoverElement(button);
+                await wait(SHOW_DELAY + 50);
+                fix.detectChanges();
+
+                const closeBtn = tooltipNativeElement.querySelector('igx-tooltip-close-button');
+                expect(closeBtn).not.toBeNull();
+                expect(fix.componentInstance.tooltip.role).toBe('status');
+
+                tooltipTarget.sticky = false;
+                fix.detectChanges();
+                hoverElement(button);
+                await wait(SHOW_DELAY + 50);
+                fix.detectChanges();
+
+                expect(fix.componentInstance.tooltip.role).toBe('tooltip');
+                expect(tooltipNativeElement.querySelector('igx-tooltip-close-button')).toBeNull();
+            });
         });
     });
 
@@ -1222,7 +1243,7 @@ const alignmentTolerance = 2;
 export const verifyTooltipPosition = (
     tooltipNativeElement: HTMLElement,
     actualTarget: { nativeElement: HTMLElement },
-    shouldAlign:boolean = true,
+    shouldAlign: boolean = true,
     placement: Placement = Placement.Bottom,
     offset: number = 6
 ) => {


### PR DESCRIPTION
Closes #17381   

## Description
Fixes `ExpressionChangedAfterItHasBeenChecked` error thrown when showing a sticky `IgxTooltipTargetDirective` with a close button in zoneless Angular applications.


## Motivation / Context
The dynamic creation of the `tooltip-close-button` view triggers a new `appRef.tick` which is ran in `requestAnimationFrame` internally in angular. In zone CD there is additional `detectChange` before the `RAF` fires (It comes from the patch of the `addEventListener` which opens the tooltip) . However, in zoneless the method is not patched so the additional check made by angular to ensure that all bindings in a single tick are the same fails. 


### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
<!-- List the component(s) or area(s) this PR touches, e.g. Grid, Combo, Theming -->


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Include relevant details so reviewers can reproduce. -->
 - [x] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **Angular version**: 
 - **Browser(s)**: 
 - **OS**: 

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain the visual changes. -->


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 