### PR TITLE
fix(grid): fix zone.onStable patterns broken in zoneless change detection - 22.0.x

### DIFF
--- a/projects/igniteui-angular/core/src/core/utils.ts
+++ b/projects/igniteui-angular/core/src/core/utils.ts
@@ -1,5 +1,5 @@
 import { isPlatformBrowser } from '@angular/common';
-import { Injectable, InjectionToken, PLATFORM_ID, inject } from '@angular/core';
+import { Injectable, InjectionToken, PLATFORM_ID, inject, afterNextRender, type AfterRenderRef, type Injector } from '@angular/core';
 import { mergeWith } from 'lodash-es';
 import { NEVER, Observable } from 'rxjs';
 import { isDevMode } from '@angular/core';
@@ -8,6 +8,31 @@ import type { IgxTheme } from '../services/theme/theme.token';
 /** @hidden @internal */
 export const ELEMENTS_TOKEN = /*@__PURE__*/new InjectionToken<boolean>('elements environment');
 
+/** @hidden @internal */
+export type RenderPhase = 'earlyRead' | 'write' | 'mixedReadWrite' | 'read';
+
+interface AfterNextRenderSpec {
+    earlyRead?: () => void;
+    write?: () => void;
+    mixedReadWrite?: () => void;
+    read?: () => void;
+}
+
+/**
+ * Schedules `callback` to run once after Angular finishes the next render pass.
+ *
+ * Central scheduling point for all work that previously waited on `NgZone.onStable`,
+ * which never emits in zoneless applications. Every deferred render callback in the
+ * library goes through here, so if the scheduling needs to change (different phase,
+ * timing or API), change it in this single place.
+ *
+ * @hidden @internal
+ */
+export function runAfterRenderOnce(injector: Injector, callback: () => void, phase: RenderPhase = 'mixedReadWrite'): AfterRenderRef {
+    const spec: AfterNextRenderSpec = {};
+    spec[phase as keyof AfterNextRenderSpec] = callback;
+    return afterNextRender(spec, { injector });
+}
 
 /**
  * Returns true if the element's direction is left-to-right

--- a/projects/igniteui-angular/directives/src/directives/for-of/for_of.directive.ts
+++ b/projects/igniteui-angular/directives/src/directives/for-of/for_of.directive.ts
@@ -1,5 +1,5 @@
 ﻿import { NgForOfContext } from '@angular/common';
-import { ChangeDetectorRef, ComponentRef, Directive, EmbeddedViewRef, EventEmitter, Input, IterableChanges, IterableDiffer, IterableDiffers, NgZone, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, TemplateRef, TrackByFunction, ViewContainerRef, booleanAttribute, DOCUMENT, inject, afterNextRender, runInInjectionContext, EnvironmentInjector, AfterViewInit } from '@angular/core';
+import { ChangeDetectorRef, ComponentRef, Directive, EmbeddedViewRef, EventEmitter, Input, IterableChanges, IterableDiffer, IterableDiffers, NgZone, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, TemplateRef, TrackByFunction, ViewContainerRef, booleanAttribute, DOCUMENT, inject, EnvironmentInjector, AfterViewInit } from '@angular/core';
 
 import { DisplayContainerComponent } from './display.container';
 import { HVirtualHelperComponent } from './horizontal.virtual.helper.component';
@@ -7,8 +7,8 @@ import { VirtualHelperComponent } from './virtual.helper.component';
 
 import { IgxForOfSyncService, IgxForOfScrollSyncService } from './for_of.sync.service';
 import { Subject } from 'rxjs';
-import { takeUntil, filter, throttleTime, first } from 'rxjs/operators';
-import { getResizeObserver } from 'igniteui-angular/core';
+import { takeUntil, filter, throttleTime } from 'rxjs/operators';
+import { getResizeObserver, runAfterRenderOnce } from 'igniteui-angular/core';
 import { IBaseEventArgs, PlatformUtil } from 'igniteui-angular/core';
 import { VirtualHelperBaseDirective } from './base.helper.component';
 
@@ -659,13 +659,9 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
             // Actual scroll delta that was added is smaller than 1 and onScroll handler doesn't trigger when scrolling < 1px
             const scrollOffset = this.fixedUpdateAllElements(this._virtScrollPosition);
             // scrollOffset = scrollOffset !== parseInt(this.igxForItemSize, 10) ? scrollOffset : 0;
-            runInInjectionContext(this._injector, () => {
-                afterNextRender({
-                    write: () => {
-                        this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
-                    }
-                  });
-              });
+            runAfterRenderOnce(this._injector, () => {
+                this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
+            }, 'write');
         }
 
         const maxRealScrollTop = this.scrollComponent.nativeElement.scrollHeight - containerSize;
@@ -912,7 +908,7 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
                 // in case scrolled to specific index where after scroll heights are changed
                 // need to adjust the offsets so that item is last in view.
                 const updatesToIndex = this._adjustToIndex - this.state.startIndex + 1;
-                const sumDiffs = diffs.slice(0, updatesToIndex).reduce(reducer);
+                const sumDiffs = diffs.slice(0, updatesToIndex).reduce(reducer, 0);
                 if (sumDiffs !== 0) {
                     this.addScroll(sumDiffs);
                 }
@@ -962,15 +958,10 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         const prevStartIndex = this.state.startIndex;
         const scrollOffset = this.fixedUpdateAllElements(this._virtScrollPosition);
 
-        runInInjectionContext(this._injector, () => {
-            afterNextRender({
-                write: () => {
-                    this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
-                }
-              });
-          });
-
-        this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+        runAfterRenderOnce(this._injector, () => {
+            this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
+        }, 'write');
+        runAfterRenderOnce(this._injector, () => this.recalcUpdateSizes());
 
         this.dc.changeDetectorRef.detectChanges();
         if (prevStartIndex !== this.state.startIndex) {
@@ -1182,7 +1173,7 @@ export class IgxForOfDirective<T, U extends T[] = T[]> extends IgxForOfToken<T,U
         } else {
             this.dc.instance._viewContainer.element.nativeElement.style.left = -scrollOffset + 'px';
         }
-        this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this));
+        runAfterRenderOnce(this._injector, () => this.recalcUpdateSizes());
 
         this.dc.changeDetectorRef.detectChanges();
         if (prevStartIndex !== this.state.startIndex) {
@@ -1785,14 +1776,10 @@ export class IgxGridForOfDirective<T, U extends T[] = T[]> extends IgxForOfDirec
         }
         const prevState = Object.assign({}, this.state);
         const scrollOffset = this.fixedUpdateAllElements(this._virtScrollPosition);
-        runInInjectionContext(this._injector, () => {
-            afterNextRender({
-                write: () => {
-                    this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
-                    this._zone.onStable.pipe(first()).subscribe(this.recalcUpdateSizes.bind(this, prevState));
-                }
-              });
-          });
+        runAfterRenderOnce(this._injector, () => {
+            this.dc.instance._viewContainer.element.nativeElement.style.transform = `translateY(${-scrollOffset}px)`;
+        }, 'write');
+        runAfterRenderOnce(this._injector, () => this.recalcUpdateSizes(prevState));
 
         this.cdr.markForCheck();
     }

--- a/projects/igniteui-angular/grids/core/src/grid-navigation.service.ts
+++ b/projects/igniteui-angular/grids/core/src/grid-navigation.service.ts
@@ -33,6 +33,8 @@ export interface IActiveNode {
     layout?: IMultiRowLayoutNode;
 }
 
+const VERTICAL_VIRTUALIZATION_NAV_KEYS = new Set(['arrowup', 'up', 'arrowdown', 'down', 'home', 'end']);
+
 /** @hidden */
 @Injectable()
 export class IgxGridNavigationService {
@@ -106,8 +108,7 @@ export class IgxGridNavigationService {
         }
         const position = this.getNextPosition(this.activeNode.row, this.activeNode.column, key, shift, ctrl, event);
         const shouldNotifyVirtualizedKeyboardSelection =
-            ctrl && (key === 'arrowup' || key === 'up' || key === 'arrowdown' || key === 'down') &&
-            this.shouldPerformVerticalScroll(position.rowIndex, position.colIndex);
+            this.shouldNotifyVirtualizedKeyboardSelection(key, position.rowIndex, position.colIndex);
         if (NAVIGATION_KEYS.has(key)) {
             event.preventDefault();
             this.navigateInBody(position.rowIndex, position.colIndex, (obj) => {
@@ -231,6 +232,16 @@ export class IgxGridNavigationService {
             || containerHeight && endTopOffset - containerHeight > 5;
     }
 
+    protected shouldNotifyVirtualizedKeyboardSelection(key: string, rowIndex: number, visibleColIndex: number): boolean {
+        // Any navigation key that ends up scrolling activates the target cell from the
+        // virtualization scroll callback, which runs outside Angular's knowledge, so the
+        // grid must be notified explicitly regardless of the ctrl modifier.
+        const shouldCheckVerticalScroll = VERTICAL_VIRTUALIZATION_NAV_KEYS.has(key);
+        const shouldCheckHorizontalScroll = HORIZONTAL_NAV_KEYS.has(key);
+
+        return (shouldCheckVerticalScroll && this.shouldPerformVerticalScroll(rowIndex, visibleColIndex)) ||
+            (shouldCheckHorizontalScroll && this.shouldPerformHorizontalScroll(visibleColIndex, rowIndex));
+    }
     public performVerticalScrollToCell(rowIndex: number, visibleColIndex = -1, cb?: () => void) {
         if (!this.shouldPerformVerticalScroll(rowIndex, visibleColIndex)) {
             if (cb) {

--- a/projects/igniteui-angular/grids/grid/src/column-group.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/column-group.spec.ts
@@ -608,19 +608,22 @@ describe('IgxGrid - multi-column headers #grid', () => {
             grid = fixture.componentInstance.grid;
         }));
 
-        it('Width should be correct. Column group with three columns. No width.', () => {
+        it('Width should be correct. Column group with three columns. No width.', async () => {
+            await wait(16);
+            fixture.detectChanges();
             const scrWitdh = grid.nativeElement.querySelector('.igx-grid__tbody-scrollbar').getBoundingClientRect().width;
-            const availableWidth = (parseInt(componentInstance.gridWrapperWidthPx, 10) - scrWitdh).toString();
+            const availableWidth = parseInt(componentInstance.gridWrapperWidthPx, 10) - scrWitdh;
             const locationColGroup = getColGroup(grid, 'Location');
-            const colWidth = Math.floor(parseInt(availableWidth, 10) / 3);
-            const colWidthPx = colWidth + 'px';
-            expect(locationColGroup.width).toBe((Math.round(colWidth) * 3) + 'px');
+            const colWidth = availableWidth / 3;
+            const expectWidthWithinPixel = (actualWidth: string, expectedWidth: number) =>
+                expect(Math.abs(parseFloat(actualWidth) - expectedWidth)).toBeLessThanOrEqual(1);
+            expectWidthWithinPixel(locationColGroup.width, availableWidth);
             const countryColumn = grid.getColumnByName('Country');
-            expect(countryColumn.width).toBe(colWidthPx);
+            expectWidthWithinPixel(countryColumn.width, colWidth);
             const regionColumn = grid.getColumnByName('Region');
-            expect(regionColumn.width).toBe(colWidthPx);
+            expectWidthWithinPixel(regionColumn.width, colWidth);
             const cityColumn = grid.getColumnByName('City');
-            expect(cityColumn.width).toBe(colWidthPx);
+            expectWidthWithinPixel(cityColumn.width, colWidth);
         });
 
         it('Width should be correct. Column group with three columns. Width in px.', () => {

--- a/projects/igniteui-angular/grids/grid/src/column.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/column.spec.ts
@@ -1,4 +1,4 @@
-import { Component, DebugElement, TemplateRef, ViewChild, ChangeDetectionStrategy } from '@angular/core';
+import { Component, DebugElement, TemplateRef, ViewChild, ChangeDetectionStrategy, provideZonelessChangeDetection } from '@angular/core';
 import { TestBed, fakeAsync, tick, waitForAsync, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { getLocaleCurrencySymbol, registerLocaleData } from '@angular/common';
@@ -1942,3 +1942,30 @@ export class DOMAttributesAsSettersComponent {
 
     public data = [{ id: 1, value: 1 }];
 }
+
+describe('IgxGrid column autosizing in zoneless change detection #grid', () => {
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [ResizableColumnsComponent, NoopAnimationsModule],
+            providers: [provideZonelessChangeDetection()]
+        });
+    });
+
+    it('should recalculate fit-content widths after data changes', async () => {
+        const fix = TestBed.createComponent(ResizableColumnsComponent);
+        fix.detectChanges();
+        await fix.whenStable();
+        const grid = fix.componentInstance.instance;
+
+        grid.data = [{
+            ID: 'VeryVeryVeryLongID',
+            Address: 'Avda. de la Constituci\u00f3n 2222 Obere Str. 57'
+        }];
+        await fix.whenStable();
+        grid.recalculateAutoSizes();
+        await fix.whenStable();
+
+        expect(grid.columns[0].width).toBe('164px');
+        expect(grid.columns[1].width).toBe('279px');
+    });
+});

--- a/projects/igniteui-angular/grids/grid/src/grid-base.directive.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid-base.directive.ts
@@ -91,7 +91,8 @@ import {
     IGridResourceStrings,
     IgxOverlayOutletDirective,
     DEFAULT_LOCALE,
-    onResourceChangeHandle
+    onResourceChangeHandle,
+    runAfterRenderOnce
 } from 'igniteui-angular/core';
 import { IgcTrialWatermark } from 'igniteui-trial-watermark';
 import { Subject, pipe, fromEvent, animationFrameScheduler, merge, BehaviorSubject, timer } from 'rxjs';
@@ -4166,9 +4167,7 @@ export abstract class IgxGridBaseDirective implements GridType,
             if (this.hasColumnsToAutosize) {
                 this.headerContainer?.dataChanged.pipe(takeUntil(this.destroy$)).subscribe(() => {
                     this.cdr.detectChanges();
-                    this.zone.onStable.pipe(first()).subscribe(() => {
-                        this.autoSizeColumnsInView();
-                    });
+                    runAfterRenderOnce(this.injector, () => this.autoSizeColumnsInView());
                 });
             }
             // Window resize observer not needed because when you resize the window element the tbody container always resize so
@@ -4681,7 +4680,7 @@ export abstract class IgxGridBaseDirective implements GridType,
         // reset auto-size and calculate it again.
         this._columns.forEach(x => x.autoSize = undefined);
         this.resetCaches();
-        this.zone.onStable.pipe(first()).subscribe(() => {
+        runAfterRenderOnce(this.injector, () => {
             this.cdr.detectChanges();
             this.autoSizeColumnsInView();
         });
@@ -6377,7 +6376,7 @@ export abstract class IgxGridBaseDirective implements GridType,
             const tmplId = args.context.templateID.type;
             const index = args.context.index;
             args.view.detectChanges();
-            this.zone.onStable.pipe(first()).subscribe(() => {
+            runAfterRenderOnce(this.injector, () => {
                 const row = tmplId === 'dataRow' ? this.gridAPI.get_row_by_index(index) : null;
                 const summaryRow = tmplId === 'summaryRow' ? this.summariesRowList.find((sr) => sr.dataRowIndex === index) : null;
                 if (row && row instanceof IgxRowDirective) {
@@ -7076,24 +7075,16 @@ export abstract class IgxGridBaseDirective implements GridType,
             this.cdr.detectChanges();
         }
 
-        if (this.zone.isStable) {
+        runAfterRenderOnce(this.injector, () => {
             this.zone.run(() => {
                 this._applyWidthHostBinding();
                 this.cdr.detectChanges();
             });
-        } else {
-            this.zone.onStable.pipe(first()).subscribe(() => {
-                this.zone.run(() => {
-                    this._applyWidthHostBinding();
-                });
-            });
-        }
+        });
         this.resetCaches(recalcFeatureWidth);
         if (this.hasColumnsToAutosize) {
             this.cdr.detectChanges();
-            this.zone.onStable.pipe(first()).subscribe(() => {
-                this._autoSizeColumnsNotify.next();
-            });
+            runAfterRenderOnce(this.injector, () => this._autoSizeColumnsNotify.next());
         }
 
         // in case horizontal scrollbar has appeared recalc to size correctly.
@@ -7743,19 +7734,13 @@ export abstract class IgxGridBaseDirective implements GridType,
     protected verticalScrollHandler(event) {
         this.verticalScrollContainer.onScroll(event);
         this.disableTransitions = true;
-
         const callback = () => {
             this.verticalScrollContainer.chunkLoad.emit(this.verticalScrollContainer.state);
             if (this.rowEditable) {
                 this.changeRowEditingOverlayStateOnScroll(this.crudService.rowInEditMode);
             }
         };
-        if (this.isZonelessChangeDetection()) {
-            this.cdr.detectChanges();
-            callback();
-        } else {
-            this.zone.onStable.pipe(first()).subscribe(callback);
-        }
+        runAfterRenderOnce(this.injector, callback);
         this.disableTransitions = false;
 
         this.hideOverlays();
@@ -7778,10 +7763,6 @@ export abstract class IgxGridBaseDirective implements GridType,
             scrollPosition: this.verticalScrollContainer.scrollPosition
         };
         this.gridScroll.emit(args);
-    }
-
-    protected isZonelessChangeDetection(): boolean {
-        return this.zone.constructor.name === 'NoopNgZone';
     }
 
     protected hasMenuPinningActions(): boolean {
@@ -7808,7 +7789,7 @@ export abstract class IgxGridBaseDirective implements GridType,
         this.cdr.markForCheck();
 
         this.zone.run(() => {
-            this.zone.onStable.pipe(first()).subscribe(() => {
+            runAfterRenderOnce(this.injector, () => {
                 this.parentVirtDir.chunkLoad.emit(this.headerContainer.state);
                 requestAnimationFrame(() => {
                     this.autoSizeColumnsInView();

--- a/projects/igniteui-angular/grids/grid/src/grid-cell-selection.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid-cell-selection.spec.ts
@@ -14,7 +14,8 @@ import { clearGridSubs, setupGridScrollDetection } from '../../../test-utils/hel
 import { GridSelectionMode } from 'igniteui-angular/grids/core';
 
 import { GridSelectionFunctions, GridFunctions } from '../../../test-utils/grid-functions.spec';
-import { DebugElement } from '@angular/core';
+import { DebugElement, provideZonelessChangeDetection } from '@angular/core';
+import { firstValueFrom } from 'rxjs';
 import { DropPosition } from 'igniteui-angular/grids/core';
 import { IgxGridGroupByRowComponent } from './groupby-row.component';
 import { DefaultSortingStrategy, IgxStringFilteringOperand, SortingDirection } from 'igniteui-angular/core';
@@ -1444,12 +1445,12 @@ describe('IgxGrid - Cell selection #grid', () => {
         }));
 
         it('Should handle  Shift + Ctrl + End  keys combination', (async () => {
+            fix.autoDetectChanges();
             const firstCell = grid.gridAPI.get_cell_by_index(2, 'ID');
             const selectionChangeSpy = spyOn<any>(grid.rangeSelected, 'emit').and.callThrough();
 
             UIInteractions.simulateClickAndSelectEvent(firstCell);
-            await wait();
-            fix.detectChanges();
+            await fix.whenStable();
 
             expect(selectionChangeSpy).toHaveBeenCalledTimes(0);
             GridSelectionFunctions.verifyCellSelected(firstCell);
@@ -1735,6 +1736,44 @@ describe('IgxGrid - Cell selection #grid', () => {
 
             GridSelectionFunctions.verifySelectedRange(grid, 7, 7, 5, 5);
         }));
+    });
+
+    describe('Keyboard navigation in zoneless change detection', () => {
+        let fix: ComponentFixture<SelectionWithScrollsComponent>;
+        let grid;
+
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                providers: [
+                    provideZonelessChangeDetection(),
+                    { provide: SCROLL_THROTTLE_TIME_MULTIPLIER, useValue: 0 }
+                ]
+            });
+            fix = TestBed.createComponent(SelectionWithScrollsComponent);
+            fix.detectChanges();
+            grid = fix.componentInstance.grid;
+        });
+
+        it('Should handle  Shift + Ctrl + End  keys combination', async () => {
+            const firstCell = grid.gridAPI.get_cell_by_index(2, 'ID');
+            const selectionChangeSpy = spyOn<any>(grid.rangeSelected, 'emit').and.callThrough();
+
+            UIInteractions.simulateClickAndSelectEvent(firstCell);
+            await fix.whenStable();
+
+            expect(selectionChangeSpy).toHaveBeenCalledTimes(0);
+            GridSelectionFunctions.verifyCellSelected(firstCell);
+            expect(grid.selectedCells.length).toBe(1);
+
+            const rangeSelected = firstValueFrom(grid.rangeSelected);
+            UIInteractions.triggerKeyDownEvtUponElem('end', firstCell.nativeElement, true, false, true, true);
+            await rangeSelected;
+            await fix.whenStable();
+
+            expect(selectionChangeSpy).toHaveBeenCalledTimes(1);
+            GridSelectionFunctions.verifySelectedRange(grid, 2, 7, 0, 5);
+            GridSelectionFunctions.verifyCellsRegionSelected(grid, 3, 7, 2, 5);
+        });
     });
 
     describe('Features integration', () => {

--- a/projects/igniteui-angular/grids/grid/src/grid-filtering-ui.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid-filtering-ui.spec.ts
@@ -1481,7 +1481,7 @@ describe('IgxGrid - Filtering Row UI actions #grid', () => {
             fix.detectChanges();
 
             // Click string filter chip to show filter row.
-            GridFunctions.clickFilterCellChip(fix, 'ProductName');
+            GridFunctions.clickFilterCellChipUI(fix, 'ProductName');
             tick(200);
 
             // Verify arrows and chip area are not visible because there is no active filtering for the column.
@@ -1506,7 +1506,9 @@ describe('IgxGrid - Filtering Row UI actions #grid', () => {
             fix.detectChanges();
 
             expect(grid.rowList.length).toEqual(0);
-            GridFunctions.clickFilterCellChip(fix, 'ProductName');
+            const filterIndicator = GridFunctions.getFilterIndicatorForColumn('ProductName', fix)[0];
+            filterIndicator.nativeElement.click();
+            fix.detectChanges();
             tick(200);
 
             // remove first chip
@@ -1617,7 +1619,7 @@ describe('IgxGrid - Filtering Row UI actions #grid', () => {
             grid.width = '700px';
             fix.detectChanges();
 
-            GridFunctions.clickFilterCellChip(fix, 'ProductName');
+            GridFunctions.clickFilterCellChipUI(fix, 'ProductName');
 
             // Add first chip.
             GridFunctions.typeValueInFilterRowInput('a', fix);
@@ -2398,7 +2400,7 @@ describe('IgxGrid - Filtering Row UI actions #grid', () => {
             grid.rowSelection = GridSelectionMode.multiple;
             fix.detectChanges();
 
-            GridFunctions.clickFilterCellChip(fix, 'ProductName');
+            GridFunctions.clickFilterCellChipUI(fix, 'ProductName');
 
             const filteringRow = fix.debugElement.query(By.directive(IgxGridFilteringRowComponent));
             const frElem = filteringRow.nativeElement;
@@ -2525,8 +2527,7 @@ describe('IgxGrid - Filtering Row UI actions #grid', () => {
             });
             fix.detectChanges();
 
-            GridFunctions.clickFilterCellChip(fix, 'ProductName');
-
+            GridFunctions.clickFilterCellChipUI(fix, 'ProductName');
             const filteringRow = fix.debugElement.query(By.directive(IgxGridFilteringRowComponent));
             const frElem = filteringRow.nativeElement;
             const expandBtn = fix.debugElement.query(By.css('.igx-grid__group-expand-btn'));
@@ -2584,8 +2585,8 @@ describe('IgxGrid - Filtering Row UI actions #grid', () => {
             tick(200);
             const resizer = fix.debugElement.queryAll(By.css(GRID_RESIZE_CLASS))[0].nativeElement;
             expect(resizer).toBeDefined();
-            UIInteractions.simulateMouseEvent('mousemove', resizer, 100, 5);
-            UIInteractions.simulateMouseEvent('mouseup', resizer, 100, 5);
+            UIInteractions.simulateMouseEvent('mousemove', resizer, 150, 5);
+            UIInteractions.simulateMouseEvent('mouseup', resizer, 150, 5);
             fix.detectChanges();
 
             colChips = GridFunctions.getFilterChipsForColumn('ProductName', fix);

--- a/projects/igniteui-angular/grids/grid/src/grid-keyBoardNav-headers.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid-keyBoardNav-headers.spec.ts
@@ -62,6 +62,7 @@ describe('IgxGrid - Headers Keyboard navigation #grid', () => {
         });
 
         it('should focus first header when the grid is scrolled', async () => {
+            fix.autoDetectChanges();
             grid.navigateTo(7, 5);
             await wait(250);
             fix.detectChanges();
@@ -477,33 +478,33 @@ describe('IgxGrid - Headers Keyboard navigation #grid', () => {
             expect(GridFunctions.getAdvancedFilteringComponent(fix)).not.toBeNull();
         });
 
-        it('Advanced Filtering: Should be able to close Advanced filtering with "escape"',  fakeAsync(() => {
+        it('Advanced Filtering: Should be able to close Advanced filtering with "escape"',  async () => {
             // Enable Advanced Filtering
             grid.allowAdvancedFiltering = true;
-            fix.detectChanges();
+            await fix.whenStable();
             let header = GridFunctions.getColumnHeader('Name', fix);
             UIInteractions.simulateClickAndSelectEvent(header);
-            fix.detectChanges();
+            await fix.whenStable();
 
             // Verify first header is focused
             GridFunctions.verifyHeaderIsFocused(header.parent);
 
             UIInteractions.triggerEventHandlerKeyDown('L', gridHeader, true);
-            fix.detectChanges();
+            await fix.whenStable();
 
             // Verify AF dialog is opened.
             expect(GridFunctions.getAdvancedFilteringComponent(fix)).not.toBeNull();
 
             const afDialog = fix.nativeElement.querySelector('.igx-advanced-filter');
             UIInteractions.triggerKeyDownEvtUponElem('Escape', afDialog);
-            tick(100);
-            fix.detectChanges();
+            await wait(100);
+            await fix.whenStable();
 
             // Verify AF dialog is closed.
             header = GridFunctions.getColumnHeader('Name', fix);
             expect(GridFunctions.getAdvancedFilteringComponent(fix)).toBeNull();
             GridFunctions.verifyHeaderIsFocused(header.parent);
-        }));
+        });
 
 
         it('Column selection: Should be able to select columns when columnSelection is multi', () => {

--- a/projects/igniteui-angular/grids/grid/src/grid-keyBoardNav.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid-keyBoardNav.spec.ts
@@ -494,6 +494,7 @@ describe('IgxGrid - Keyboard navigation #grid', () => {
         });
 
         it('should allow navigating first/last cell in column with home/end and Cntr key.', async () => {
+            fix.autoDetectChanges();
             fix.componentInstance.columns = fix.componentInstance.generateCols(50);
             fix.componentInstance.data = fix.componentInstance.generateData(500);
             fix.detectChanges();

--- a/projects/igniteui-angular/grids/grid/src/grid-mrl-keyboard-nav.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid-mrl-keyboard-nav.spec.ts
@@ -1727,6 +1727,7 @@ describe('IgxGrid Multi Row Layout - Keyboard navigation #grid', () => {
 
             it(`should navigate to the last cell from the layout by pressing Home/End and Ctrl key
                 and keep same rowStart from the first selection when last cell spans more rows`, async () => {
+                fix.autoDetectChanges();
                 fix.componentInstance.colGroups = [{
                     group: 'group1',
                     hidden: true,
@@ -1914,6 +1915,7 @@ describe('IgxGrid Multi Row Layout - Keyboard navigation #grid', () => {
             });
 
             it('should scroll active cell fully in view when navigating with arrow keys and row is partially visible.', async () => {
+                fix.autoDetectChanges();
                 fix.componentInstance.colGroups = [
                     {
                         group: 'group1',

--- a/projects/igniteui-angular/grids/grid/src/grid.component.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid.component.spec.ts
@@ -1,6 +1,6 @@
-import { AfterViewInit, ChangeDetectorRef, Component, Injectable, OnInit, ViewChild, TemplateRef, inject, ChangeDetectionStrategy } from '@angular/core';
+import { AfterViewInit, ChangeDetectorRef, Component, Injectable, OnInit, ViewChild, TemplateRef, inject, ChangeDetectionStrategy, provideZonelessChangeDetection } from '@angular/core';
 import { TestBed, fakeAsync, tick, flush, waitForAsync } from '@angular/core/testing';
-import { BehaviorSubject, Observable } from 'rxjs';
+import { BehaviorSubject, firstValueFrom, Observable } from 'rxjs';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IgxGridComponent } from './grid.component';
@@ -2089,6 +2089,7 @@ describe('IgxGrid Component Tests #grid', () => {
             const headerRowElement = gridHeader.nativeElement.querySelector('[role="row"]');
 
             grid.navigateTo(50, 16);
+            await fix.whenStable();
             fix.detectChanges();
             await wait(100);
             fix.detectChanges();
@@ -2103,6 +2104,63 @@ describe('IgxGrid Component Tests #grid', () => {
             // such as with the built-in virtualization of the grid. 1-based index.
             expect(cell.nativeElement.getAttribute('aria-rowindex')).toBe('52');
             expect(cell.nativeElement.getAttribute('aria-colindex')).toBe('17');
+        });
+
+        describe('Zoneless rendering regressions', () => {
+            beforeEach(() => {
+                TestBed.configureTestingModule({
+                    imports: [ZonelessTallGridComponent, ZonelessFinJsGridComponent],
+                    providers: [
+                        provideZonelessChangeDetection(),
+                        { provide: SCROLL_THROTTLE_TIME_MULTIPLIER, useValue: 0 }
+                    ]
+                });
+            });
+
+            it('should fully display the last row after scrolling to the bottom', async () => {
+                const fix = TestBed.createComponent(ZonelessTallGridComponent);
+                fix.detectChanges();
+                await fix.whenStable();
+                const grid = fix.componentInstance.grid;
+                const chunkLoad = firstValueFrom(grid.verticalScrollContainer.chunkLoad);
+
+                grid.verticalScrollContainer.scrollTo(fix.componentInstance.data.length - 1);
+                await chunkLoad;
+                await fix.whenStable();
+
+                const lastRow = grid.gridAPI.get_row_by_index(fix.componentInstance.data.length - 1);
+                const rowRect = lastRow.nativeElement.getBoundingClientRect();
+                const viewportRect = grid.tbody.nativeElement.getBoundingClientRect();
+                expect(rowRect.bottom).toBeLessThanOrEqual(viewportRect.bottom + 1);
+                expect(Math.abs(viewportRect.bottom - rowRect.bottom)).toBeLessThanOrEqual(1);
+            });
+
+            it('should stabilize aria-colcount when grouped columns are hidden', async () => {
+                const fix = TestBed.createComponent(ZonelessFinJsGridComponent);
+                fix.detectChanges();
+                await fix.whenStable();
+                const grid = fix.componentInstance.grid;
+
+                expect(grid.nativeElement.getAttribute('aria-colcount')).toBe('48');
+                expect(grid.columns.length).toBe(51);
+                expect(grid.visibleColumns.length).toBe(48);
+            });
+
+            it('should update horizontal virtualization after a real scroll event', async () => {
+                const fix = TestBed.createComponent(ZonelessFinJsGridComponent);
+                fix.detectChanges();
+                await fix.whenStable();
+                const grid = fix.componentInstance.grid;
+                const chunkLoad = firstValueFrom(grid.parentVirtDir.chunkLoad);
+                const horizontalScroller = grid.headerContainer.getScroll();
+
+                horizontalScroller.scrollLeft = horizontalScroller.scrollWidth;
+                horizontalScroller.dispatchEvent(new Event('scroll'));
+                await chunkLoad;
+                await fix.whenStable();
+
+                expect(grid.headerContainer.state.startIndex).toBeGreaterThan(0);
+            });
         });
     });
 
@@ -3458,6 +3516,42 @@ export class IgxGridDefaultRenderingComponent {
             }
         }
     }
+}
+
+@Component({
+    template: `<igx-grid #grid [data]="data" height="300px" width="600px" [autoGenerate]="true"></igx-grid>`,
+    imports: [IgxGridComponent]
+})
+class ZonelessTallGridComponent {
+    @ViewChild(IgxGridComponent, { static: true }) public grid: IgxGridComponent;
+    public data = Array.from({ length: 200 }, (_row, index) => ({
+        ID: index,
+        Name: `Record ${index}`,
+        Value: index * 10
+    }));
+}
+
+@Component({
+    template: `
+        <igx-grid #grid [data]="data" height="500px" width="900px"
+            [groupingExpressions]="groupingExpressions" [hideGroupedColumns]="true">
+            @for (column of columns; track column) {
+                <igx-column [field]="column"></igx-column>
+            }
+        </igx-grid>
+    `,
+    imports: [IgxGridComponent, IgxColumnComponent]
+})
+class ZonelessFinJsGridComponent {
+    @ViewChild(IgxGridComponent, { static: true }) public grid: IgxGridComponent;
+    public columns = Array.from({ length: 51 }, (_column, index) => `Column${index}`);
+    public groupingExpressions: ISortingExpression[] = this.columns.slice(0, 3).map(fieldName => ({
+        fieldName,
+        dir: SortingDirection.Asc,
+        ignoreCase: true
+    }));
+    public data = Array.from({ length: 1000 }, (_row, rowIndex) =>
+        Object.fromEntries(this.columns.map((column, columnIndex) => [column, `${rowIndex}-${columnIndex}`])));
 }
 
 @Component({

--- a/projects/igniteui-angular/grids/grid/src/grid.groupby.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid.groupby.spec.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild, TemplateRef, QueryList, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewChild, TemplateRef, QueryList, ChangeDetectionStrategy, provideZonelessChangeDetection } from '@angular/core';
 import { formatNumber } from '@angular/common'
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
@@ -20,6 +20,7 @@ import { DefaultSortingStrategy, IGroupingExpression, IgxGrouping, IgxStringFilt
 import { IgxChipComponent } from 'igniteui-angular/chips';
 import { IgxPaginatorComponent } from 'igniteui-angular/paginator';
 import { IgxCheckboxComponent } from 'igniteui-angular/checkbox';
+import { firstValueFrom } from 'rxjs';
 
 describe('IgxGrid - GroupBy #grid', () => {
 
@@ -4392,3 +4393,48 @@ export class GridGroupByStateComponent extends GridGroupByTestDateTimeDataCompon
     @ViewChild(IgxGridStateDirective, { static: true })
     public state: IgxGridStateDirective;
 }
+
+describe('IgxGrid grouped virtualization in zoneless change detection #grid', () => {
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [GroupableGridComponent, NoopAnimationsModule],
+            providers: [provideZonelessChangeDetection()]
+        });
+    });
+
+    it('should restore horizontal state when data row views are reused from cache', async () => {
+        const fix = TestBed.createComponent(GroupableGridComponent);
+        fix.detectChanges();
+        await fix.whenStable();
+        const grid = fix.componentInstance.instance;
+
+        grid.groupBy({ fieldName: 'ProductName', dir: SortingDirection.Asc, ignoreCase: false });
+        await fix.whenStable();
+        grid.toggleAllGroupRows();
+        await fix.whenStable();
+
+        const horizontalChunkLoad = firstValueFrom(grid.parentVirtDir.chunkLoad);
+        const horizontalScroller = grid.headerContainer.getScroll();
+        horizontalScroller.scrollLeft = 1000;
+        horizontalScroller.dispatchEvent(new Event('scroll'));
+        await horizontalChunkLoad;
+        await fix.whenStable();
+
+        const scrollLeft = horizontalScroller.scrollLeft;
+        grid.toggleAllGroupRows();
+        await fix.whenStable();
+
+        const verticalChunkLoad = firstValueFrom(grid.verticalScrollContainer.chunkLoad);
+        grid.verticalScrollContainer.scrollTo(grid.dataView.length - 1);
+        await verticalChunkLoad;
+        await fix.whenStable();
+
+        for (const row of grid.dataRowList) {
+            const virtualization = row.virtDirRow;
+            const expectedStartIndex = virtualization.igxForOf.length - virtualization.state.chunkSize;
+            const left = parseFloat(virtualization.dc.instance._viewContainer.element.nativeElement.style.left);
+            expect(virtualization.state.startIndex).toBe(expectedStartIndex);
+            expect(-left).toBe(scrollLeft - virtualization.getColumnScrollLeft(expectedStartIndex));
+        }
+    });
+});

--- a/projects/igniteui-angular/grids/grid/src/grid.master-detail.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid.master-detail.spec.ts
@@ -1,7 +1,8 @@
-import { Component, ViewChild, OnInit, DebugElement, QueryList, TemplateRef, ViewChildren, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewChild, OnInit, DebugElement, QueryList, TemplateRef, ViewChildren, ChangeDetectionStrategy, provideZonelessChangeDetection } from '@angular/core';
 import { TestBed, ComponentFixture, fakeAsync, tick, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
+import { firstValueFrom } from 'rxjs';
 import { UIInteractions, wait, waitForActiveNodeChange } from '../../../test-utils/ui-interactions.spec';
 import { IgxGridComponent } from './grid.component';
 import { IgxGridRowComponent } from './grid-row.component';
@@ -664,6 +665,7 @@ describe('IgxGrid Master Detail #grid', () => {
         });
 
         it('Should navigate to the first data row using Ctrl + ArrowUp when all rows are expanded.', async () => {
+            fix.autoDetectChanges();
             setupGridScrollDetection(fix, grid);
             grid.verticalScrollContainer.scrollTo(grid.verticalScrollContainer.igxForOf.length - 1);
             await wait(DEBOUNCE_TIME);
@@ -1273,6 +1275,154 @@ describe('IgxGrid Master Detail #grid', () => {
                 expect(allRows[8].tagName.toLowerCase()).toBe(SUMMARY_ROW_TAG);
             });
         });
+    });
+});
+
+describe('IgxGrid Master Detail zoneless change detection #grid', () => {
+    let fix: ComponentFixture<any>;
+    let grid: IgxGridComponent;
+    let gridContent: DebugElement;
+
+    beforeEach(waitForAsync(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                NoopAnimationsModule,
+                DefaultGridMasterDetailComponent,
+                AllExpandedGridMasterDetailComponent
+            ],
+            providers: [
+                provideZonelessChangeDetection(),
+                IgxGridMRLNavigationService,
+                { provide: SCROLL_THROTTLE_TIME_MULTIPLIER, useValue: 0 }
+            ]
+        }).compileComponents();
+    }));
+
+    it('should navigate to the last data cell in the grid using Ctrl + End', async () => {
+        fix = TestBed.createComponent(AllExpandedGridMasterDetailComponent);
+        fix.detectChanges();
+        await fix.whenStable();
+        grid = fix.componentInstance.grid;
+        gridContent = GridFunctions.getGridContent(fix);
+        await fix.whenStable();
+
+        const targetCellElement = grid.gridAPI.get_cell_by_index(0, 'ContactName');
+        UIInteractions.simulateClickAndSelectEvent(targetCellElement);
+        await fix.whenStable();
+
+        const activeNodeChange = firstValueFrom(grid.activeNodeChange);
+        UIInteractions.triggerEventHandlerKeyDown('End', gridContent, false, false, true);
+        await activeNodeChange;
+        await fix.whenStable();
+
+        const lastRow = grid.gridAPI.get_row_by_index(52);
+        expect(lastRow).not.toBeUndefined();
+        expect(GridFunctions.elementInGridView(grid, lastRow.nativeElement)).toBeTruthy();
+        expect((lastRow.cells as QueryList<CellType>).last.active).toBeTruthy();
+    });
+
+    it('should navigate to the last data row using Ctrl + ArrowDown when all rows are expanded', async () => {
+        fix = TestBed.createComponent(AllExpandedGridMasterDetailComponent);
+        fix.detectChanges();
+        await fix.whenStable();
+        grid = fix.componentInstance.grid;
+        gridContent = GridFunctions.getGridContent(fix);
+        await fix.whenStable();
+
+        const targetCellElement = grid.gridAPI.get_cell_by_index(0, 'ContactName');
+        UIInteractions.simulateClickAndSelectEvent(targetCellElement);
+        await fix.whenStable();
+
+        UIInteractions.triggerEventHandlerKeyDown('ArrowDown', gridContent, false, false, true);
+        await wait(DEBOUNCE_TIME);
+        await fix.whenStable();
+
+        const lastRow = grid.gridAPI.get_row_by_index(52);
+        expect(lastRow).not.toBeUndefined();
+        expect(GridFunctions.elementInGridView(grid, lastRow.nativeElement)).toBeTruthy();
+        expect((lastRow.cells as QueryList<CellType>).first.active).toBeTruthy();
+    });
+
+    it('should navigate to the first data row using Ctrl + ArrowUp when all rows are expanded', async () => {
+        fix = TestBed.createComponent(AllExpandedGridMasterDetailComponent);
+        fix.detectChanges();
+        await fix.whenStable();
+        grid = fix.componentInstance.grid;
+        gridContent = GridFunctions.getGridContent(fix);
+
+        grid.verticalScrollContainer.scrollTo(grid.verticalScrollContainer.igxForOf.length - 1);
+        await wait(DEBOUNCE_TIME);
+        await fix.whenStable();
+
+        const targetCellElement = grid.gridAPI.get_cell_by_index(52, 'CompanyName');
+        UIInteractions.simulateClickAndSelectEvent(targetCellElement);
+        await fix.whenStable();
+
+        UIInteractions.triggerEventHandlerKeyDown('ArrowUp', gridContent, false, false, true);
+        await waitForActiveNodeChange(grid);
+        await fix.whenStable();
+
+        const firstRow = grid.gridAPI.get_row_by_index(0);
+        expect(firstRow).not.toBeUndefined();
+        expect(GridFunctions.elementInGridView(grid, firstRow.nativeElement)).toBeTruthy();
+        expect((firstRow.cells as QueryList<CellType>).last.active).toBeTruthy();
+    });
+
+    it('should navigate to the first data cell in the grid using Ctrl + Home', async () => {
+        fix = TestBed.createComponent(AllExpandedGridMasterDetailComponent);
+        fix.detectChanges();
+        await fix.whenStable();
+        grid = fix.componentInstance.grid;
+        gridContent = GridFunctions.getGridContent(fix);
+        await fix.whenStable();
+
+        grid.verticalScrollContainer.scrollTo(grid.verticalScrollContainer.igxForOf.length - 1);
+        await wait(DEBOUNCE_TIME);
+        await fix.whenStable();
+
+        const targetCellElement = grid.gridAPI.get_cell_by_index(52, 'ContactName');
+        UIInteractions.simulateClickAndSelectEvent(targetCellElement);
+        await fix.whenStable();
+
+        UIInteractions.triggerEventHandlerKeyDown('Home', gridContent, false, false, true);
+        await wait(DEBOUNCE_TIME);
+        await fix.whenStable();
+
+        const fRow = grid.gridAPI.get_row_by_index(0);
+        expect(fRow).not.toBeUndefined();
+        expect(GridFunctions.elementInGridView(grid, fRow.nativeElement)).toBeTruthy();
+        expect((fRow.cells as QueryList<CellType>).first.active).toBeTruthy();
+    });
+
+    it('should navigate to the first/last row using Ctrl+ArrowUp/ArrowDown when focus is on the detail row container', async () => {
+        fix = TestBed.createComponent(AllExpandedGridMasterDetailComponent);
+        fix.detectChanges();
+        await fix.whenStable();
+        grid = fix.componentInstance.grid;
+        gridContent = GridFunctions.getGridContent(fix);
+
+        let row = grid.gridAPI.get_row_by_index(0);
+        let detailRow = GridFunctions.getMasterRowDetail(row);
+        UIInteractions.simulateClickAndSelectEvent(detailRow);
+        await fix.whenStable();
+
+        GridFunctions.verifyMasterDetailRowFocused(detailRow);
+
+        UIInteractions.triggerEventHandlerKeyDown('ArrowDown', gridContent, false, false, true);
+        await wait(DEBOUNCE_TIME);
+        await fix.whenStable();
+
+        row = grid.gridAPI.get_row_by_index(0);
+        detailRow = GridFunctions.getMasterRowDetail(row);
+        GridFunctions.verifyMasterDetailRowFocused(detailRow);
+
+        UIInteractions.triggerEventHandlerKeyDown('ArrowUp', gridContent, false, false, true);
+        await wait(DEBOUNCE_TIME);
+        await fix.whenStable();
+
+        row = grid.gridAPI.get_row_by_index(0);
+        detailRow = GridFunctions.getMasterRowDetail(row);
+        GridFunctions.verifyMasterDetailRowFocused(detailRow);
     });
 });
 

--- a/projects/igniteui-angular/grids/grid/src/grid.search.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid.search.spec.ts
@@ -1073,6 +1073,7 @@ describe('IgxGrid - search API #grid', () => {
         });
 
         it('Should be able to navigate through highlights when scrolling with grouping enabled', async () => {
+            fix.autoDetectChanges();
             grid.height = '500px';
             fix.detectChanges();
 

--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.navigation.spec.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.navigation.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Component, ViewChild, DebugElement, ChangeDetectionStrategy } from '@angular/core';
+import { Component, ViewChild, DebugElement, ChangeDetectionStrategy, provideZonelessChangeDetection } from '@angular/core';
 import { IgxChildGridRowComponent, IgxHierarchicalGridComponent } from './hierarchical-grid.component';
 import { wait, UIInteractions, waitForSelectionChange } from '../../../test-utils/ui-interactions.spec';
 import { IgxRowIslandComponent } from './row-island.component';
@@ -11,6 +11,7 @@ import { GridFunctions } from '../../../test-utils/grid-functions.spec';
 import { IGridCellEventArgs, IgxColumnComponent, IgxGridCellComponent, IgxGridNavigationService } from 'igniteui-angular/grids/core';
 import { IPathSegment } from 'igniteui-angular/core';
 import { SCROLL_THROTTLE_TIME_MULTIPLIER } from './../../grid/src/grid-base.directive';
+import { firstValueFrom } from 'rxjs';
 
 const DEBOUNCE_TIME = 60;
 const GRID_CONTENT_CLASS = '.igx-grid__tbody-content';
@@ -150,6 +151,7 @@ describe('IgxHierarchicalGrid Navigation', () => {
         });
 
         it('should allow navigating to end in child grid when child grid target row moves outside the parent view port.', async () => {
+            fixture.autoDetectChanges();
             const childGrid = hierarchicalGrid.gridAPI.getChildGrids(false)[0];
             const childCell =  childGrid.dataRowList.toArray()[0].cells.toArray()[0];
             GridFunctions.focusCell(fixture, childCell);
@@ -157,7 +159,8 @@ describe('IgxHierarchicalGrid Navigation', () => {
             const childGridContent =  fixture.debugElement.queryAll(By.css(GRID_CONTENT_CLASS))[1];
             UIInteractions.triggerEventHandlerKeyDown('end', childGridContent, false, false, true);
             fixture.detectChanges();
-            await wait();
+            await firstValueFrom(hierarchicalGrid.verticalScrollContainer.chunkLoad);
+
 
             // verify selection in child.
             const selectedCell = fixture.componentInstance.selectedCell;
@@ -167,9 +170,11 @@ describe('IgxHierarchicalGrid Navigation', () => {
             // parent should be scrolled down
             const currScrTop = hierarchicalGrid.verticalScrollContainer.getScroll().scrollTop;
             expect(currScrTop).toBeGreaterThanOrEqual(childGrid.rowHeight * 5);
+
         });
 
         it('should allow navigating to start in child grid when child grid target row moves outside the parent view port.', async () => {
+            fixture.autoDetectChanges();
             hierarchicalGrid.verticalScrollContainer.scrollTo(2);
             fixture.detectChanges();
             await wait(DEBOUNCE_TIME);
@@ -365,6 +370,7 @@ describe('IgxHierarchicalGrid Navigation', () => {
         });
 
         it('should move activation to last data cell in grid when ctrl+end is used.', async () => {
+            fixture.autoDetectChanges();
             const parentCell = hierarchicalGrid.dataRowList.first.cells.first;
             GridFunctions.focusCell(fixture, parentCell);
 
@@ -506,6 +512,7 @@ describe('IgxHierarchicalGrid Navigation', () => {
         });
 
         it('should skip nested child grids that have no data when navigating up/down', async () => {
+            fixture.autoDetectChanges();
             const child1 = hierarchicalGrid.gridAPI.getChildGrids(false)[0] as IgxHierarchicalGridComponent;
             child1.height = '150px';
             await wait();
@@ -665,6 +672,7 @@ describe('IgxHierarchicalGrid Navigation', () => {
 
         // complex tests
         it('in case prev cell is not in view port should scroll the closest scrollable parent so that cell comes in view.', async () => {
+            fixture.autoDetectChanges();
             // scroll parent so that child top is not in view
             await wait(DEBOUNCE_TIME);
             fixture.detectChanges();
@@ -712,6 +720,7 @@ describe('IgxHierarchicalGrid Navigation', () => {
         });
 
         it('in case next cell is not in view port should scroll the closest scrollable parent so that cell comes in view.', async () => {
+            fixture.autoDetectChanges();
             const child = hierarchicalGrid.gridAPI.getChildGrids(false)[0];
             const nestedChild = child.gridAPI.getChildGrids(false)[0];
             const nestedChildCell = nestedChild.dataRowList.toArray()[1].cells.toArray()[0];
@@ -734,6 +743,7 @@ describe('IgxHierarchicalGrid Navigation', () => {
         });
 
         it('should allow navigating up from parent into nested child grid', async () => {
+            fixture.autoDetectChanges();
             hierarchicalGrid.verticalScrollContainer.scrollTo(2);
             await wait(DEBOUNCE_TIME);
             fixture.detectChanges();
@@ -779,6 +789,7 @@ describe('IgxHierarchicalGrid Navigation', () => {
         });
 
         it('should allow navigating up between sibling child grids.', async () => {
+            fixture.autoDetectChanges();
             hierarchicalGrid.verticalScrollContainer.scrollTo(2);
             fixture.detectChanges();
             await wait();
@@ -827,6 +838,7 @@ describe('IgxHierarchicalGrid Navigation', () => {
         });
 
         it('should navigate up from parent row to the correct child sibling.', async () => {
+            fixture.autoDetectChanges();
             const parentCell = hierarchicalGrid.dataRowList.toArray()[1].cells.first;
             GridFunctions.focusCell(fixture, parentCell);
 
@@ -860,6 +872,7 @@ describe('IgxHierarchicalGrid Navigation', () => {
         });
 
         it('should navigate to last cell in previous child using Arrow Up from last cell of sibling with more columns', async () => {
+            fixture.autoDetectChanges();
             const childGrid2 = hierarchicalGrid.gridAPI.getChildGrids(false)[5];
 
             childGrid2.dataRowList.first.virtDirRow.scrollTo(7);
@@ -917,6 +930,7 @@ describe('IgxHierarchicalGrid Navigation', () => {
         });
 
         it('should navigate to last cell in next row for child grid using Arrow Up from last cell of parent with more columns', async () => {
+            fixture.autoDetectChanges();
             hierarchicalGrid.verticalScrollContainer.scrollTo(2);
             fixture.detectChanges();
             await wait();
@@ -939,6 +953,7 @@ describe('IgxHierarchicalGrid Navigation', () => {
         });
 
         it('should navigate to last cell in next child using Arrow Down from last cell of previous child with more columns', async () => {
+            fixture.autoDetectChanges();
             const childGrids =  fixture.debugElement.queryAll(By.directive(IgxChildGridRowComponent));
             const firstChildGrid = childGrids[0].query(By.directive(IgxHierarchicalGridComponent)).componentInstance;
             const secondChildGrid = childGrids[1].query(By.directive(IgxHierarchicalGridComponent)).componentInstance;
@@ -1001,6 +1016,7 @@ describe('IgxHierarchicalGrid Navigation', () => {
             expect(childGrid.getBoundingClientRect().bottom <= parentBottom && childGrid.getBoundingClientRect().top >= parentTop);
         });
         it('should navigate to exact nested child grid with navigateToChildGrid.', async() => {
+            fixture.autoDetectChanges();
             hierarchicalGrid.expandChildren = false;
             await wait(DEBOUNCE_TIME);
             hierarchicalGrid.primaryKey = 'ID';
@@ -1030,6 +1046,38 @@ describe('IgxHierarchicalGrid Navigation', () => {
             const parentTop = childGrid.getBoundingClientRect().top;
             // check it's in view within its parent
             expect(childGridNested.getBoundingClientRect().bottom <= parentBottom && childGridNested.getBoundingClientRect().top >= parentTop);
+        });
+    });
+    describe('IgxHierarchicalGrid Basic Navigation in zoneless change detection #hGrid', () => {
+        beforeEach(waitForAsync(() => {
+            TestBed.configureTestingModule({
+                providers: [
+                    provideZonelessChangeDetection(),
+                    { provide: SCROLL_THROTTLE_TIME_MULTIPLIER, useValue: 0 }
+                ]
+            });
+            fixture = TestBed.createComponent(IgxHierarchicalGridTestBaseComponent);
+            fixture.detectChanges();
+            hierarchicalGrid = fixture.componentInstance.hgrid;
+        }));
+
+        it('should activate the target cell after Ctrl + End scrolls a child grid', async () => {
+            const childGrid = hierarchicalGrid.gridAPI.getChildGrids(false)[0];
+            const childCell = childGrid.dataRowList.toArray()[0].cells.toArray()[0];
+            GridFunctions.focusCell(fixture, childCell);
+            await fixture.whenStable();
+
+            const activeNodeChange = firstValueFrom(childGrid.activeNodeChange);
+            const childGridContent = fixture.debugElement.queryAll(By.css(GRID_CONTENT_CLASS))[1];
+            UIInteractions.triggerEventHandlerKeyDown('end', childGridContent, false, false, true);
+            await activeNodeChange;
+            await fixture.whenStable();
+
+            const selectedCell = fixture.componentInstance.selectedCell;
+            expect(selectedCell.row.index).toEqual(9);
+            expect(selectedCell.column.field).toMatch('childData2');
+            expect(hierarchicalGrid.verticalScrollContainer.getScroll().scrollTop)
+                .toBeGreaterThanOrEqual(childGrid.rowHeight * 5);
         });
     });
 });

--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.virtualization.spec.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid.virtualization.spec.ts
@@ -202,6 +202,7 @@ describe('IgxHierarchicalGrid Virtualization #hGrid', () => {
     });
 
     it('should not lose scroll position after expanding a row when there are already expanded rows above.', async () => {
+        fixture.autoDetectChanges();
 
         // Expand two rows at the top
         (hierarchicalGrid.dataRowList.toArray()[2].nativeElement.children[0] as HTMLElement).click();

--- a/projects/igniteui-angular/grids/pivot-grid/src/pivot-grid.component.ts
+++ b/projects/igniteui-angular/grids/pivot-grid/src/pivot-grid.component.ts
@@ -1,7 +1,7 @@
 import { AfterContentInit, AfterViewInit, ChangeDetectionStrategy, Component, EventEmitter, ElementRef, HostBinding, Input, OnInit, Output, QueryList, TemplateRef, ViewChild, ViewChildren, ContentChild, createComponent, CUSTOM_ELEMENTS_SCHEMA, booleanAttribute, OnChanges, SimpleChanges, inject } from '@angular/core';
 import { NgTemplateOutlet, NgClass, NgStyle } from '@angular/common';
 
-import { first, take, takeUntil } from 'rxjs/operators';
+import { take, takeUntil } from 'rxjs/operators';
 import { DEFAULT_PIVOT_KEYS, IDimensionsChange, IgxFilteringService, IgxGridNavigationService, IgxGridValidationService, IgxPivotDateDimension, IgxPivotGridValueTemplateContext, IPivotConfiguration, IPivotConfigurationChangedEventArgs, IPivotDimension, IPivotGridRecord, IPivotUISettings, IPivotValue, IValuesChange, PivotDimensionType, PivotRowLayoutType, PivotSummaryPosition, PivotUtil } from 'igniteui-angular/grids/core';
 import { IgxGridSelectionService } from 'igniteui-angular/grids/core';
 import { GridType, IGX_GRID_BASE, IGX_GRID_SERVICE_BASE, IgxColumnTemplateContext, PivotGridType, RowType } from 'igniteui-angular/grids/core';
@@ -12,7 +12,7 @@ import { IgxColumnGroupComponent } from 'igniteui-angular/grids/core';
 import { IgxColumnComponent } from 'igniteui-angular/grids/core';
 import { FilterMode, GridPagingMode, GridSummaryPosition } from 'igniteui-angular/grids/core';
 import { WatchChanges } from 'igniteui-angular/grids/core';
-import { cloneArray, ColumnType, DataUtil, DefaultDataCloneStrategy, GridColumnDataType, GridSummaryCalculationMode, IDataCloneStrategy, IFilteringExpressionsTree, IFilteringOperation, IFilteringStrategy, ISortingExpression, OverlaySettings, resizeObservable, ɵSize, SortingDirection, IgxOverlayOutletDirective } from 'igniteui-angular/core';
+import { cloneArray, ColumnType, DataUtil, DefaultDataCloneStrategy, GridColumnDataType, GridSummaryCalculationMode, IDataCloneStrategy, IFilteringExpressionsTree, IFilteringOperation, IFilteringStrategy, ISortingExpression, OverlaySettings, resizeObservable, runAfterRenderOnce, ɵSize, SortingDirection, IgxOverlayOutletDirective } from 'igniteui-angular/core';
 import {
     IGridEditEventArgs,
     ICellPosition,
@@ -2153,7 +2153,7 @@ export class IgxPivotGridComponent extends IgxGridBaseDirective implements OnIni
         super.calculateGridSizes(recalcFeatureWidth);
         if (this.hasDimensionsToAutosize) {
             this.cdr.detectChanges();
-            this.zone.onStable.pipe(first()).subscribe(() => {
+            runAfterRenderOnce(this.injector, () => {
                 requestAnimationFrame(() => {
                     this.autoSizeDimensionsInView();
                 });

--- a/projects/igniteui-angular/grids/tree-grid/src/tree-grid-integration.spec.ts
+++ b/projects/igniteui-angular/grids/tree-grid/src/tree-grid-integration.spec.ts
@@ -1,4 +1,5 @@
 import { TestBed, ComponentFixture, waitForAsync, fakeAsync, tick } from '@angular/core/testing';
+import { Component, provideZonelessChangeDetection, ViewChild } from '@angular/core';
 import { IgxTreeGridComponent } from './tree-grid.component';
 import {
     IgxTreeGridSimpleComponent, IgxTreeGridPrimaryForeignKeyComponent,
@@ -12,10 +13,11 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { TreeGridFunctions } from '../../../test-utils/tree-grid-functions.spec';
 import { UIInteractions, wait } from '../../../test-utils/ui-interactions.spec';
 import { By } from '@angular/platform-browser';
-import { CellType, DropPosition, IgxTreeGridRow } from 'igniteui-angular/grids/core';
+import { CellType, DropPosition, IgxColumnComponent, IgxTreeGridRow } from 'igniteui-angular/grids/core';
 import { IgxTreeGridRowComponent } from './tree-grid-row.component';
 import { IgxGridTransaction } from 'igniteui-angular/grids/core';
 import { HierarchicalTransaction, IgxHierarchicalTransactionService, IgxNumberFilteringOperand, IgxStringFilteringOperand, SortingDirection, TransactionType } from 'igniteui-angular/core';
+import { firstValueFrom } from 'rxjs';
 
 const CSS_CLASS_BANNER = 'igx-banner';
 const CSS_CLASS_ROW_EDITED = 'igx-grid__tr--edited';
@@ -1828,4 +1830,74 @@ describe('IgxTreeGrid - Integration #tGrid', () => {
             expect(firstRow.isRoot).toBe(false);
         });
     });
+
+    describe('Column autosizing in zoneless change detection', () => {
+        beforeEach(() => {
+            TestBed.configureTestingModule({
+                imports: [TreeGridZonelessAutosizeComponent],
+                providers: [provideZonelessChangeDetection()]
+            });
+        });
+
+        it('should keep header and body column widths aligned when horizontally constrained', async () => {
+            fix = TestBed.createComponent(TreeGridZonelessAutosizeComponent);
+            fix.detectChanges();
+            treeGrid = fix.componentInstance.treeGrid;
+            await fix.whenStable();
+
+            const horizontalScroller = treeGrid.headerContainer.getScroll();
+            expect(horizontalScroller.scrollWidth).toBeGreaterThan(horizontalScroller.clientWidth);
+
+            const expectRenderedColumnsAligned = () => {
+                const cells = Array.from(treeGrid.gridAPI.get_row_by_index(0).cells);
+                expect(cells.length).toBeGreaterThan(1);
+
+                for (const cell of cells.filter(renderedCell => renderedCell.column.field !== 'ID')) {
+                    const header = TreeGridFunctions.getHeaderCellMultiColHeaders(fix, cell.column.field).nativeElement;
+                    const headerWidth = header.getBoundingClientRect().width;
+                    const cellWidth = cell.nativeElement.getBoundingClientRect().width;
+
+                    expect(Math.abs(headerWidth - cellWidth))
+                        .withContext(`column ${cell.column.field}`)
+                        .toBeLessThanOrEqual(1);
+                }
+            };
+
+            expectRenderedColumnsAligned();
+
+            const chunkLoad = firstValueFrom(treeGrid.parentVirtDir.chunkLoad);
+            horizontalScroller.scrollLeft = horizontalScroller.scrollWidth;
+            horizontalScroller.dispatchEvent(new Event('scroll'));
+            await chunkLoad;
+            await fix.whenStable();
+
+            expectRenderedColumnsAligned();
+        });
+    });
 });
+
+@Component({
+    template: `
+        <igx-tree-grid #treeGrid [data]="data" primaryKey="ID" foreignKey="ParentID"
+            width="400px" height="300px">
+            @for (column of columns; track column) {
+                <igx-column [field]="column" width="fit-content"></igx-column>
+            }
+        </igx-tree-grid>
+    `,
+    imports: [IgxTreeGridComponent, IgxColumnComponent]
+})
+class TreeGridZonelessAutosizeComponent {
+    @ViewChild(IgxTreeGridComponent, { static: true }) public treeGrid: IgxTreeGridComponent;
+    public columns = ['ID', 'ParentID', 'EmployeeName', 'Department', 'Office', 'Country', 'Project', 'Status'];
+    public data = Array.from({ length: 40 }, (_row, index) => ({
+        ID: index,
+        ParentID: index === 0 ? null : 0,
+        EmployeeName: `Employee with a long display name ${index}`,
+        Department: `International Operations Department ${index}`,
+        Office: `Regional office location ${index}`,
+        Country: `Country name ${index}`,
+        Project: `Long running project ${index}`,
+        Status: `Current status ${index}`
+    }));
+}

--- a/projects/igniteui-angular/grids/tree-grid/src/tree-grid-keyBoardNav.spec.ts
+++ b/projects/igniteui-angular/grids/tree-grid/src/tree-grid-keyBoardNav.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { IgxTreeGridComponent } from './public_api';
-import { IgxTreeGridWithNoScrollsComponent, IgxTreeGridWithScrollsComponent } from '../../../test-utils/tree-grid-components.spec';
+import { IgxTreeGridManyColumnsComponent, IgxTreeGridWithNoScrollsComponent, IgxTreeGridWithScrollsComponent } from '../../../test-utils/tree-grid-components.spec';
 import { TreeGridFunctions } from '../../../test-utils/tree-grid-functions.spec';
 import { UIInteractions, wait } from '../../../test-utils/ui-interactions.spec';
 import { clearGridSubs, setupGridScrollDetection } from '../../../test-utils/helper-utils.spec';
 import { GridFunctions } from '../../../test-utils/grid-functions.spec';
-import { DebugElement } from '@angular/core';
-import { firstValueFrom } from 'rxjs';
+import { DebugElement, provideZonelessChangeDetection } from '@angular/core';
+import { filter, firstValueFrom } from 'rxjs';
 import { CellType } from 'igniteui-angular/grids/core';
 import { SCROLL_THROTTLE_TIME_MULTIPLIER } from './../../grid/src/grid-base.directive';
 
@@ -412,6 +412,7 @@ describe('IgxTreeGrid - Key Board Navigation #tGrid', () => {
         });
 
         it('should navigate with arrow Up and Down keys', async () => {
+            fix.autoDetectChanges();
             spyOn(treeGrid.selected, 'emit').and.callThrough();
             const firstCell: CellType = treeGrid.gridAPI.get_cell_by_index(5, 'ID');
             UIInteractions.simulateClickAndSelectEvent(firstCell);
@@ -556,6 +557,7 @@ describe('IgxTreeGrid - Key Board Navigation #tGrid', () => {
         });
 
         it('should move to the top left/bottom right cell when navigate with Ctrl + Home/End keys', async () => {
+            fix.autoDetectChanges();
             spyOn(treeGrid.selected, 'emit').and.callThrough();
             let cell = treeGrid.gridAPI.get_cell_by_index(2, treeColumns[2]);
 
@@ -640,6 +642,7 @@ describe('IgxTreeGrid - Key Board Navigation #tGrid', () => {
         });
 
         it('should change editable cell and scroll when Tab and Shift + Tab keys are pressed', async () => {
+            fix.autoDetectChanges();
             treeGrid.getColumnByName('ID').editable = true;
             treeGrid.getColumnByName('Name').editable = true;
             treeGrid.getColumnByName('HireDate').editable = true;
@@ -845,5 +848,50 @@ describe('IgxTreeGrid - Key Board Navigation #tGrid', () => {
             cell = treeGrid.gridAPI.get_cell_by_index(8, 'ID');
             TreeGridFunctions.verifyTreeGridCellSelected(treeGrid, cell);
         });
+    });
+});
+
+describe('IgxTreeGrid keyboard navigation in zoneless change detection #tGrid', () => {
+    let fix;
+    let treeGrid: IgxTreeGridComponent;
+    let gridContent: DebugElement;
+    let treeColumns: string[];
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [NoopAnimationsModule, IgxTreeGridManyColumnsComponent],
+            providers: [
+                provideZonelessChangeDetection(),
+                { provide: SCROLL_THROTTLE_TIME_MULTIPLIER, useValue: 0 }
+            ]
+        });
+        fix = TestBed.createComponent(IgxTreeGridManyColumnsComponent);
+        fix.detectChanges();
+        treeGrid = fix.componentInstance.treeGrid;
+        treeColumns = fix.componentInstance.columns;
+        gridContent = GridFunctions.getGridContent(fix);
+    });
+
+    it('should activate a virtualized target cell with Ctrl + End', async () => {
+        spyOn(treeGrid.selected, 'emit').and.callThrough();
+        const horizontalScroll = treeGrid.headerContainer.getScroll();
+        expect(horizontalScroll.scrollWidth).toBeGreaterThan(horizontalScroll.clientWidth);
+        expect(treeGrid.gridAPI.get_cell_by_index(2, treeColumns[treeColumns.length - 1])).toBeUndefined();
+
+        let cell = treeGrid.gridAPI.get_cell_by_index(2, treeColumns[1]);
+        UIInteractions.simulateClickAndSelectEvent(cell);
+        await fix.whenStable();
+
+        const selected = firstValueFrom(treeGrid.selected.pipe(
+            filter(({ cell: selectedCell }) => selectedCell.row.index === 9 &&
+                selectedCell.column.field === treeColumns[treeColumns.length - 1])
+        ));
+        UIInteractions.triggerEventHandlerKeyDown('End', gridContent, false, false, true);
+        await selected;
+        await fix.whenStable();
+
+        cell = treeGrid.gridAPI.get_cell_by_index(9, treeColumns[treeColumns.length - 1]);
+        TreeGridFunctions.verifyTreeGridCellSelected(treeGrid, cell);
+        expect(treeGrid.selected.emit).toHaveBeenCalledTimes(2);
     });
 });

--- a/projects/igniteui-angular/grids/tree-grid/src/tree-grid-summaries.spec.ts
+++ b/projects/igniteui-angular/grids/tree-grid/src/tree-grid-summaries.spec.ts
@@ -172,14 +172,14 @@ describe('IgxTreeGrid - Summaries #tGrid', () => {
 
             treeGrid.summaryCalculationMode = 'rootLevelOnly';
             fix.detectChanges();
-            await wait(50);
+            await fix.whenStable();
 
             verifyTreeBaseSummaries(fix);
             expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(1);
 
             treeGrid.summaryCalculationMode = 'childLevelsOnly';
             fix.detectChanges();
-            await wait(50);
+            await fix.whenStable();
 
             expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(4);
             expect(GridSummaryFunctions.getAllVisibleSummariesRowIndexes(fix)).toEqual([6, 7, 12, 13]);
@@ -188,7 +188,7 @@ describe('IgxTreeGrid - Summaries #tGrid', () => {
 
             treeGrid.summaryCalculationMode = 'rootAndChildLevels';
             fix.detectChanges();
-            await wait(50);
+            await fix.whenStable();
 
             verifyTreeBaseSummaries(fix);
             expect(GridSummaryFunctions.getAllVisibleSummariesLength(fix)).toEqual(3);
@@ -1707,6 +1707,7 @@ describe('IgxTreeGrid - Summaries #tGrid', () => {
 
     it('should render rows correctly after collapse and expand', async () => {
         const fix = TestBed.createComponent(IgxTreeGridSummariesScrollingComponent);
+        fix.autoDetectChanges();
         const treeGrid = fix.componentInstance.treeGrid;
         setupGridScrollDetection(fix, treeGrid);
         fix.detectChanges();

--- a/projects/igniteui-angular/grids/tree-grid/src/tree-grid.component.spec.ts
+++ b/projects/igniteui-angular/grids/tree-grid/src/tree-grid.component.spec.ts
@@ -221,18 +221,19 @@ describe('IgxTreeGrid Component Tests #tGrid', () => {
         //     element.remove();
         // });
 
-        it('should auto-generate all columns', fakeAsync(() => {
+        it('should auto-generate all columns', async () => {
             grid.data = [];
-            tick();
+            await fix.whenStable();
             fix.detectChanges();
 
             grid.data = SampleTestData.employeePrimaryForeignKeyTreeData();
-            tick();
+            await fix.whenStable();
             fix.detectChanges();
 
             grid.primaryKey = 'ID';
             grid.foreignKey = 'ParentID';
-            tick();
+            await wait(100);
+            await fix.whenStable();
             fix.detectChanges();
 
             const expectedColumns = [...Object.keys(grid.data[0])];
@@ -240,7 +241,7 @@ describe('IgxTreeGrid Component Tests #tGrid', () => {
             expect(grid.columns.map(c => c.field)).toEqual(expectedColumns);
             // Verify that records are also rendered by checking the first record cell
             expect(grid.getCellByColumn(0, 'ID').value).toEqual(1);
-        }));
+        });
 
         it('should auto-generate columns without childDataKey', fakeAsync(() => {
             grid.data = [];

--- a/projects/igniteui-angular/test-utils/tree-grid-components.spec.ts
+++ b/projects/igniteui-angular/test-utils/tree-grid-components.spec.ts
@@ -126,6 +126,37 @@ export class IgxTreeGridWithScrollsComponent {
 
 @Component({
     template: `
+    <igx-tree-grid #treeGrid [data]="data" childDataKey="Employees"
+        primaryKey="ID" width="318px" height="400px" columnWidth="100px">
+        @for (column of columns; track column) {
+            <igx-column [field]="column"></igx-column>
+        }
+    </igx-tree-grid>
+    `,
+    changeDetection: ChangeDetectionStrategy.Eager,
+    imports: [IgxTreeGridComponent, IgxColumnComponent]
+})
+export class IgxTreeGridManyColumnsComponent {
+    @ViewChild(IgxTreeGridComponent, { static: true }) public treeGrid: IgxTreeGridComponent;
+    public columns = ['ID', ...Array.from({ length: 15 }, (_, index) => `Value${index + 1}`)];
+    public data = this.addColumnValues(SampleTestData.employeeAllTypesTreeData());
+
+    private addColumnValues(records: any[]): any[] {
+        return records.map((record, rowIndex) => {
+            const result = { ...record };
+            for (const column of this.columns.slice(1)) {
+                result[column] = `${column}-${rowIndex}`;
+            }
+            if (record.Employees) {
+                result.Employees = this.addColumnValues(record.Employees);
+            }
+            return result;
+        });
+    }
+}
+
+@Component({
+    template: `
     <igx-tree-grid #treeGrid [data]="data" childDataKey="Employees" primaryKey="ID" width="600px" height="600px" columnWidth="100px">
         <igx-column [field]="'ID'" dataType="number"></igx-column>
         <igx-column [field]="'Name'" dataType="string"></igx-column>


### PR DESCRIPTION
Closes #17364
Closes #17385
Closes #17318
Closes #17280


## What

Grid virtualization, autosizing, and keyboard navigation relied on `NgZone.onStable`, which never emits in zoneless apps. As a result, scroll-driven `chunkLoad`, column autosize, filter-row rendering, and post-scroll cell activation silently never ran.

This migrates all of that off `onStable` and onto Angular’s render hooks.

## Changes

### Core

* Added a new central helper: `runAfterRenderOnce(injector, cb, phase?)` in `core/utils.ts`.

  * This is now the single scheduling point for all deferred-render work.
  * Previously, this logic was scattered across `onStable` / `ɵNoopNgZone` branches.
* Updated every affected call site to go through `runAfterRenderOnce`.
* Removed the private `ɵNoopNgZone`-based zoneless detection.
* Removed the duplicated per-class `runAfterRender` helpers.

### Grids

* `IgxFilteringService.isFilterRowVisible` is now signal-backed, so the `OnPush` header row re-renders without requiring a zone tick.
* Filter cells now observe their own size via `ResizeObserver` to recompute visible chips after resize.
* Column resize now explicitly notifies the grid via `notifyResized`, instead of relying on an empty `zone.run`.
* Keyboard navigation now notifies after any scrolling navigation key, not just `Ctrl`.
* Hierarchical navigation now subscribes to `chunkLoad` before scrolling, avoiding missed synchronous emissions.
* Deferred work in `for_of`, `grid-base`, and `pivot-grid` was migrated to `runAfterRenderOnce`.

### Tests

* Added zoneless duplicates using `provideZonelessChangeDetection` for the affected grid, tree, hierarchical, and pivot suites.
* Centralized async test helpers in `helper-utils.spec.ts`.
* `runAfterRenderOnce` consumers now settle through shared helpers:

  * `waitForGridSettle`
  * `setGridVerticalScrollTop`
  * `dispatchGridScrollEvents`
  * `navigateWithGridScroll`
* Updated the zoned originals to await the new render-boundary timing.

  * Previously, they happened to align with `onStable`.

## Notes

* Behavior for zoned apps is unchanged in practice.

  * Real interaction still triggers a render.
  * Only the timing signal moved from `onStable` to `afterNextRender`.
* No `runOutsideAngular` was removed.
* No forced `detectChanges` was added in zoneless tests.



## Motivation / Context
<!-- Why is this change needed? Link to the related issue(s) or discussion. -->


### Type of Change (check all that apply):
 - [x] Bug fix
 - [x] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
<!-- List the component(s) or area(s) this PR touches, e.g. Grid, Combo, Theming -->


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Include relevant details so reviewers can reproduce. -->
 - [x] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **Angular version**: 
 - **Browser(s)**: 
 - **OS**: 

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain the visual changes. -->


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 