### PR TITLE
fix(nav-drawer): preserve single-tap actions on iOS - 22.1.x

### DIFF
--- a/projects/igniteui-angular/core/src/core/touch.spec.ts
+++ b/projects/igniteui-angular/core/src/core/touch.spec.ts
@@ -1,0 +1,84 @@
+import { IgxTouchManager } from './touch';
+
+describe('IgxTouchManager', () => {
+    let manager: IgxTouchManager;
+    let target: HTMLDivElement;
+
+    beforeEach(() => {
+        target = document.createElement('div');
+        document.body.appendChild(target);
+    });
+
+    afterEach(() => {
+        manager?.destroy();
+        target.remove();
+    });
+
+    it('should stop tracking when pointerDown vetoes the gesture', () => {
+        const panStart = jasmine.createSpy('panStart');
+        const panMove = jasmine.createSpy('panMove');
+        manager = new IgxTouchManager(target, {
+            pointerDown: () => false,
+            panStart,
+            panMove
+        });
+
+        dispatchPointerEvent(target, 'pointerdown', 10, 10);
+        const touchMove = dispatchTouchMove(target);
+        dispatchPointerEvent(target, 'pointermove', 30, 10);
+
+        expect(touchMove.defaultPrevented).toBeFalse();
+        expect(panStart).not.toHaveBeenCalled();
+        expect(panMove).not.toHaveBeenCalled();
+    });
+
+    it('should preserve native touch behavior until the pan threshold is exceeded', () => {
+        const panStart = jasmine.createSpy('panStart');
+        const panMove = jasmine.createSpy('panMove');
+        manager = new IgxTouchManager(target, {
+            panStart,
+            panMove
+        }, { panAxis: 'horizontal', panThreshold: 5 });
+
+        dispatchPointerEvent(target, 'pointerdown', 10, 10);
+        const initialTouchMove = dispatchTouchMove(target);
+        dispatchPointerEvent(target, 'pointermove', 13, 10);
+        const candidateTouchMove = dispatchTouchMove(target);
+
+        expect(initialTouchMove.defaultPrevented).toBeFalse();
+        expect(candidateTouchMove.defaultPrevented).toBeFalse();
+        expect(panStart).not.toHaveBeenCalled();
+        expect(panMove).not.toHaveBeenCalled();
+
+        dispatchPointerEvent(target, 'pointermove', 11, 20);
+        const verticalTouchMove = dispatchTouchMove(target);
+
+        expect(verticalTouchMove.defaultPrevented).toBeFalse();
+        expect(panStart).not.toHaveBeenCalled();
+        expect(panMove).not.toHaveBeenCalled();
+
+        dispatchPointerEvent(target, 'pointermove', 16, 10);
+        const activePanTouchMove = dispatchTouchMove(target);
+
+        expect(panStart).toHaveBeenCalledTimes(1);
+        expect(panMove).toHaveBeenCalledTimes(1);
+        expect(activePanTouchMove.defaultPrevented).toBeTrue();
+    });
+});
+
+function dispatchPointerEvent(target: EventTarget, type: string, clientX: number, clientY: number): void {
+    target.dispatchEvent(new PointerEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        pointerId: 1,
+        pointerType: 'touch',
+        clientX,
+        clientY
+    }));
+}
+
+function dispatchTouchMove(target: EventTarget): Event {
+    const event = new Event('touchmove', { bubbles: true, cancelable: true });
+    target.dispatchEvent(event);
+    return event;
+}

--- a/projects/igniteui-angular/core/src/core/touch.spec.ts
+++ b/projects/igniteui-angular/core/src/core/touch.spec.ts
@@ -64,7 +64,36 @@ describe('IgxTouchManager', () => {
         expect(panMove).toHaveBeenCalledTimes(1);
         expect(activePanTouchMove.defaultPrevented).toBeTrue();
     });
+
+    for (const eventType of ['pointerup', 'pointercancel']) {
+        it(`should reset tracking state on ${eventType}`, () => {
+            manager = new IgxTouchManager(target, {});
+
+            dispatchPointerEvent(target, 'pointerdown', 10, 10);
+            dispatchPointerEvent(target, 'pointermove', 20, 10);
+            dispatchPointerEvent(target, eventType, 20, 10);
+
+            expectTrackingStateToBeReset(manager);
+        });
+    }
+
+    it('should reset tracking state when destroyed', () => {
+        manager = new IgxTouchManager(target, {});
+
+        dispatchPointerEvent(target, 'pointerdown', 10, 10);
+        dispatchPointerEvent(target, 'pointermove', 20, 10);
+        manager.destroy();
+
+        expectTrackingStateToBeReset(manager);
+    });
 });
