### PR TITLE
fix(drag-drop): disable drag on secondary pointer button - 21.2.x

### DIFF
--- a/projects/igniteui-angular/directives/src/directives/drag-drop/drag-drop.directive.ts
+++ b/projects/igniteui-angular/directives/src/directives/drag-drop/drag-drop.directive.ts
@@ -927,6 +927,11 @@ export class IgxDragDirective implements AfterContentInit, OnDestroy {
      * @param event PointerDown event captured
      */
     public onPointerDown(event) {
+        // Start drag only with the primary pointer button.
+        if ((this.pointerEventsEnabled || !this.touchEventsEnabled) && event.button !== undefined && event.button !== 0) {
+            return;
+        }
+
         const ignoredElement = this.dragIgnoredElems.find(elem => elem.element.nativeElement === event.target);
         if (ignoredElement) {
             return;

--- a/projects/igniteui-angular/directives/src/directives/drag-drop/drag-drop.directive.ts
+++ b/projects/igniteui-angular/directives/src/directives/drag-drop/drag-drop.directive.ts
@@ -928,7 +928,7 @@ export class IgxDragDirective implements AfterContentInit, OnDestroy {
      */
     public onPointerDown(event) {
         // Start drag only with the primary pointer button.
-        if ((this.pointerEventsEnabled || !this.touchEventsEnabled) && event.button !== undefined && event.button !== 0) {
+        if ((this.pointerEventsEnabled || !this.touchEventsEnabled) && 'button' in event && event.button !== 0) {
             return;
         }
 

--- a/projects/igniteui-angular/directives/src/directives/drag-drop/drag-drop.spec.ts
+++ b/projects/igniteui-angular/directives/src/directives/drag-drop/drag-drop.spec.ts
@@ -2003,6 +2003,41 @@ describe('igxDrag touch, mouse, pointerLost and shadow root coverage', () => {
         await wait();
     });
 
+    it('should not initiate drag on secondary pointer button', async () => {
+        const firstDrag = fix.componentInstance.dragElems.first;
+        const firstElement = firstDrag.element.nativeElement;
+        const startingX = (dragDirsRects[0].left + dragDirsRects[0].right) / 2;
+        const startingY = (dragDirsRects[0].top + dragDirsRects[0].bottom) / 2;
+
+        spyOn(firstDrag.dragStart, 'emit');
+        spyOn(firstDrag.dragClick, 'emit');
+
+        const pointerDown = new PointerEvent('pointerdown', {
+            view: window,
+            bubbles: true,
+            cancelable: true,
+            pointerId: 1,
+            button: 2
+        });
+        Object.defineProperty(pointerDown, 'pageX', { value: startingX, enumerable: true });
+        Object.defineProperty(pointerDown, 'pageY', { value: startingY, enumerable: true });
+        firstElement.dispatchEvent(pointerDown);
+        fix.detectChanges();
+        await wait();
+
+        UIInteractions.simulatePointerEvent('pointermove', firstElement, startingX + 20, startingY + 20);
+        fix.detectChanges();
+        await wait(100);
+
+        UIInteractions.simulatePointerEvent('pointerup', firstElement, startingX + 20, startingY + 20);
+        fix.detectChanges();
+        await wait();
+
+        expect(firstDrag.dragStart.emit).not.toHaveBeenCalled();
+        expect(firstDrag.dragClick.emit).not.toHaveBeenCalled();
+        expect(firstDrag.ghostElement).not.toBeDefined();
+    });
+
     it('should call onPointerLost early return when _clicked is false', async () => {
         const firstDrag = fix.componentInstance.dragElems.first;
 


### PR DESCRIPTION
Closes #17424   

## Description
Modifying drag-drop directive to start drag only on primary mouse button

## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 