### PR TITLE
fix(grid): notify change detection when column state changes

### DIFF
--- a/projects/igniteui-angular-elements/src/app/custom-strategy.spec.ts
+++ b/projects/igniteui-angular-elements/src/app/custom-strategy.spec.ts
@@ -14,6 +14,9 @@ import {
     IgcColumnLayoutComponent,
     IgcActionStripComponent,
     IgcGridEditingActionsComponent,
+    IgcGridToolbarComponent,
+    IgcGridToolbarActionsComponent,
+    IgcGridToolbarHidingComponent,
 } from './components';
 import { defineComponents } from '../utils/register';
 
@@ -30,7 +33,10 @@ describe('Elements: ', () => {
             IgcPaginatorComponent,
             IgcGridStateComponent,
             IgcActionStripComponent,
-            IgcGridEditingActionsComponent
+            IgcGridEditingActionsComponent,
+            IgcGridToolbarComponent,
+            IgcGridToolbarActionsComponent,
+            IgcGridToolbarHidingComponent
         );
     });
 
@@ -364,6 +370,55 @@ describe('Elements: ', () => {
             // verify that no cell is highlighted after clearing the search
             highlightedCell = gridEl.querySelector(HIGHLIGHT_ACTIVE_CSS_CLASS);
             expect(highlightedCell).toBeNull();
+        });
+
+        it('should update the open column hiding dropdown when a column is removed', async () => {
+            // The column actions list renders grid._columns through pure pipes. With the dropdown
+            // already open, removing a column resets the QueryList with no click and no element
+            // insert - none of the triggers Angular's zoneless scheduler recognises - so without an
+            // explicit notification the list keeps rendering the collection as it was before.
+            const gridEl = document.createElement("igc-grid");
+            const toolbar = document.createElement("igc-grid-toolbar");
+            const actions = document.createElement("igc-grid-toolbar-actions");
+            const hiding = document.createElement("igc-grid-toolbar-hiding");
+            actions.appendChild(hiding);
+            toolbar.appendChild(actions);
+            gridEl.appendChild(toolbar);
+
+            const columns = ["ProductID", "ProductName", "InStock"].map(field => {
+                const col = document.createElement("igc-column");
+                col.setAttribute("field", field);
+                gridEl.appendChild(col);
+                return col;
+            });
+
+            gridEl.data = SampleTestData.foodProductData();
+            testContainer.appendChild(gridEl);
+
+            await firstValueFrom(fromEvent(gridEl, "childrenResolved"));
+            await firstValueFrom(fromEvent(gridEl, "dataChanged"));
+
+            const listedColumns = () =>
+                document.querySelectorAll('igx-column-actions .igx-column-actions__columns-item').length;
+            // A fixed SCHEDULE_DELAY wait is too short when grid init is slow, so poll until the
+            // rendered count settles instead of guessing how long it takes. A missing notification
+            // never settles and falls through to the expectation below.
+            const waitForListed = async (expected: number) => {
+                for (let waited = 0; waited < 3000 && listedColumns() !== expected; waited += 20) {
+                    await firstValueFrom(timer(20));
+                }
+            };
+
+            hiding.querySelector('button').click();
+            await waitForListed(3);
+            expect(listedColumns()).toBe(3);
+
+            const resolved = firstValueFrom(fromEvent(gridEl, "childrenResolved"));
+            gridEl.removeChild(columns[2]);
+            await resolved;
+
+            await waitForListed(2);
+            expect(listedColumns()).toBe(2);
         });
     });
 });

--- a/projects/igniteui-angular/grids/core/src/column-actions/column-actions.component.ts
+++ b/projects/igniteui-angular/grids/core/src/column-actions/column-actions.component.ts
@@ -15,8 +15,12 @@ import {
     forwardRef,
     inject,
     ChangeDetectionStrategy,
+    ChangeDetectorRef,
+    DestroyRef,
+    OnInit,
     ViewEncapsulation
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ColumnDisplayOrder } from '../common/enums';
 import { GridType } from '../common/grid.interface';
 import { IColumnToggledEventArgs } from '../common/events';
