### PR TITLE
fix(grid): eliminate empty space after last column and scrollbar not reaching the end

### DIFF
--- a/projects/igniteui-angular/core/src/core/styles/components/_common/_igx-vhelper.scss
+++ b/projects/igniteui-angular/core/src/core/styles/components/_common/_igx-vhelper.scss
@@ -13,10 +13,12 @@
     top: 0;
     inset-inline-end: 0;
     width: var(--vhelper-scrollbar-size);
+    overflow-x: hidden;
 }
 
 %vhelper--horizontal {
     width: 100%;
+    overflow-y: hidden;
 }
 
 %vhelper-content--vertical {

--- a/projects/igniteui-angular/grids/grid/src/cell.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/cell.spec.ts
@@ -201,13 +201,10 @@ describe('IgxGrid - Cell component #grid', () => {
             const lastCell = cells[cells.length - 1];
             expect(GridFunctions.getValueFromCellElement(lastCell)).toEqual('990');
 
-            const scrollbarBorderWidth = parseFloat(getComputedStyle(
-                grid.nativeElement.querySelector('.igx-grid__tbody-scrollbar')
-            ).getPropertyValue('border-inline-start-width')) || 0;
-            // Calculate where the end of the cell is. Relative left position should equal the grid calculated width.
+            // Calculate where the end of the cell is. Relative left position should equal the grid calculated
+            // width, which is already reduced by the vertical scrollbar's width.
             expect(lastCell.nativeElement.getBoundingClientRect().left +
-                lastCell.nativeElement.offsetWidth +
-                grid.scrollSize).toEqual(grid.calcWidth + scrollbarBorderWidth);
+                lastCell.nativeElement.offsetWidth).toEqual(grid.calcWidth);
         }));
 
         it('should not reduce the width of last pinned cell when there is vertical scroll.', () => {


### PR DESCRIPTION
Closes #17428  

## Description
Fixes the Grid's horizontal scrollbar leaving empty, unscrollable space after the last
column, with the scrollbar thumb never reaching the end of its track.

Root cause: `igx-horizontal-virtual-helper` (and its vertical counterpart) used a shared
`overflow: auto` on both axes. The horizontal helper's height is pinned to exactly the
native scrollbar thickness, so once the real horizontal scrollbar claims that space,
`clientHeight` becomes `0`. Since `overflow-y` was also `auto`, the helper's 1px-tall
placeholder content then always "overflows" that 0px client height, causing the browser
to spawn a phantom vertical scrollbar. That phantom scrollbar eats ~16-17px of width from
the helper, shrinking its effective scrollable range below the real content width — so
the grid can never scroll far enough to bring the last column fully into view.

Fix: constrain each virtual helper to scroll only along its intended axis —
`overflow-y: hidden` on the horizontal helper and `overflow-x: hidden` on the vertical
helper (defensive, symmetrical fix for the same latent failure mode) in
`_igx-vhelper.scss`.

## Motivation / Context
Reported bug: opening almost any grid sample with a horizontal scrollbar (e.g. the Grid
Filtering dev sample) and scrolling all the way to the right leaves a gap after the last
column, and the horizontal scrollbar thumb stops short of the track's end.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
Grid (and other grid-based components sharing `igxFor` virtualization: Tree Grid,
Hierarchical Grid, Pivot Grid) — horizontal/vertical virtual scrollbar helpers.

## How Has This Been Tested?
 - [ ] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests

Manually reproduced and verified via the Grid Filtering dev sample: measured
`clientWidth`/`scrollWidth` of `igx-horizontal-virtual-helper` before and after the fix,
and confirmed `scrollLeft` now reaches exactly `scrollWidth - clientWidth`, with the last
column ("Index") flush against the grid's right edge.

### Test Configuration:
 - **Angular version**: 22.1.x (also verified applies cleanly to 22.0.x and 21.2.x)
 - **Browser(s)**: Chrome (Windows)
 - **OS**: Windows

## Checklist:
 - [ ] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code
 - [ ] This PR includes API docs for newly added methods/properties
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [x] Accessibility (ARIA, keyboard navigation, focus management) has been verified (no ARIA/keyboard impact — style-only fix)
 