### PR TITLE
fix(grid): restore trailing scroll emission so top rows aren't lost after fast scroll - 21.2.x

### DIFF
--- a/projects/igniteui-angular/grids/grid/src/grid-base.directive.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid-base.directive.ts
@@ -3719,7 +3719,12 @@ export abstract class IgxGridBaseDirective implements GridType,
                 this.throttleTime$.pipe(
                     take(1),
                     switchMap(time => timer(time, this.throttleScheduler))
-                )
+                ),
+                // `trailing: true` ensures the final settle position of a fast momentum
+                // scroll is processed; otherwise the last scroll events are dropped and the
+                // rows stay frozen at an intermediate startIndex while the scrollbar is at top.
+                // `leading: true` keeps the immediate response on scroll start.
+                { leading: true, trailing: true }
             ),
             destructor
         )

--- a/projects/igniteui-angular/grids/grid/src/grid.component.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid.component.spec.ts
@@ -3309,6 +3309,49 @@ describe('IgxGrid Component Tests #grid', () => {
             expect(() => fix.detectChanges()).not.toThrow();
         });
     });
+
+    describe('IgxGrid - scroll throttle trailing edge', () => {
+        beforeEach(waitForAsync(() => {
+            TestBed.configureTestingModule({
+                imports: [NoopAnimationsModule, IgxGridScrollThrottleComponent],
+                providers: [{ provide: SCROLL_THROTTLE_TIME_MULTIPLIER, useValue: 0 }]
+            }).compileComponents();
+        }));
+
+        it('should settle at the top row when a fast momentum scroll ends at scrollTop 0 (throttle trailing edge)', async () => {
+            const fix = TestBed.createComponent(IgxGridScrollThrottleComponent);
+            fix.detectChanges();
+            await wait(50);
+            fix.detectChanges();
+            const grid = fix.componentInstance.grid;
+            const virtDir = grid.verticalScrollContainer;
+            const scrollEl = virtDir.getScroll();
+            const maxScroll = scrollEl.scrollHeight - scrollEl.clientHeight;
+
+            // Move away from the top so the first rows are virtualized out of view.
+            grid.scrollNotify.next({ target: { scrollTop: maxScroll } });
+            await wait(50);
+            fix.detectChanges();
+            expect(virtDir.state.startIndex).toBeGreaterThan(0);
+
+            // Simulate a fast momentum/inertia scroll back to the top: an intermediate
+            // position lands on the throttle's leading edge and the scrollTop = 0 settle
+            // arrives within the same throttle window - timer(0, animationFrameScheduler)
+            // still defers the window close to the next frame - so it can only be delivered
+            // on the trailing edge. Feeding scrollNotify directly (instead of setting
+            // scrollTop) avoids the browser's async native scroll events, which all read the
+            // final scrollTop of 0, from masking a dropped-trailing regression.
+            grid.scrollNotify.next({ target: { scrollTop: Math.round(maxScroll / 2) } });
+            grid.scrollNotify.next({ target: { scrollTop: 0 } });
+            await wait(50);
+            fix.detectChanges();
+
+            // Without the trailing edge the settle event is dropped and the grid stays
+            // frozen at an intermediate startIndex while the scrollbar sits at the top.
+            expect(virtDir.state.startIndex).toBe(0);
+            expect(grid.gridAPI.get_row_by_index(0)).toBeDefined();
+        });
+    });
 });
 
 @Component({
@@ -4031,4 +4074,13 @@ export class IgxGridPerformanceComponent implements AfterViewInit, OnInit {
 })
 export class IgxGridNoDataComponent {
     @ViewChild(IgxGridComponent, { static: true }) public grid: IgxGridComponent;
+}
+
+@Component({
+    template: `<igx-grid #grid [data]="data" height="300px" width="600px" [autoGenerate]="true"></igx-grid>`,
+    imports: [IgxGridComponent]
+})
+class IgxGridScrollThrottleComponent {
+    @ViewChild(IgxGridComponent, { static: true }) public grid: IgxGridComponent;
+    public data = Array.from({ length: 200 }, (_row, index) => ({ ID: index, Name: `Record ${index}`, Value: index * 10 }));
 }

--- a/projects/igniteui-angular/grids/grid/src/grid.component.spec.ts
+++ b/projects/igniteui-angular/grids/grid/src/grid.component.spec.ts
@@ -881,6 +881,73 @@ describe('IgxGrid Component Tests #grid', () => {
             expect(grid.verticalScrollContainer.getScroll().scrollTop).toBe(initialScroll);
             expect(grid.headerContainer.getScroll().scrollLeft).toBeGreaterThanOrEqual(2 * (initialHorScroll + 50));
         }));