+
+function expectTrackingStateToBeReset(manager: IgxTouchManager): void {
+    expect((manager as any)._tracking).toBeFalse();
+    expect((manager as any)._panStarted).toBeFalse();
+    expect((manager as any)._pointerId).toBeNull();
+    expect((manager as any)._startTarget).toBeNull();
+}
 
 function dispatchPointerEvent(target: EventTarget, type: string, clientX: number, clientY: number): void {
     target.dispatchEvent(new PointerEvent(type, {

--- a/projects/igniteui-angular/core/src/core/touch.spec.ts
+++ b/projects/igniteui-angular/core/src/core/touch.spec.ts
@@ -106,8 +106,8 @@ function dispatchPointerEvent(target: EventTarget, type: string, clientX: number
     }));
 }
 
-function dispatchTouchMove(target: EventTarget): Event {
-    const event = new Event('touchmove', { bubbles: true, cancelable: true });
+function dispatchTouchMove(target: EventTarget): TouchEvent {
+    const event = new TouchEvent('touchmove', { bubbles: true, cancelable: true });
     target.dispatchEvent(event);
     return event;
 }

--- a/projects/igniteui-angular/core/src/core/touch.ts
+++ b/projects/igniteui-angular/core/src/core/touch.ts
@@ -78,6 +78,10 @@ export interface IgxTouchManagerOptions {
     setPointerCapture?: boolean;
     /** Maximum movement (in px) for a pointer up to be recognized as a tap. Defaults to `0` (disabled). */
     tapThreshold?: number;
+    /** Minimum movement (in px) before a pan starts. Defaults to `0`. */
+    panThreshold?: number;
+    /** Axis on which movement can start a pan. Defaults to `'all'`. */
+    panAxis?: 'all' | 'horizontal' | 'vertical';
     /** Minimum velocity (in px/ms) for a primarily horizontal gesture to be recognized as a swipe. Defaults to `0.3`. */
     swipeVelocityThreshold?: number;
     /**
@@ -134,6 +138,8 @@ export class IgxTouchManager {
     private readonly _pointerTypes: string[];
     private readonly _setPointerCapture: boolean;
     private readonly _tapThreshold: number;
+    private readonly _panThreshold: number;
+    private readonly _panAxis: 'all' | 'horizontal' | 'vertical';
     private readonly _swipeVelocityThreshold: number;
     private readonly _canStart: ((event: PointerEvent) => boolean) | null;
     private readonly _ngZone: NgZone | null;
@@ -146,6 +152,8 @@ export class IgxTouchManager {
         this._pointerTypes = options.pointerTypes ?? ['touch', 'pen'];
         this._setPointerCapture = options.setPointerCapture ?? true;
         this._tapThreshold = options.tapThreshold ?? 0;
+        this._panThreshold = options.panThreshold ?? 0;
+        this._panAxis = options.panAxis ?? 'all';
         this._swipeVelocityThreshold = options.swipeVelocityThreshold ?? 0.3;
         this._canStart = options.canStart ?? null;
         this._ngZone = options.ngZone ?? null;
@@ -280,9 +288,10 @@ export class IgxTouchManager {
             return;
         }
         const gesture = this._createEvent(event);
-        // Defer `panStart` until movement actually begins, mirroring Hammer's `panstart`.
-        // A press with no movement (a tap) therefore never raises `panStart`.
         if (!this._panStarted) {
+            if (!this._canStartPan(gesture)) {
+                return;
+            }
             this._panStarted = true;
             if (this.callbacks.panStart) {
                 this._runInAngular(() => this.callbacks.panStart?.(gesture));
@@ -335,15 +344,32 @@ export class IgxTouchManager {
             this._runInAngular(() => this.callbacks.panCancel?.(gesture));
         }
     };
-    
+
     private _onTouchMove = (event: Event) => {
         if (!(event instanceof TouchEvent)) {
             return;
         }
-        // Prevent scrolling only while a gesture is actively tracked.
-        if (this._tracking && event.cancelable) {
+        // Preserve native scrolling and compatibility clicks while the contact is
+        // only a tap candidate. Suppress scrolling after a pan is recognized.
+        if (this._tracking && this._panStarted && event.cancelable) {
             event.preventDefault();
         }
+    }
+
+    private _canStartPan(event: IgxGestureEvent): boolean {
+        if (event.distance < this._panThreshold) {
+            return false;
+        }
+
+        if (this._panAxis === 'horizontal') {
+            return Math.abs(event.deltaX) > Math.abs(event.deltaY);
+        }
+
+        if (this._panAxis === 'vertical') {
+            return Math.abs(event.deltaY) > Math.abs(event.deltaX);
+        }
+
+        return true;
     }
 
     /** Stops tracking the current gesture and best-effort releases the pointer capture. */

--- a/projects/igniteui-angular/core/src/core/touch.ts
+++ b/projects/igniteui-angular/core/src/core/touch.ts
@@ -354,7 +354,7 @@ export class IgxTouchManager {
         if (this._tracking && this._panStarted && event.cancelable) {
             event.preventDefault();
         }
-    }
+    };
 
     private _canStartPan(event: IgxGestureEvent): boolean {
         if (event.distance < this._panThreshold) {

--- a/projects/igniteui-angular/core/src/core/touch.ts
+++ b/projects/igniteui-angular/core/src/core/touch.ts
@@ -183,15 +183,14 @@ export class IgxTouchManager {
 
     /** Detaches all listeners and stops tracking. */
     public destroy(): void {
-        if (!this._supported) {
-            return;
+        if (this._supported) {
+            this.target.removeEventListener('pointerdown', this._onPointerDown);
+            this.target.removeEventListener('pointermove', this._onPointerMove);
+            this.target.removeEventListener('pointerup', this._onPointerUp);
+            this.target.removeEventListener('pointercancel', this._onPointerCancel);
+            this.target.removeEventListener('touchmove', this._onTouchMove);
         }
-        this.target.removeEventListener('pointerdown', this._onPointerDown);
-        this.target.removeEventListener('pointermove', this._onPointerMove);
-        this.target.removeEventListener('pointerup', this._onPointerUp);
-        this.target.removeEventListener('pointercancel', this._onPointerCancel);
-        this.target.removeEventListener('touchmove', this._onTouchMove);
-        this._tracking = false;
+        this._resetTracking();
     }
 
     private _accepts(pointerType: string): boolean {
@@ -310,9 +309,8 @@ export class IgxTouchManager {
         if (!this._tracking || event.pointerId !== this._pointerId || !this._accepts(event.pointerType)) {
             return;
         }
-        this._tracking = false;
-        this._pointerId = null;
         const gesture = this._createEvent(event);
+        this._resetTracking();
 
         this._runInAngular(() => {
             if (this.callbacks.tap && gesture.distance < this._tapThreshold) {
@@ -337,10 +335,9 @@ export class IgxTouchManager {
         if (!this._tracking || event.pointerId !== this._pointerId) {
             return;
         }
-        this._tracking = false;
-        this._pointerId = null;
+        const gesture = this._createEvent(event);
+        this._resetTracking();
         if (this.callbacks.panCancel) {
-            const gesture = this._createEvent(event);
             this._runInAngular(() => this.callbacks.panCancel?.(gesture));
         }
     };
@@ -374,10 +371,7 @@ export class IgxTouchManager {
 
     /** Stops tracking the current gesture and best-effort releases the pointer capture. */
     private _stopTracking(pointerId: number): void {
-        this._tracking = false;
-        this._panStarted = false;
-        this._pointerId = null;
-        this._startTarget = null;
+        this._resetTracking();
 
         if (this._setPointerCapture && typeof (this.target as Element).releasePointerCapture === 'function') {
             try {
@@ -387,5 +381,12 @@ export class IgxTouchManager {
                 // Releasing is a best-effort cleanup, so ignore it.
             }
         }
+    }
+
+    private _resetTracking(): void {
+        this._tracking = false;
+        this._panStarted = false;
+        this._pointerId = null;
+        this._startTarget = null;
     }
 }

--- a/projects/igniteui-angular/navigation-drawer/src/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/projects/igniteui-angular/navigation-drawer/src/navigation-drawer/navigation-drawer.component.spec.ts
@@ -439,6 +439,26 @@ describe('Navigation Drawer', () => {
             });
     }, 10000);
 
+    it('should preserve a tap that starts inside the edge gesture zone', waitForAsync(() => {
+        TestBed.compileComponents().then(() => {
+            const fixture = TestBed.createComponent(TestComponentDIComponent);
+            fixture.detectChanges();
+            const navDrawer = fixture.componentInstance.navDrawer;
+
+            dispatchTouchPointerEvent(document.body, 'pointerdown', 10, 10);
+            dispatchTouchPointerEvent(document.body, 'pointermove', 13, 10);
+            const touchMove = new Event('touchmove', { bubbles: true, cancelable: true });
+            document.body.dispatchEvent(touchMove);
+
+            expect((navDrawer as any)._panning).toBeFalse();
+            expect(navDrawer.drawer.classList).not.toContain('panning');
+            expect(touchMove.defaultPrevented).toBeFalse();
+
+            dispatchTouchPointerEvent(document.body, 'pointerup', 13, 10);
+            fixture.destroy();
+        });
+    }));
+
     it('should update edge zone with mini width', waitForAsync(() => {
         const template = `<igx-nav-drawer [miniWidth]="drawerMiniWidth">
                             <ng-template igxDrawer></ng-template>

--- a/projects/igniteui-angular/navigation-drawer/src/navigation-drawer/navigation-drawer.component.spec.ts
+++ b/projects/igniteui-angular/navigation-drawer/src/navigation-drawer/navigation-drawer.component.spec.ts
@@ -752,9 +752,20 @@ describe('Navigation Drawer', () => {
             expect(navDrawer.isOpen).toBeFalse();
         });
 
-        it('panStart: should set _panning flag when conditions are met', () => {
+        it('canStartPan: should qualify only edge touches while closed', () => {
+            expect((navDrawer as any).canStartPan(makeGestureInput({ center: { x: 30, y: 10 } }))).toBeTrue();
+            expect((navDrawer as any).canStartPan(makeGestureInput({ center: { x: 100, y: 10 } }))).toBeFalse();
+        });
+
+        it('canStartPan: should qualify touches anywhere while open', () => {
+            navDrawer.open();
+            fixture.detectChanges();
+
+            expect((navDrawer as any).canStartPan(makeGestureInput({ center: { x: 100, y: 10 } }))).toBeTrue();
+        });
+
+        it('panStart: should initialize panning after gesture recognition', () => {
             expect((navDrawer as any)._panning).toBeFalse();
-            // simulate start from left edge (startPosition < maxEdgeZone)
             (navDrawer as any).panStart(makeGestureInput({ deltaX: 0, center: { x: 30, y: 10 }, distance: 0 }));
             expect((navDrawer as any)._panning).toBeTrue();
         });

--- a/projects/igniteui-angular/navigation-drawer/src/navigation-drawer/navigation-drawer.component.ts
+++ b/projects/igniteui-angular/navigation-drawer/src/navigation-drawer/navigation-drawer.component.ts
@@ -29,6 +29,7 @@ import { IgxNavigationService, IToggleView } from 'igniteui-angular/core';
 import { IgxNavDrawerMiniTemplateDirective, IgxNavDrawerTemplateDirective, IgxNavDrawerItemDirective } from './navigation-drawer.directives';
 import { IgxGestureEvent, IgxTouchManager, PlatformUtil } from 'igniteui-angular/core';
 
+const PAN_THRESHOLD = 5;
 let NEXT_ID = 0;
 /**
  * **Ignite UI for Angular Navigation Drawer** -
@@ -686,12 +687,18 @@ export class IgxNavigationDrawerComponent implements
         if (this.enableGestures && !this.pin) {
             if (!this._gesturesAttached) {
                 this._gestures = new IgxTouchManager(this._document, {
-                    pointerDown: (event) => this.panStart(event),
+                    pointerDown: (event) => this.canStartPan(event),
+                    panStart: (event) => this.panStart(event),
                     panMove: (event) => this.pan(event),
                     swipe: (event) => this.swipe(event),
                     panEnd: (event) => this.panEnd(event),
                     panCancel: () => this.panCancel()
-                }, { pointerTypes: ['touch'], setPointerCapture: false });
+                }, {
+                    panAxis: 'horizontal',
+                    panThreshold: PAN_THRESHOLD,
+                    pointerTypes: ['touch'],
+                    setPointerCapture: false
+                });
 
                 this._gesturesAttached = true;
             }
@@ -767,36 +774,35 @@ export class IgxNavigationDrawerComponent implements
         }
     };
 
-    private panStart = (evt: IgxGestureEvent): boolean => {
+    private canStartPan = (evt: IgxGestureEvent): boolean => {
         if (!this.enableGestures || this.pin || evt.pointerType !== 'touch') {
             return false;
         }
         const startPosition = this.position === 'right' ? this.getWindowWidth() - (evt.center.x + evt.distance)
             : evt.center.x - evt.distance;
 
-        // cache width during animation, flag to allow further handling
-        if (this.isOpen || (startPosition < this.maxEdgeZone)) {
-            this._panning = true;
-            this._panStartWidth = this.getExpectedWidth(!this.isOpen);
-            this._panLimit = this.getExpectedWidth(this.isOpen);
+        return this.isOpen || startPosition < this.maxEdgeZone;
+    };
 
-            this.renderer.addClass(this.overlay, 'igx-nav-drawer__overlay--panning');
-            this.renderer.addClass(this.drawer, 'igx-nav-drawer__aside--panning');
-
-            if (!this.hasAnimateWidth) {
-                // Translate-mode pan slides the panel via `transform`, but its width is
-                // driven by `--ig-nav-drawer-size`, which is forced to 0 while the drawer
-                // is closed. Pin the real width for the duration of the gesture so the
-                // slide reveals the full panel instead of just its padding/border.
-                this.renderer.setStyle(this.drawer, 'width', `${this.getExpectedWidth(false)}px`);
-            }
-            return true;
+    private panStart = (_evt: IgxGestureEvent) => {
+        if (!this.enableGestures || this.pin) {
+            return;
         }
 
-        // The touch did not start in the edge zone (and the drawer is closed), so this
-        // gesture should be ignored. Returning `false` lets the touch manager stop
-        // tracking immediately and not interfere with normal page scrolling.
-        return false;
+        this._panning = true;
+        this._panStartWidth = this.getExpectedWidth(!this.isOpen);
+        this._panLimit = this.getExpectedWidth(this.isOpen);
+
+        this.renderer.addClass(this.overlay, 'igx-nav-drawer__overlay--panning');
+        this.renderer.addClass(this.drawer, 'igx-nav-drawer__aside--panning');
+
+        if (!this.hasAnimateWidth) {
+            // Translate-mode pan slides the panel via `transform`, but its width is
+            // driven by `--ig-nav-drawer-size`, which is forced to 0 while the drawer
+            // is closed. Pin the real width for the duration of the gesture so the
+            // slide reveals the full panel instead of just its padding/border.
+            this.renderer.setStyle(this.drawer, 'width', `${this.getExpectedWidth(false)}px`);
+        }
     };
 
     private pan = (evt: IgxGestureEvent) => {


### PR DESCRIPTION
Closes #17472 

## Description
Fixes an iOS regression where Navbar and icon-button actions could require two taps while Navigation Drawer gestures were enabled.

The Navigation Drawer now waits for meaningful horizontal movement before claiming the touch gesture and preventing native behavior. This preserves single-tap actions and vertical scrolling while keeping edge-swipe navigation working.

### Implementation

The Navigation Drawer previously started tracking a pan immediately on `pointerdown`. Its document-level `touchmove` listener could consequently call `preventDefault()` for the small involuntary movement produced during a tap. On iOS, this can suppress the compatibility `click`, making actions appear to require two taps.

The fix separates gesture eligibility from gesture recognition:

- `pointerDown` only checks whether the gesture is eligible, such as starting inside the drawer edge zone.
- A pan starts only after at least 5px of primarily horizontal movement.
- `touchmove` is prevented only after the pan has been recognized.
- Taps and vertical movement retain their native browser behavior.

### Testing

- Added touch-manager gesture arbitration tests.
- Added a Navigation Drawer tap regression test.
- Verified the focused test suite passes.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
<!-- List the component(s) or area(s) this PR touches, e.g. Grid, Combo, Theming -->


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Include relevant details so reviewers can reproduce. -->
 - [x] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **Angular version**: 
 - **Browser(s)**: 
 - **OS**: 

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain the visual changes. -->


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [x] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 