### PR TITLE
refactor(navdrawer): consume size tokens from theming schema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "express": "^5.2.1",
         "fflate": "^0.8.1",
         "igniteui-i18n-core": "^1.0.2",
-        "igniteui-theming": "^27.3.0",
+        "igniteui-theming": "^27.4.0",
         "igniteui-trial-watermark": "^3.1.0",
         "jspdf": "^4.2.1",
         "lodash-es": "^4.17.21",
@@ -14612,9 +14612,9 @@
       }
     },
     "node_modules/igniteui-theming": {
-      "version": "27.3.0",
-      "resolved": "https://registry.npmjs.org/igniteui-theming/-/igniteui-theming-27.3.0.tgz",
-      "integrity": "sha512-9xpPZkMUBSBzA1KzBoXurx61RoaUKW7p/H6CWks+Nh8SehsvAj2j4DSQlT0IR6bb41kRICYVNuyTqMicqLmaLA==",
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/igniteui-theming/-/igniteui-theming-27.4.0.tgz",
+      "integrity": "sha512-0lxn6jDcPKdEtewxx/q+F0MBGhlfXCx1nzfFRS55GmfcYAexNwAjfjS2MlE+Tc/aN33spDA9GkP6cQNI2s+BdA==",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "express": "^5.2.1",
     "fflate": "^0.8.1",
     "igniteui-i18n-core": "^1.0.2",
-    "igniteui-theming": "^27.3.0",
+    "igniteui-theming": "^27.4.0",
     "igniteui-trial-watermark": "^3.1.0",
     "jspdf": "^4.2.1",
     "lodash-es": "^4.17.21",

--- a/projects/igniteui-angular/core/src/core/styles/components/navdrawer/_navdrawer-theme.scss
+++ b/projects/igniteui-angular/core/src/core/styles/components/navdrawer/_navdrawer-theme.scss
@@ -39,17 +39,7 @@
         'indigo': rem(32px),
     ), $variant);
 
