### PR TITLE
fix(pivot-grid): match scroll-start border/background to header cells

### DIFF
--- a/projects/igniteui-angular/grids/pivot-grid/src/pivot-grid.component.scss
+++ b/projects/igniteui-angular/grids/pivot-grid/src/pivot-grid.component.scss
@@ -1,0 +1,1 @@
+@use 'themes/grid/base';

--- a/projects/igniteui-angular/grids/pivot-grid/src/pivot-grid.component.ts
+++ b/projects/igniteui-angular/grids/pivot-grid/src/pivot-grid.component.ts
@@ -205,6 +205,7 @@ export interface IPivotRecordTemplateContext {
     preserveWhitespaces: false,
     selector: 'igx-pivot-grid',
     templateUrl: 'pivot-grid.component.html',
+    styleUrl: 'pivot-grid.component.css',
     encapsulation: ViewEncapsulation.None,
     providers: [
         IgxGridCRUDService,
@@ -459,6 +460,12 @@ export class IgxPivotGridComponent extends IgxGridBaseDirective implements OnIni
      */
     @HostBinding('attr.role')
     public role = 'grid';
+
+    /**
+     * @hidden @internal
+     */
+    @HostBinding('class.igx-grid--pivot')
+    protected readonly pivotClass = true;
 
     /**
      * Enables a super compact theme for the component.

--- a/projects/igniteui-angular/grids/pivot-grid/src/pivot-grid.component.ts
+++ b/projects/igniteui-angular/grids/pivot-grid/src/pivot-grid.component.ts
@@ -206,6 +206,7 @@ export interface IPivotRecordTemplateContext {
     selector: 'igx-pivot-grid',
     templateUrl: 'pivot-grid.component.html',
     styleUrl: 'pivot-grid.component.css',
+    host: { 'class': 'igx-grid--pivot' },
     encapsulation: ViewEncapsulation.None,
     providers: [
         IgxGridCRUDService,
@@ -460,12 +461,6 @@ export class IgxPivotGridComponent extends IgxGridBaseDirective implements OnIni
      */
     @HostBinding('attr.role')
     public role = 'grid';
-
-    /**
-     * @hidden @internal
-     */
-    @HostBinding('class.igx-grid--pivot')
-    protected readonly pivotClass = true;
 
     /**
      * Enables a super compact theme for the component.

--- a/projects/igniteui-angular/grids/pivot-grid/src/themes/grid/_base.scss
+++ b/projects/igniteui-angular/grids/pivot-grid/src/themes/grid/_base.scss
@@ -1,0 +1,23 @@
+////
+/// @group pivot-grid
+/// @access private
+////
+
+@use 'igniteui-theming/sass/bem' as *;
+@use 'igniteui-theming/sass/themes' as *;
+@use 'styles/themes/scoping' as *;
+@use 'grids/themes/variables' as *;
+
+@include layer(base) {
+    @include b(igx-grid) {
+        @include m(pivot) {
+            @include e(scroll-start) {
+                background: var-get($theme, 'header-background');
+            }
+
+            @include e(scroll-start, $m: pinned) {
+                border-inline-end: $grid-header-border;
+            }
+        }
+    }
+}

--- a/projects/igniteui-angular/grids/themes/_base.scss
+++ b/projects/igniteui-angular/grids/themes/_base.scss
@@ -7,40 +7,7 @@
 @use 'igniteui-theming/sass/color/functions' as *;
 @use 'igniteui-theming/sass/elevations' as *;
 @use 'styles/themes/scoping' as *;
-@use 'igniteui-theming/sass/themes/schemas/components/light/grid' as *;
-
-$theme: digest-schema($material-grid);
-$cell-font-size: rem(13px);
-$cell-line-height: rem(16px);
-$cell-editing-outline-width: rem(1px);
-$grid-header-border-color: var(--_grid-header-border-color, hsla(from var-get($theme, 'header-border-color') h s l / 0.38));
-$grid-action-border-color: var(--_grid-action-border-color, hsla(from var-get($theme, 'action-border-color') h s l / 0.38));
-$grid-header-border: var-get($theme, 'header-border-width') var-get($theme, 'header-border-style') $grid-header-border-color;
-$grid-row-border: var-get($theme, 'row-border-width') var-get($theme, 'row-border-style') var-get($theme, 'row-border-color');
-$grid-scrollbar-borders: rem(1px) solid var(--ig-grid-summary-border-color, var(--row-border-color));
-$grid-body-column-border-odd: var-get($theme, 'header-border-width') solid var-get($theme, 'body-column-border-color-odd');
-$grid-body-column-border-even: var-get($theme, 'header-border-width') solid var-get($theme, 'body-column-border-color-even');
-$grid-active-state-border: var-get($theme, 'cell-active-border-width')  var-get($theme, 'active-state-border-style') var-get($theme, 'cell-active-border-color');
-$cell-padding-sm: rem(12px);
-$cell-padding-md: rem(16px);
-$cell-padding-lg: rem(24px);
-
-// The shadow size that simulates border glueth to the pinned border to make it thicker
-$pinned-shadow-size: #{rem(1px)};
-
-// Z-Indices
-$z-grid-base: 1;
-$z-grid-decoration: 2;
-$z-grid-interaction: 3;
-$z-grid-selection: 4;
-$z-grid-edit-indicator: 5;
-$z-grid-drag-ghost: 20;
-$z-grid-scroll-drag: 25;
-$z-grid-pinned-cell: 9999;
-$z-grid-pinned-row: 10000;
-$z-grid-scroll: 10001;
-$z-grid-overlay: 10002;
-$z-grid-loading: 10003;
+@use 'variables' as *;
 
 @include layer(base) {
     @include scale-in-ver-center();
@@ -2793,6 +2760,10 @@ $z-grid-loading: 10003;
     .igx-pivot-grid-row-filler__wrapper {
         .igx-grid-thead__wrapper {
             height: 100%;
+            // This wrapper only reuses header styles for visual consistency in
+            // the empty space below the last row - it isn't an actual header,
+            // so it shouldn't carry the thead/tbody separator border.
+            border-bottom: none;
 
             .igx-grid-th {
                 height: 100%;

--- a/projects/igniteui-angular/grids/themes/_variables.scss
+++ b/projects/igniteui-angular/grids/themes/_variables.scss
@@ -1,0 +1,43 @@
+////
+/// @group grids
+/// @access private
+////
+
+@use 'igniteui-theming/sass/themes' as *;
+@use 'igniteui-theming/sass/typography' as *;
+@use 'igniteui-theming/sass/themes/schemas/components/light/grid' as *;
+
+$theme: digest-schema($material-grid);
+
+$cell-font-size: rem(13px);
+$cell-line-height: rem(16px);
+$cell-editing-outline-width: rem(1px);
+$grid-header-border-color: var(--_grid-header-border-color, hsla(from var-get($theme, 'header-border-color') h s l / 0.38));
+$grid-action-border-color: var(--_grid-action-border-color, hsla(from var-get($theme, 'action-border-color') h s l / 0.38));
+$grid-header-border: var-get($theme, 'header-border-width') var-get($theme, 'header-border-style') $grid-header-border-color;
+$grid-row-border: var-get($theme, 'row-border-width') var-get($theme, 'row-border-style') var-get($theme, 'row-border-color');
+$grid-pinned-border: var-get($theme, 'pinned-border-width') var-get($theme, 'pinned-border-style') var-get($theme, 'pinned-border-color');
+$grid-scrollbar-borders: rem(1px) solid var(--ig-grid-summary-border-color, var(--row-border-color));
+$grid-body-column-border-odd: var-get($theme, 'header-border-width') solid var-get($theme, 'body-column-border-color-odd');
+$grid-body-column-border-even: var-get($theme, 'header-border-width') solid var-get($theme, 'body-column-border-color-even');
+$grid-active-state-border: var-get($theme, 'cell-active-border-width')  var-get($theme, 'active-state-border-style') var-get($theme, 'cell-active-border-color');
+$cell-padding-sm: rem(12px);
+$cell-padding-md: rem(16px);
+$cell-padding-lg: rem(24px);
+
+// The shadow size that simulates border glueth to the pinned border to make it thicker
+$pinned-shadow-size: #{rem(1px)};
+
+// Z-Indices
+$z-grid-base: 1;
+$z-grid-decoration: 2;
+$z-grid-interaction: 3;
+$z-grid-selection: 4;
+$z-grid-edit-indicator: 5;
+$z-grid-drag-ghost: 20;
+$z-grid-scroll-drag: 25;
+$z-grid-pinned-cell: 9999;
+$z-grid-pinned-row: 10000;
+$z-grid-scroll: 10001;
+$z-grid-overlay: 10002;
+$z-grid-loading: 10003;


### PR DESCRIPTION
Fixes #17584 

## Description

`IgxPivotGridComponent` no longer inherits the shared, unscoped `.igx-grid__scroll-start--pinned` bold border/`content-background` fill used by `IgxGrid`/`IgxTreeGrid`/`IgxHierarchicalGrid`. A new `.igx-grid--pivot` host class scopes pivot-only overrides (border matches the plain header border, background matches `header-background`) via a dedicated `pivot-grid.component.scss`/`themes/grid/_base.scss` pair, wired through Angular's normal `styleUrl` instead of touching the shared grid theme file.
Also removes the stray `border-bottom` inherited by `.igx-pivot-grid-row-filler__wrapper`'s reused header markup. Shared grid Sass variables (`$grid-header-border`, `$grid-pinned-border`, z-indices, etc.) were extracted into `grids/themes/_variables.scss` so both the shared grid theme and the new pivot-grid theme file can consume them without duplication.

## Motivation / Context

Fixes #17584 — the pivot grid rendered a bold "pinned column" border (and mismatched background) on the horizontal scrollbar's leading edge, even though pivot's row dimensions aren't part of the public column-pinning API. The border should visually match the plain header/cell border pivot's row dimension cells actually use.

### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [ ] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:

Pivot Grid (theming/styles only — `grids/pivot-grid`, `grids/themes`)

## How Has This Been Tested?

 - [ ] Unit tests
 - [x] Manual testing
 - [ ] Automated e2e tests

Verified `npm run build:styles:components` compiles the new/changed SCSS without errors and produces the expected scoped selectors (`.igx-grid--pivot .igx-grid__scroll-start(--pinned)`, `.igx-pivot-grid-row-filler__wrapper .igx-grid-thead__wrapper`), confirmed `npm run lint:styles` and `eslint` pass, and confirmed the unrelated `grid-base.styles.ts` output (flat/tree/hierarchical grids) is unchanged after the variable extraction. Visual/browser verification against the pivot hierarchy dev sample and the pivot-grid Karma suite (`npm run test:lib:pgrid`) are still outstanding.

## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified