### PR TITLE
fix(hierarchicalGrid): Ensure col instances created from ri cols are …

### DIFF
--- a/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid-base.directive.ts
+++ b/projects/igniteui-angular/grids/hierarchical-grid/src/hierarchical-grid-base.directive.ts
@@ -1,5 +1,6 @@
 import {
     booleanAttribute,
+    ComponentRef,
     createComponent,
     Directive,
     EventEmitter,
@@ -132,6 +133,8 @@ export abstract class IgxHierarchicalGridBaseDirective extends IgxGridBaseDirect
     /* blazorSuppress */
     public abstract expandChildren: boolean;
 
+    protected _rowIslandColumnRefs: ComponentRef<IgxColumnComponent>[] = [];
+
     /**
      * @hidden
      */
@@ -141,6 +144,7 @@ export abstract class IgxHierarchicalGridBaseDirective extends IgxGridBaseDirect
         topLevelCols.forEach((col) => {
             col.grid = this;
             const ref = this._createColumn(col);
+            this._rowIslandColumnRefs.push(ref);
             ref.changeDetectorRef.detectChanges();
             columns.push(ref.instance);
         });
@@ -189,7 +193,9 @@ export abstract class IgxHierarchicalGridBaseDirective extends IgxGridBaseDirect
         if (col.children.length > 0) {
             const newChildren = [];
             col.children.forEach(child => {
-                const newCol = this._createColumn(child).instance;
+                const childRef = this._createColumn(child);
+                this._rowIslandColumnRefs.push(childRef);
+                const newCol = childRef.instance;
                 newCol.parent = ref.instance;
                 newChildren.push(newCol);
             });
@@ -212,6 +218,16 @@ export abstract class IgxHierarchicalGridBaseDirective extends IgxGridBaseDirect
         });
         ref.instance.validators = col.validators;
         return ref;
+    }
+
+    public override ngOnDestroy() {
+        this.destroyRowIslandColumnRefs();
+        super.ngOnDestroy();
+    }
+
+    protected destroyRowIslandColumnRefs() {
+        this._rowIslandColumnRefs.forEach(ref => ref.destroy());
+        this._rowIslandColumnRefs = [];
     }
 
     protected getGridsForIsland(rowIslandID: string) {


### PR DESCRIPTION
…destroyed.

Closes #17502  

## Description
Destroy column instances that are created for child grids from row island column declarations, since they seem to remain after target grid is destroyed for some reason.

## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 