+
+        describe('scroll throttle trailing edge', () => {
+            beforeEach(waitForAsync(() => {
+                TestBed.configureTestingModule({
+                    imports: [NoopAnimationsModule, IgxGridScrollThrottleComponent],
+                    providers: [{ provide: SCROLL_THROTTLE_TIME_MULTIPLIER, useValue: 0 }]
+                }).compileComponents();
+            }));
+
+            // Drive scrollNotify directly (not programmatic scrollTop, whose async native events would mask a dropped-trailing regression) to exercise the throttle window deterministically.
+            it('should settle at the top row after a fast momentum scroll back to scrollTop 0', async () => {
+                const fix = TestBed.createComponent(IgxGridScrollThrottleComponent);
+                fix.detectChanges();
+                await wait(50);
+                fix.detectChanges();
+                const grid = fix.componentInstance.grid;
+                const virtDir = grid.verticalScrollContainer;
+                const scrollEl = virtDir.getScroll();
+                const hScroll = grid.headerContainer.getScroll();
+                const maxScroll = scrollEl.scrollHeight - scrollEl.clientHeight;
+
+                // Guard the reproduction condition: the fixture must overflow horizontally.
+                expect(hScroll.scrollWidth).toBeGreaterThan(hScroll.clientWidth);
+
+                // Move away from the top so the first rows are virtualized out of view.
+                grid.scrollNotify.next({ target: { scrollTop: maxScroll } });
+                await wait(50);
+                fix.detectChanges();
+                expect(virtDir.state.startIndex).toBeGreaterThan(0);
+
+                // Momentum scroll back to top: intermediate on the leading edge, scrollTop = 0 settle only on the trailing edge.
+                grid.scrollNotify.next({ target: { scrollTop: Math.round(maxScroll / 2) } });
+                grid.scrollNotify.next({ target: { scrollTop: 0 } });
+                await wait(50);
+                fix.detectChanges();
+
+                // Without the trailing edge the settle is dropped and startIndex stays frozen mid-list.
+                expect(virtDir.state.startIndex).toBe(0);
+                expect(grid.gridAPI.get_row_by_index(0)).toBeDefined();
+            });
+
+            it('should settle at the last row after a fast momentum scroll to the bottom', async () => {
+                const fix = TestBed.createComponent(IgxGridScrollThrottleComponent);
+                fix.detectChanges();
+                await wait(50);
+                fix.detectChanges();
+                const grid = fix.componentInstance.grid;
+                const virtDir = grid.verticalScrollContainer;
+                const scrollEl = virtDir.getScroll();
+                const hScroll = grid.headerContainer.getScroll();
+                const maxScroll = scrollEl.scrollHeight - scrollEl.clientHeight;
+                const lastIndex = fix.componentInstance.data.length - 1;
+
+                expect(hScroll.scrollWidth).toBeGreaterThan(hScroll.clientWidth);
+                expect(virtDir.state.startIndex).toBe(0);
+
+                // Momentum scroll top to bottom: intermediate on the leading edge, max-scroll settle only on the trailing edge.
+                grid.scrollNotify.next({ target: { scrollTop: Math.round(maxScroll / 2) } });
+                grid.scrollNotify.next({ target: { scrollTop: maxScroll } });
+                await wait(50);
+                fix.detectChanges();
+
+                // Without the trailing edge the settle is dropped and the last row is never brought into view.
+                expect((virtDir.state.startIndex ?? 0) + (virtDir.state.chunkSize ?? 0)).toBeGreaterThanOrEqual(lastIndex + 1);
+                expect(grid.gridAPI.get_row_by_index(lastIndex)).toBeDefined();
+            });
+        });
     });
 
     describe('IgxGrid - default rendering for rows and columns', () => {
@@ -3309,49 +3376,6 @@ describe('IgxGrid Component Tests #grid', () => {
             expect(() => fix.detectChanges()).not.toThrow();
         });
     });