@@ -42,8 +46,10 @@ let NEXT_ID = 0;
     changeDetection: ChangeDetectionStrategy.Eager,
     imports: [IgxInputGroupComponent, FormsModule, IgxInputDirective, IgxCheckboxComponent, IgxButtonDirective, IgxRippleDirective, forwardRef(() => IgxColumnActionEnabledPipe), forwardRef(() => IgxFilterActionColumnsPipe), forwardRef(() => IgxSortActionColumnsPipe)]
 })
-export class IgxColumnActionsComponent implements DoCheck {
+export class IgxColumnActionsComponent implements DoCheck, OnInit {
     private differs = inject(IterableDiffers);
+    private cdr = inject(ChangeDetectorRef);
+    private destroyRef = inject(DestroyRef);
 
 
     /**
@@ -185,6 +191,21 @@ export class IgxColumnActionsComponent implements DoCheck {
 
     constructor() {
         this._differ = this.differs.find([]).create(this.trackChanges);
+    }
+
+    /**
+     * @hidden @internal
+     */
+    public ngOnInit() {
+        // ngDoCheck only runs when something else checks this view. The list can live in a view the
+        // grid's own change detection does not reach - a separately attached host view in Elements,
+        // or an overlay - so a column change has to mark this view dirty itself.
+        this.grid?.columnList?.changes
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe(() => {
+                this.pipeTrigger++;
+                this.cdr.markForCheck();
+            });
     }
 
     /**

--- a/projects/igniteui-angular/grids/core/src/toolbar/grid-toolbar-advanced-filtering.component.ts
+++ b/projects/igniteui-angular/grids/core/src/toolbar/grid-toolbar-advanced-filtering.component.ts
@@ -1,4 +1,5 @@
-import { Component, Input, OnInit, inject, ChangeDetectionStrategy } from '@angular/core';
+import { Component, Input, OnInit, inject, ChangeDetectionStrategy, ChangeDetectorRef, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { IgxToolbarToken } from './token';
 import { IgxButtonDirective, IgxRippleDirective } from 'igniteui-angular/directives';
 import { IgxIconComponent } from 'igniteui-angular/icon';
@@ -31,6 +32,8 @@ import { IFilteringExpressionsTree, isTree, OverlaySettings } from 'igniteui-ang
 })
 export class IgxGridToolbarAdvancedFilteringComponent implements OnInit {
     private toolbar = inject<IgxToolbarToken>(IgxToolbarToken);
+    private cdr = inject(ChangeDetectorRef);
+    private destroyRef = inject(DestroyRef);
 
     protected numberOfColumns!: number;
     /**
@@ -52,9 +55,14 @@ export class IgxGridToolbarAdvancedFilteringComponent implements OnInit {
         this.numberOfColumns = this.grid?.advancedFilteringExpressionsTree ? this.extractUniqueFieldNamesFromFilterTree(this.grid?.advancedFilteringExpressionsTree).length : 0;
 
         // Subscribing for future updates
-        this.grid?.advancedFilteringExpressionsTreeChange.subscribe(filteringTree => {
-            this.numberOfColumns = this.extractUniqueFieldNamesFromFilterTree(filteringTree).length;
-        });
+        this.grid?.advancedFilteringExpressionsTreeChange
+            .pipe(takeUntilDestroyed(this.destroyRef))
+            .subscribe(filteringTree => {
+                this.numberOfColumns = this.extractUniqueFieldNamesFromFilterTree(filteringTree).length;
+                // The tree is changed from the advanced filtering dialog, i.e. outside of a check of
+                // this view, so nothing else marks it dirty in a zoneless app.
+                this.cdr.markForCheck();
+            });
     }
 
     protected extractUniqueFieldNamesFromFilterTree(filteringTree?: IFilteringExpressionsTree) : string[] {

--- a/projects/igniteui-angular/grids/core/src/toolbar/grid-toolbar.base.ts
+++ b/projects/igniteui-angular/grids/core/src/toolbar/grid-toolbar.base.ts
@@ -1,4 +1,5 @@
-import { Directive, Input, EventEmitter, OnDestroy, Output, booleanAttribute, inject } from '@angular/core';
+import { Directive, Input, EventEmitter, OnDestroy, OnInit, Output, booleanAttribute, inject, ChangeDetectorRef, DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Subject, Subscription } from 'rxjs';
 import { first, takeUntil } from 'rxjs/operators';
 
@@ -163,7 +164,10 @@ export abstract class BaseToolbarDirective implements OnDestroy {
  * Base class for pinning/hiding column actions
  */
 @Directive()
-export abstract class BaseToolbarColumnActionsDirective extends BaseToolbarDirective {
+export abstract class BaseToolbarColumnActionsDirective extends BaseToolbarDirective implements OnInit {
+    private cdr = inject(ChangeDetectorRef);
+    private destroyRef = inject(DestroyRef);
+
     @Input({ transform: booleanAttribute })
     public hideFilter = false;
 
@@ -189,6 +193,16 @@ export abstract class BaseToolbarColumnActionsDirective extends BaseToolbarDirec
     public buttonText!: string;
 
     protected columnActionsUI!: IgxColumnActionsComponent;
+
+    /** @hidden @internal */
+    public ngOnInit() {
+        // The button label reads the pinned/hidden counts straight off the grid. Those change from
+        // the column actions dropdown or from the other toolbar action, neither of which checks
+        // this view, so in a zoneless app nothing marks it dirty and the label goes stale.
+        const markDirty = () => this.cdr.markForCheck();
+        this.grid?.columnPinned.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(markDirty);
+        this.grid?.columnVisibilityChanged.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(markDirty);
+    }
 
     public checkAll() {
         this.columnActionsUI.checkAllColumns();


### PR DESCRIPTION
Closes #17598 

## Description
The column actions list and the toolbar action buttons read grid state
directly but never marked their own views dirty. Under zone.js every
timer and overlay callback produced a tick, so the indicators refreshed
incidentally. Zoneless recognises only markForCheck, setInput, signal
updates, listeners and attaching a dirty view - none of which a QueryList
reset or an EventEmitter is - so the views can stay stale until an
unrelated interaction checks them.

Each component now marks itself dirty from the state it renders:
column actions on columnList.changes, the pinning and hiding buttons on
columnPinned and columnVisibilityChanged, and advanced filtering on
advancedFilteringExpressionsTreeChange. The advanced filtering
subscription also gains the teardown it was missing.



## Motivation / Context
<!-- Why is this change needed? Link to the related issue(s) or discussion. -->


### Type of Change (check all that apply):
 - [x] Bug fix
 - [ ] New functionality
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] Refactoring (no functional changes)
 - [ ] Documentation
 - [ ] Demos
 - [ ] CI/CD
 - [x] Tests
 - [ ] Changelog
 - [ ] Skills/Agents

### Component(s) / Area(s) Affected:
<!-- List the component(s) or area(s) this PR touches, e.g. Grid, Combo, Theming -->


## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes. Include relevant details so reviewers can reproduce. -->
 - [ ] Unit tests
 - [ ] Manual testing
 - [ ] Automated e2e tests

### Test Configuration:
 - **Angular version**: 
 - **Browser(s)**: 
 - **OS**: 

## Screenshots / Recordings
<!-- If applicable, add screenshots or recordings to help explain the visual changes. -->


## Checklist:
 - [x] All relevant tags have been applied to this PR
 - [ ] This PR includes unit tests covering all the new code ([test guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Test-implementation-guidelines-for-Ignite-UI-for-Angular))
 - [ ] This PR includes API docs for newly added methods/properties ([api docs guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Documentation-Guidelines))
 - [ ] This PR includes `feature/README.MD` updates for the feature docs
 - [ ] This PR includes general feature table updates in the root `README.MD`
 - [ ] This PR includes `CHANGELOG.MD` updates for newly added functionality
 - [ ] This PR contains breaking changes
 - [ ] This PR includes `ng update` migrations for the breaking changes ([migrations guidelines](https://github.com/IgniteUI/igniteui-angular/wiki/Update-Migrations))
 - [ ] This PR includes behavioral changes and the feature specification has been updated with them
 - [ ] Accessibility (ARIA, keyboard navigation, focus management) has been verified
 