-    $item-mini-size: map.get((
-        'material': rem(56px),
-        'fluent': rem(40px),
-        'bootstrap': rem(88px),
-        'indigo': rem(48px),
-    ), $variant);
-
     %navdrawer-display {
-        --ig-nav-drawer-size: #{rem(240px)};
-        --ig-nav-drawer-size--mini: #{$item-mini-size};
-
         flex-basis: 0;
         transition: flex-basis;
         transition-duration: .3s;
@@ -58,11 +48,11 @@
     }
 
     %navdrawer-display-pinned {
-        flex-basis: var(--ig-nav-drawer-size);
+        flex-basis: var-get($theme, 'size');
     }
 
     %navdrawer-display-mini-pinned {
-        flex-basis: calc(var(--ig-mini-nav-drawer-size, #{$item-mini-size}) + rem(1px));
+        flex-basis: calc(#{var-get($theme, 'size--mini')} + #{rem(1px)});
     }
 
     %aside {
@@ -72,7 +62,7 @@
         overflow-x: hidden;
         background: var-get($theme, 'background');
         inset: 0 auto;
-        width: var(--ig-nav-drawer-size);
+        width: var-get($theme, 'size');
         inset-inline-start: 0;
         transition: width, padding, transform;
         transition-timing-function: $in-out-quad;
@@ -142,7 +132,7 @@
 
     %aside--mini {
         transition-duration: .3s;
-        width: var(--ig-nav-drawer-size--mini);
+        width: var-get($theme, 'size--mini');
         min-width: fit-content;
 
         %item {
@@ -168,7 +158,7 @@
 
     %aside--normal {
         transition-duration: .3s;
-        width: var(--ig-nav-drawer-size);
+        width: var-get($theme, 'size');
     }
 
     %overlay {

--- a/projects/igniteui-angular/navigation-drawer/src/navigation-drawer/navigation-drawer.component.html
+++ b/projects/igniteui-angular/navigation-drawer/src/navigation-drawer/navigation-drawer.component.html
@@ -12,7 +12,7 @@
     [attr.popover]="pin ? null : 'manual'"
     class="igx-nav-drawer__overlay"
     [class.igx-nav-drawer__overlay--hidden]="!isOpen"
-    [class.igx-nav-drawer--disable-animation]="disableAnimation"
+    [class.igx-nav-drawer--disable-animation]="animationsDisabled"
     (click)="close()" #overlay>
 </div>
 <nav
@@ -23,7 +23,7 @@
     [class.igx-nav-drawer__aside--normal]="!miniTemplate || isOpen"
     [class.igx-nav-drawer__aside--pinned]="pin"
     [class.igx-nav-drawer__aside--right]="position === 'right'" #aside
-    [class.igx-nav-drawer--disable-animation]="disableAnimation">
+    [class.igx-nav-drawer--disable-animation]="animationsDisabled">
 
     <ng-container *ngTemplateOutlet="template || defaultItemsTemplate"></ng-container>
 </nav>

--- a/projects/igniteui-angular/navigation-drawer/src/navigation-drawer/navigation-drawer.component.ts
+++ b/projects/igniteui-angular/navigation-drawer/src/navigation-drawer/navigation-drawer.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentInit, afterRenderEffect, Component, ContentChild, ElementRef, EventEmitter, HostBinding, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChange, ViewChild, Renderer2, booleanAttribute, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
+import { AfterContentInit, afterNextRender, afterRenderEffect, Component, ContentChild, ElementRef, EventEmitter, HostBinding, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChange, ViewChild, Renderer2, booleanAttribute, inject, signal, computed, ChangeDetectionStrategy } from '@angular/core';
 import { fromEvent, interval, Subscription } from 'rxjs';
 import { debounce } from 'rxjs/operators';
 import { IgxNavigationService, IToggleView } from 'igniteui-angular/core';
@@ -188,8 +188,24 @@ export class IgxNavigationDrawerComponent implements
      * <igx-nav-drawer [disableAnimation]="true"></igx-nav-drawer>
      * ````
      */
-    @HostBinding('class.igx-nav-drawer--disable-animation')
     @Input({ transform: booleanAttribute }) public disableAnimation = false;
+
+    /**
+     * Suppresses transitions until the first render has painted, so the drawer
+     * settles into its resting (mini/expanded) size without an initial width
+     * animation when the aside is first shown as a top-layer popover.
+     */
+    private _animationsReady = signal(false);
+
+    /**
+     * Whether transitions are currently suppressed — either explicitly via
+     * `disableAnimation`, or implicitly until the first paint has settled.
+     * @hidden
+     */
+    @HostBinding('class.igx-nav-drawer--disable-animation')
+    public get animationsDisabled(): boolean {
+        return this.disableAnimation || !this._animationsReady();
+    }
 
     /**
      * Width of the drawer in its mini state.
@@ -456,6 +472,14 @@ export class IgxNavigationDrawerComponent implements
         afterRenderEffect(() => {
             if (this._closingAnimation()) return;
             this.togglePopover(this._visibleOverlay());
+        });
+
+        // Enable transitions only after the first paint. The initial popover show
+        // resolves the aside's width (e.g. to its mini size) as it enters the top
+        // layer; deferring past the first frame lets that settle instantly instead
+        // of animating from the fallback/expanded width.
+        afterNextRender(() => {
+            requestAnimationFrame(() => this._animationsReady.set(true));
         });
     }
 

--- a/projects/igniteui-angular/package.json
+++ b/projects/igniteui-angular/package.json
@@ -75,7 +75,7 @@
         "igniteui-trial-watermark": "^3.1.0",
         "jspdf": "^4.2.1",
         "lodash-es": "^4.17.21",
-        "igniteui-theming": "^27.3.0",
+        "igniteui-theming": "^27.4.0",
         "igniteui-i18n-core": "^1.0.5",
         "@igniteui/material-icons-extended": "^3.1.0"
     },


### PR DESCRIPTION
Align the nav drawer with the shared --ig-nav-drawer-size / --ig-nav-drawer-size--mini tokens from igniteui-theming instead of redeclaring the drawer sizes locally.

Refs IgniteUI/igniteui-webcomponents#2240
Depends on https://github.com/IgniteUI/igniteui-theming/pull/590
 