-
-    describe('IgxGrid - scroll throttle trailing edge', () => {
-        beforeEach(waitForAsync(() => {
-            TestBed.configureTestingModule({
-                imports: [NoopAnimationsModule, IgxGridScrollThrottleComponent],
-                providers: [{ provide: SCROLL_THROTTLE_TIME_MULTIPLIER, useValue: 0 }]
-            }).compileComponents();
-        }));
-
-        it('should settle at the top row when a fast momentum scroll ends at scrollTop 0 (throttle trailing edge)', async () => {
-            const fix = TestBed.createComponent(IgxGridScrollThrottleComponent);
-            fix.detectChanges();
-            await wait(50);
-            fix.detectChanges();
-            const grid = fix.componentInstance.grid;
-            const virtDir = grid.verticalScrollContainer;
-            const scrollEl = virtDir.getScroll();
-            const maxScroll = scrollEl.scrollHeight - scrollEl.clientHeight;
-
-            // Move away from the top so the first rows are virtualized out of view.
-            grid.scrollNotify.next({ target: { scrollTop: maxScroll } });
-            await wait(50);
-            fix.detectChanges();
-            expect(virtDir.state.startIndex).toBeGreaterThan(0);
-
-            // Simulate a fast momentum/inertia scroll back to the top: an intermediate
-            // position lands on the throttle's leading edge and the scrollTop = 0 settle
-            // arrives within the same throttle window - timer(0, animationFrameScheduler)
-            // still defers the window close to the next frame - so it can only be delivered
-            // on the trailing edge. Feeding scrollNotify directly (instead of setting
-            // scrollTop) avoids the browser's async native scroll events, which all read the
-            // final scrollTop of 0, from masking a dropped-trailing regression.
-            grid.scrollNotify.next({ target: { scrollTop: Math.round(maxScroll / 2) } });
-            grid.scrollNotify.next({ target: { scrollTop: 0 } });
-            await wait(50);
-            fix.detectChanges();
-
-            // Without the trailing edge the settle event is dropped and the grid stays
-            // frozen at an intermediate startIndex while the scrollbar sits at the top.
-            expect(virtDir.state.startIndex).toBe(0);
-            expect(grid.gridAPI.get_row_by_index(0)).toBeDefined();
-        });
-    });
 });
 
 @Component({
@@ -4082,5 +4106,12 @@ export class IgxGridNoDataComponent {
 })
 class IgxGridScrollThrottleComponent {
     @ViewChild(IgxGridComponent, { static: true }) public grid: IgxGridComponent;
-    public data = Array.from({ length: 200 }, (_row, index) => ({ ID: index, Name: `Record ${index}`, Value: index * 10 }));
+    // 30 columns in a 600px-wide grid guarantee horizontal overflow, plus 200 rows for vertical virtualization.
+    public data = Array.from({ length: 200 }, (_row, rowIndex) => {
+        const record: Record<string, number | string> = { ID: rowIndex };
+        for (let col = 0; col < 30; col++) {
+            record[`Col${col}`] = `r${rowIndex}c${col}`;
+        }
+        return record;
+    });
 }


### PR DESCRIPTION
Closes #17287

## Description
Fixes a regression where the top rows of `igx-grid` / `igx-tree-grid` /
`igx-hierarchical-grid` could become invisible after a fast momentum/inertia
scroll back to the top. The scrollbar reports `scrollTop ≈ 0`, but the
virtualized rows stay frozen at an intermediate `startIndex` (~row 10–15).

The vertical-scroll `throttle` on `scrollNotify` was passing no config, so it
used RxJS's default `{ leading: true, trailing: false }`. The **trailing** edge
is what guarantees the final settle position of a scroll gets processed, so
without it the last events of a momentum flick (including the `scrollTop ≈ 0`
settle) were dropped. Restoring `{ leading: true, trailing: true }` fixes this
while keeping the immediate leading-edge response.

## Motivation / Context
The throttle originally used
`throttleTime(THROTTLE_TIME, animationFrameScheduler, { leading: false, trailing: true })`.
When it was changed to a data-size–dependent `throttle(durationSelector)` (in
"feat(grids): Apply different throttle based on the amount of data in display"),
the config object was dropped and the operator fell back to the RxJS default
`{ leading: true, trailing: false }`.

Without the trailing edge, the last scroll events of a momentum flick fall inside
a throttle window (up to 60 ms for large grids) and are discarded.
`verticalScrollContainer.onScroll` never runs for the final position, so
virtualization stays at the last *leading* `startIndex` while the DOM scrollbar
settles at the top → the top rows appear missing.

The fix keeps `leading: true` (matching current `master`, so timing-sensitive
scroll/navigation tests are unaffected) and adds `trailing: true` to restore the
guarantee that the final resting scroll position is always handled — a strict
superset of the current behavior. Independent of zone/zoneless change detection.

Backported to `21.2.x` and `22.0.x`.

